### PR TITLE
fix: keep a value property an AI-marked field owns

### DIFF
--- a/packages/field-highlighter/src/vaadin-ai-field-marker.js
+++ b/packages/field-highlighter/src/vaadin-ai-field-marker.js
@@ -96,6 +96,9 @@ class DelayedFieldValue {
   /** The queued value, while `#timer` is pending. */
   #queuedValue;
 
+  /** Whether the field's own `value` accessor is currently replaced. */
+  #installed = false;
+
   constructor(field, delay) {
     this.#field = field;
     this.#delay = delay;
@@ -146,12 +149,17 @@ class DelayedFieldValue {
         this.#timer = setTimeout(() => this.#flush(), this.#delay);
       },
     });
+    this.#installed = true;
   }
 
   /** Restores the field's own accessor, applying a queued value right away. */
   uninstall() {
-    if (Object.getOwnPropertyDescriptor(this.#field, 'value')) {
+    // Only remove an own property that this instance defined, so that a field
+    // keeping its value in an own property instead of an accessor — which
+    // `install()` leaves alone — does not lose it.
+    if (this.#installed) {
       delete this.#field.value;
+      this.#installed = false;
     }
     this.#flush();
   }

--- a/packages/field-highlighter/test/ai-field-marker.test.ts
+++ b/packages/field-highlighter/test/ai-field-marker.test.ts
@@ -84,6 +84,18 @@ class FocusSensitiveField extends HTMLElement {
 
 customElements.define('focus-sensitive-field', FocusSensitiveField);
 
+/** A field that keeps its value in an own property instead of an accessor. */
+class OwnValueField extends HTMLElement {
+  value = 'own value';
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+}
+
+customElements.define('own-value-field', OwnValueField);
+
 // A composite field can ship under its own tag name, the way a framework
 // provides a field derived from custom-field.
 customElements.define('derived-custom-field', class extends customElements.get('vaadin-custom-field')! {});
@@ -918,6 +930,29 @@ describe('ai field marker', () => {
       await nextRender();
       expect(container.hasAttribute('ai-working')).to.be.false;
       expect(marker.working).to.be.true;
+    });
+
+    describe('field with an own value property', () => {
+      // A field that keeps its value in an own property has no accessor to
+      // intercept, so the marker must leave the property alone.
+      let ownValueField: OwnValueField;
+
+      beforeEach(async () => {
+        ownValueField = fixtureSync(`<own-value-field></own-value-field>`);
+        await nextRender();
+      });
+
+      it('should keep a value property the field owns itself', async () => {
+        const marker = mark(ownValueField, { working: true });
+        await nextRender();
+        clock = sinon.useFakeTimers({ shouldClearNativeTimers: true, toFake: ['setTimeout', 'clearTimeout'] });
+
+        marker.working = false;
+        await nextUpdate(marker);
+        await clock.tickAsync(500);
+
+        expect(ownValueField.value).to.equal('own value');
+      });
     });
 
     describe('field without a value property', () => {


### PR DESCRIPTION
## Summary
- The value hold-back only replaces a `value` accessor found on the field's prototype chain, but it removed any own `value` property when the working state ended.
- A field that keeps its value in an own property was therefore left without one after an AI fill, even though the marker never intercepted it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)