### PR TITLE
refactor: rename keyframes to use __ prefix instead of --

### DIFF
--- a/packages/field-highlighter/src/styles/vaadin-ai-field-marker-base-styles.js
+++ b/packages/field-highlighter/src/styles/vaadin-ai-field-marker-base-styles.js
@@ -7,7 +7,7 @@ import { css } from 'lit';
 import { screenReaderOnly } from '@vaadin/a11y-base/src/styles/sr-only-styles.js';
 
 export const aiFieldMarkerHostStyles = css`
-  @keyframes --vaadin-ai-field-marker-slide {
+  @keyframes __vaadin-ai-field-marker-slide {
     0% {
       --vaadin-ai-field-marker-mask-pos: -100px;
     }
@@ -17,7 +17,7 @@ export const aiFieldMarkerHostStyles = css`
     }
   }
 
-  @keyframes --vaadin-ai-field-marker-remove-mask {
+  @keyframes __vaadin-ai-field-marker-remove-mask {
     100% {
       mask-image: none;
     }
@@ -65,7 +65,7 @@ export const aiFieldMarkerStyles = css`
         transparent calc(var(--vaadin-ai-field-marker-mask-pos) + 20px),
         transparent
       );
-      animation: --vaadin-ai-field-marker-slide 700ms 200ms both;
+      animation: __vaadin-ai-field-marker-slide 700ms 200ms both;
       animation-timing-function: cubic-bezier(0.78, 0, 0.22, 1);
     }
 
@@ -88,7 +88,7 @@ export const aiFieldMarkerStyles = css`
       line-height: 1;
       cursor: pointer;
       transition: color 200ms;
-      animation: --vaadin-ai-field-marker-fade-in 300ms 700ms backwards;
+      animation: __vaadin-ai-field-marker-fade-in 300ms 700ms backwards;
 
       &:hover {
         color: var(--vaadin-ai-field-marker-badge-icon-color, var(--vaadin-text-color));
@@ -194,12 +194,12 @@ export const aiFieldMarkerStyles = css`
       #000 calc(var(--vaadin-ai-field-marker-mask-pos) + 100px)
     );
     animation:
-      --vaadin-ai-field-marker-slide 1s cubic-bezier(0.78, 0, 0.22, 1) forwards,
-      --vaadin-ai-field-marker-remove-mask 0s 1s forwards;
+      __vaadin-ai-field-marker-slide 1s cubic-bezier(0.78, 0, 0.22, 1) forwards,
+      __vaadin-ai-field-marker-remove-mask 0s 1s forwards;
   }
 
   [ai-working] {
-    animation: --vaadin-ai-field-marker-slide 1s ease-in-out infinite;
+    animation: __vaadin-ai-field-marker-slide 1s ease-in-out infinite;
   }
 
   /* While the AI is working, the badge and glow describe a value that is about
@@ -210,7 +210,7 @@ export const aiFieldMarkerStyles = css`
     display: none;
   }
 
-  @keyframes --vaadin-ai-field-marker-fade-in {
+  @keyframes __vaadin-ai-field-marker-fade-in {
     0% {
       opacity: 0;
     }

--- a/packages/field-highlighter/src/vaadin-ai-field-marker.js
+++ b/packages/field-highlighter/src/vaadin-ai-field-marker.js
@@ -27,7 +27,7 @@ const DEFAULT_I18N = {
 
 const POPOVER_TRIGGER = ['click'];
 
-// Half of the 1s working shimmer slide (`--vaadin-ai-field-marker-slide` in
+// Half of the 1s working shimmer slide (`__vaadin-ai-field-marker-slide` in
 // the base styles), so that held-back values land — and the read-only lock
 // lifts — in the middle of a slide instead of at its edge.
 const HALF_WORKING_SLIDE_MS = 500;

--- a/packages/field-highlighter/test/ai-field-marker.test.ts
+++ b/packages/field-highlighter/test/ai-field-marker.test.ts
@@ -42,7 +42,7 @@ function hasMarkerKeyframes(root: ShadowRoot): boolean {
       .filter((sheet): sheet is CSSStyleSheet => sheet !== null),
   ];
   return sheets.some((sheet) =>
-    [...sheet.cssRules].some((rule) => rule instanceof CSSKeyframesRule && rule.name.startsWith('--vaadin-ai-')),
+    [...sheet.cssRules].some((rule) => rule instanceof CSSKeyframesRule && rule.name.startsWith('__vaadin-ai-')),
   );
 }
 

--- a/packages/field-highlighter/test/visual/ai-field-marker-not-animated-styles.css
+++ b/packages/field-highlighter/test/visual/ai-field-marker-not-animated-styles.css
@@ -1,5 +1,5 @@
 /* The marker entrance animations rely on their fill modes to hold the end
-   state (the glow slide-in opens the mask, --vaadin-ai-field-marker-remove-mask
+   state (the glow slide-in opens the mask, __vaadin-ai-field-marker-remove-mask
    clears the field mask), so `animation: none` would freeze the initial
    frames instead. Zero the durations and delays to jump straight to the
    settled end state. */

--- a/packages/notification/src/styles/vaadin-notification-card-base-styles.js
+++ b/packages/notification/src/styles/vaadin-notification-card-base-styles.js
@@ -107,7 +107,7 @@ const notificationCard = css`
     @supports not (interpolate-size: allow-keywords) {
       :host([opening]:not(:nth-child(1 of [slot='middle']))),
       :host([closing]) {
-        animation-name: --notification-max-height, --notification-margins;
+        animation-name: __notification-max-height, __notification-margins;
         animation-duration: calc(var(--vaadin-overlay-animation-duration) * 2 + var(--vaadin-overlay-animation-delay));
         animation-delay: 0s;
         animation-timing-function: ease-in-out, cubic-bezier(0.4, 1.1, 0, 1);
@@ -118,11 +118,11 @@ const notificationCard = css`
   @media (prefers-reduced-motion) {
     /* The height animation of the fallback above is a keyframe animation, not a transition */
     :host(:is([opening], [closing])) {
-      animation-name: --fade !important;
+      animation-name: __fade !important;
     }
   }
 
-  @keyframes --notification-max-height {
+  @keyframes __notification-max-height {
     0% {
       max-height: 0;
     }
@@ -132,7 +132,7 @@ const notificationCard = css`
     }
   }
 
-  @keyframes --notification-margins {
+  @keyframes __notification-margins {
     0% {
       margin-top: 0;
       margin-bottom: 0;

--- a/packages/notification/test/animation-styles.test.js
+++ b/packages/notification/test/animation-styles.test.js
@@ -54,8 +54,8 @@ describe('notification card animation styles', () => {
       notification.opened = true;
 
       const animations = overlay.getAnimations().map((animation) => animation.animationName);
-      expect(animations).to.include('--fade');
-      expect(animations).to.include('--transform');
+      expect(animations).to.include('__fade');
+      expect(animations).to.include('__transform');
     });
 
     it('should keep the card in the DOM until the closing animation ends', async () => {
@@ -125,7 +125,7 @@ describe('notification card animation styles', () => {
       it('should not animate the height of the card, only opacity', () => {
         notification.opened = true;
 
-        expect(getComputedStyle(card).animationName).to.equal('--fade');
+        expect(getComputedStyle(card).animationName).to.equal('__fade');
       });
     });
   });

--- a/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.js
@@ -49,7 +49,7 @@ export const overlayAnimationStyles = css`
 
   :host(:where([opening], [closing])) {
     /* This empty animation only reports the state, the parts run the visible animation */
-    animation-name: --no-op;
+    animation-name: __no-op;
     animation-duration: var(--vaadin-overlay-animation-duration);
     animation-delay: var(--vaadin-overlay-animation-delay);
   }
@@ -60,7 +60,7 @@ export const overlayAnimationStyles = css`
   }
 
   :host(:where([opening], [closing])) :is([part='overlay'], [part='backdrop']) {
-    animation-name: --fade, --transform;
+    animation-name: __fade, __transform;
     animation-duration: var(--vaadin-overlay-animation-duration);
     animation-timing-function: var(--vaadin-overlay-animation-timing-function);
     animation-delay: var(--vaadin-overlay-animation-delay);
@@ -68,12 +68,12 @@ export const overlayAnimationStyles = css`
     animation-fill-mode: backwards;
 
     @media (prefers-reduced-motion) {
-      animation-name: --fade;
+      animation-name: __fade;
     }
   }
 
   :host(:where([opening], [closing])) [part='backdrop'] {
-    animation-name: --fade;
+    animation-name: __fade;
     animation-timing-function: linear;
     --vaadin-overlay-opacity-closed: 0;
   }
@@ -82,11 +82,11 @@ export const overlayAnimationStyles = css`
     animation-direction: reverse;
   }
 
-  @keyframes --no-op {
+  @keyframes __no-op {
   }
 
   /* Only the closed state is declared, so the animations end at the value the part already has */
-  @keyframes --transform {
+  @keyframes __transform {
     0% {
       transform: var(--vaadin-overlay-transform-closed);
       translate: var(--vaadin-overlay-translate-closed);
@@ -94,7 +94,7 @@ export const overlayAnimationStyles = css`
     }
   }
 
-  @keyframes --fade {
+  @keyframes __fade {
     0% {
       opacity: var(--vaadin-overlay-opacity-closed);
     }

--- a/packages/overlay/test/animation-styles.test.js
+++ b/packages/overlay/test/animation-styles.test.js
@@ -80,13 +80,13 @@ describe('animation properties', () => {
     overlay.style.setProperty('--vaadin-overlay-animation-delay', '2s');
 
     overlay.opened = true;
-    let timing = getAnimation(overlay.$.overlay, '--fade').effect.getTiming();
+    let timing = getAnimation(overlay.$.overlay, '__fade').effect.getTiming();
     expect(timing.duration).to.equal(10000);
     expect(timing.delay).to.equal(2000);
 
     overlay._flushAnimation('opening');
     overlay.opened = false;
-    timing = getAnimation(overlay.$.overlay, '--fade').effect.getTiming();
+    timing = getAnimation(overlay.$.overlay, '__fade').effect.getTiming();
     expect(timing.duration).to.equal(10000);
     expect(timing.delay).to.equal(2000);
   });
@@ -95,11 +95,11 @@ describe('animation properties', () => {
     overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
 
     overlay.opened = true;
-    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().easing).to.equal('linear');
+    expect(getAnimation(overlay.$.overlay, '__fade').effect.getTiming().easing).to.equal('linear');
 
     overlay._flushAnimation('opening');
     overlay.opened = false;
-    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().easing).to.equal('linear');
+    expect(getAnimation(overlay.$.overlay, '__fade').effect.getTiming().easing).to.equal('linear');
   });
 
   // The animations start at the closed value and end at the value of the part, because the
@@ -111,8 +111,8 @@ describe('animation properties', () => {
     overlay.$.overlay.style.opacity = '0.6';
 
     overlay.opened = true;
-    expect(stylesDuringAnimation(overlay.$.overlay, '--fade', 0).opacity).to.equal('0.25');
-    expect(stylesDuringAnimation(overlay.$.overlay, '--fade', 5000).opacity).to.equal('0.425');
+    expect(stylesDuringAnimation(overlay.$.overlay, '__fade', 0).opacity).to.equal('0.25');
+    expect(stylesDuringAnimation(overlay.$.overlay, '__fade', 5000).opacity).to.equal('0.425');
   });
 
   it('should use the closed translate for the transform animation', () => {
@@ -121,8 +121,8 @@ describe('animation properties', () => {
     overlay.$.overlay.style.translate = '30px 40px';
 
     overlay.opened = true;
-    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 0).translate).to.equal('10px 20px');
-    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 5000).translate).to.equal('20px 30px');
+    expect(stylesDuringAnimation(overlay.$.overlay, '__transform', 0).translate).to.equal('10px 20px');
+    expect(stylesDuringAnimation(overlay.$.overlay, '__transform', 5000).translate).to.equal('20px 30px');
   });
 
   it('should use the closed scale for the transform animation', () => {
@@ -131,8 +131,8 @@ describe('animation properties', () => {
     overlay.$.overlay.style.scale = '1.5';
 
     overlay.opened = true;
-    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 0).scale).to.equal('0.5');
-    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 5000).scale).to.equal('1');
+    expect(stylesDuringAnimation(overlay.$.overlay, '__transform', 0).scale).to.equal('0.5');
+    expect(stylesDuringAnimation(overlay.$.overlay, '__transform', 5000).scale).to.equal('1');
   });
 
   it('should use the closed transform for the transform animation', () => {
@@ -141,21 +141,21 @@ describe('animation properties', () => {
     overlay.$.overlay.style.transform = 'rotate(20deg)';
 
     overlay.opened = true;
-    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 0).transform).to.equal(
+    expect(stylesDuringAnimation(overlay.$.overlay, '__transform', 0).transform).to.equal(
       computedValue('transform', 'rotate(10deg)'),
     );
-    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 5000).transform).to.equal(
+    expect(stylesDuringAnimation(overlay.$.overlay, '__transform', 5000).transform).to.equal(
       computedValue('transform', 'rotate(15deg)'),
     );
   });
 
   it('should reverse the animation direction while closing', () => {
     overlay.opened = true;
-    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().direction).to.equal('normal');
+    expect(getAnimation(overlay.$.overlay, '__fade').effect.getTiming().direction).to.equal('normal');
 
     overlay._flushAnimation('opening');
     overlay.opened = false;
-    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().direction).to.equal('reverse');
+    expect(getAnimation(overlay.$.overlay, '__fade').effect.getTiming().direction).to.equal('reverse');
   });
 
   describe('backdrop', () => {
@@ -167,32 +167,32 @@ describe('animation properties', () => {
     it('should only run the fade animation on the backdrop', () => {
       overlay.opened = true;
       const names = overlay.$.backdrop.getAnimations().map((animation) => animation.animationName);
-      expect(names).to.eql(['--fade']);
+      expect(names).to.eql(['__fade']);
     });
 
     it('should use linear timing function for the backdrop animation', () => {
       overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'ease-in');
 
       overlay.opened = true;
-      expect(getAnimation(overlay.$.backdrop, '--fade').effect.getTiming().easing).to.equal('linear');
+      expect(getAnimation(overlay.$.backdrop, '__fade').effect.getTiming().easing).to.equal('linear');
     });
 
     it('should always use zero closed opacity for the backdrop animation', () => {
       overlay.style.setProperty('--vaadin-overlay-opacity-closed', '0.25');
 
       overlay.opened = true;
-      const keyframes = getAnimation(overlay.$.backdrop, '--fade').effect.getKeyframes();
+      const keyframes = getAnimation(overlay.$.backdrop, '__fade').effect.getKeyframes();
       expect(keyframes[0].opacity).to.equal('0');
       expect(keyframes[1].opacity).to.equal('1');
     });
 
     it('should reverse the backdrop animation direction while closing', () => {
       overlay.opened = true;
-      expect(getAnimation(overlay.$.backdrop, '--fade').effect.getTiming().direction).to.equal('normal');
+      expect(getAnimation(overlay.$.backdrop, '__fade').effect.getTiming().direction).to.equal('normal');
 
       overlay._flushAnimation('opening');
       overlay.opened = false;
-      expect(getAnimation(overlay.$.backdrop, '--fade').effect.getTiming().direction).to.equal('reverse');
+      expect(getAnimation(overlay.$.backdrop, '__fade').effect.getTiming().direction).to.equal('reverse');
     });
   });
 
@@ -208,7 +208,7 @@ describe('animation properties', () => {
     it('should only run the fade animation on the overlay part', () => {
       overlay.opened = true;
       const names = overlay.$.overlay.getAnimations().map((animation) => animation.animationName);
-      expect(names).to.eql(['--fade']);
+      expect(names).to.eql(['__fade']);
     });
   });
 


### PR DESCRIPTION
Some keyframes were named with a `--` prefix (`--fade`, `--transform`, `--notification-max-height`, `--vaadin-ai-field-marker-slide`, and so on), which made them easy to confuse with CSS custom properties. This renames them to use a `__` prefix instead. Real custom properties such as `--vaadin-overlay-animation-duration` are unchanged.
