### PR TITLE
feat: support date metadata provider in date-time-picker

### DIFF
--- a/packages/date-picker/ARCHITECTURE.md
+++ b/packages/date-picker/ARCHITECTURE.md
@@ -197,6 +197,14 @@ button are the ones that need it open.
 A value whose month resolved while the field was detached is validated when it is attached again, since the
 controller re-reports its state on reconnect and the armed flag is still set.
 
+Re-validation is delivered through `_requestValidation()`, which a host that sets `manualValidation` turns
+off — `<vaadin-date-time-picker>` does, for both of its pickers, so that it alone decides when the composite
+field reports an error. A wrapper like that therefore gets everything else the provider offers and not this:
+the month is still loaded and `checkValidity()` still consults the answer, but nothing tells the wrapper the
+answer arrived, so the value is re-checked at the wrapper's next validation instead of straight away.
+Reporting it upwards would need a signal that survives `manualValidation`, and the current design has no way
+to send one.
+
 ## What custom part names can do
 
 `part` from an entry is appended to the date's own parts, so a theme can style particular dates through

--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.d.ts
@@ -7,7 +7,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
 import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
-import type { DatePickerI18n } from '@vaadin/date-picker/src/vaadin-date-picker.js';
+import type { DatePickerDateMetadataProvider, DatePickerI18n } from '@vaadin/date-picker/src/vaadin-date-picker.js';
 import type { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
 import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
@@ -128,6 +128,46 @@ export declare class DateTimePickerMixinClass {
   showWeekNumbers: boolean | null | undefined;
 
   /**
+   * A function that provides metadata for the dates the calendar is about to render: whether they
+   * are disabled, and CSS `part` names for styling from outside using the `::part()` selector.
+   * The provider is called for a range of dates at a time, and again as the calendar renders
+   * further dates.
+   *
+   * It receives a `DatePickerDateRange` and returns an array of `DatePickerDateMetadata` objects
+   * for the dates in that range that have metadata. It can return a `Promise` to load the metadata
+   * asynchronously, and `null` or `undefined` when no date in the range has metadata.
+   *
+   * The returned array has the following structure:
+   *
+   * ```js
+   * [
+   *   // month is 0-based: January = 0 and December = 11.
+   *   { year: 2026, month: 0, day: 1, disabled: true },
+   *
+   *   // Adds a custom part name to the date.
+   *   { year: 2026, month: 0, day: 2, part: 'busy' },
+   * ]
+   * ```
+   *
+   * A date is disabled if its metadata marks it disabled, or it is outside `min` and `max`.
+   * Disabled dates are not selectable, and a value on a disabled date makes the field invalid.
+   * The provider does not affect which date is focused when opening the overlay. Use
+   * `initialPosition` property to provide a selectable date.
+   *
+   * While a returned `Promise` is pending, the dates it covers are not disabled yet and render with
+   * the `loading` part. If the function throws or rejects, corresponding dates are requested again
+   * the next time the user navigates.
+   *
+   * The provider is used for validation also when the overlay is closed. Date is considered valid
+   * while the provider is pending. Unlike `<vaadin-date-picker>`, the value is not re-validated
+   * when the metadata is loaded, but checked against it at the next validation instead.
+   *
+   * Keep a stable reference to the function: assigning a new one clears the cache and re-fetches
+   * visible range. Call `clearCache()` to re-fetch when the data behind the same function changed.
+   */
+  dateMetadataProvider: DatePickerDateMetadataProvider | null | undefined;
+
+  /**
    * Set to true to prevent the overlays from opening automatically.
    * @attr {boolean} auto-open-disabled
    */
@@ -171,4 +211,9 @@ export declare class DateTimePickerMixinClass {
    * [`<vaadin-time-picker>`](#/elements/vaadin-time-picker) are supported.
    */
   i18n: DateTimePickerI18n;
+
+  /**
+   * Clears the `dateMetadataProvider` cache and reloads the date metadata.
+   */
+  clearCache(): void;
 }

--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
@@ -182,6 +182,51 @@ export const DateTimePickerMixin = (superClass) =>
         },
 
         /**
+         * A function that provides metadata for the dates the calendar is about to render: whether they
+         * are disabled, and CSS `part` names for styling from outside using the `::part()` selector.
+         * The provider is called for a range of dates at a time, and again as the calendar renders
+         * further dates.
+         *
+         * It receives a `DatePickerDateRange` and returns an array of `DatePickerDateMetadata` objects
+         * for the dates in that range that have metadata. It can return a `Promise` to load the metadata
+         * asynchronously, and `null` or `undefined` when no date in the range has metadata.
+         *
+         * The returned array has the following structure:
+         *
+         * ```js
+         * [
+         *   // month is 0-based: January = 0 and December = 11.
+         *   { year: 2026, month: 0, day: 1, disabled: true },
+         *
+         *   // Adds a custom part name to the date.
+         *   { year: 2026, month: 0, day: 2, part: 'busy' },
+         * ]
+         * ```
+         *
+         * A date is disabled if its metadata marks it disabled, or it is outside `min` and `max`.
+         * Disabled dates are not selectable, and a value on a disabled date makes the field invalid.
+         * The provider does not affect which date is focused when opening the overlay. Use
+         * `initialPosition` property to provide a selectable date.
+         *
+         * While a returned `Promise` is pending, the dates it covers are not disabled yet and render with
+         * the `loading` part. If the function throws or rejects, corresponding dates are requested again
+         * the next time the user navigates.
+         *
+         * The provider is used for validation also when the overlay is closed. Date is considered valid
+         * while the provider is pending. Unlike `<vaadin-date-picker>`, the value is not re-validated
+         * when the metadata is loaded, but checked against it at the next validation instead.
+         *
+         * Keep a stable reference to the function: assigning a new one clears the cache and re-fetches
+         * visible range. Call `clearCache()` to re-fetch when the data behind the same function changed.
+         *
+         * @type {DatePickerDateMetadataProvider | null | undefined}
+         */
+        dateMetadataProvider: {
+          type: Function,
+          sync: true,
+        },
+
+        /**
          * Set to true to prevent the overlays from opening automatically.
          * @attr {boolean} auto-open-disabled
          */
@@ -246,6 +291,7 @@ export const DateTimePickerMixin = (superClass) =>
         '__stepChanged(step, __timePicker)',
         '__initialPositionChanged(initialPosition, __datePicker)',
         '__showWeekNumbersChanged(showWeekNumbers, __datePicker)',
+        '__dateMetadataProviderChanged(dateMetadataProvider, __datePicker)',
         '__requiredChanged(required, __datePicker, __timePicker)',
         '__invalidChanged(invalid, __datePicker, __timePicker)',
         '__disabledChanged(disabled, __datePicker, __timePicker)',
@@ -545,6 +591,7 @@ export const DateTimePickerMixin = (superClass) =>
         this.datePlaceholder = newDatePicker.placeholder;
         this.initialPosition = newDatePicker.initialPosition;
         this.showWeekNumbers = newDatePicker.showWeekNumbers;
+        this.dateMetadataProvider = newDatePicker.dateMetadataProvider;
       }
 
       // Min and max are always synchronized from date time picker (host) to inner fields because time picker
@@ -660,6 +707,13 @@ export const DateTimePickerMixin = (superClass) =>
     __showWeekNumbersChanged(showWeekNumbers, datePicker) {
       if (datePicker) {
         datePicker.showWeekNumbers = showWeekNumbers;
+      }
+    }
+
+    /** @private */
+    __dateMetadataProviderChanged(dateMetadataProvider, datePicker) {
+      if (datePicker) {
+        datePicker.dateMetadataProvider = dateMetadataProvider;
       }
     }
 
@@ -799,6 +853,13 @@ export const DateTimePickerMixin = (superClass) =>
           this.step,
         ),
       );
+    }
+
+    /**
+     * Clears the `dateMetadataProvider` cache and reloads the date metadata.
+     */
+    clearCache() {
+      this.__datePicker?.clearCache();
     }
 
     /**

--- a/packages/date-time-picker/test/date-metadata.test.js
+++ b/packages/date-time-picker/test/date-metadata.test.js
@@ -1,0 +1,160 @@
+import { expect } from '@vaadin/chai-plugins';
+import { aTimeout, fixtureSync, nextRender, tap } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../src/vaadin-date-time-picker.js';
+
+describe('dateMetadataProvider', () => {
+  let dateTimePicker, datePicker, timePicker;
+
+  // The 15th of January 2024 is disabled, whatever range the provider is asked about.
+  function disableFifteenth() {
+    return [{ year: 2024, month: 0, day: 15, disabled: true }];
+  }
+
+  function deferredProvider() {
+    const pending = [];
+    const provider = () =>
+      new Promise((resolve) => {
+        pending.push(() => resolve(disableFifteenth()));
+      });
+    provider.resolveAll = () => {
+      pending.splice(0).forEach((resolve) => resolve());
+    };
+    return provider;
+  }
+
+  function getDateCell(day) {
+    return [...datePicker._overlayContent.querySelectorAll('vaadin-month-calendar')]
+      .filter((calendar) => calendar.month)
+      .flatMap((calendar) => [...calendar.shadowRoot.querySelectorAll('[part~="date"]:not(:empty)')])
+      .find((cell) => cell.date && cell.date.getMonth() === 0 && cell.date.getDate() === day);
+  }
+
+  // The reactive chain after a provider resolves can span more than one render. Throws rather than
+  // giving up, so that a test whose predicate is a precondition fails instead of passing silently.
+  async function untilRendered(predicate) {
+    for (let i = 0; i < 50 && !predicate(); i++) {
+      await nextRender();
+    }
+    if (!predicate()) {
+      throw new Error('Timed out waiting for the expected state');
+    }
+    await nextRender();
+  }
+
+  beforeEach(async () => {
+    dateTimePicker = fixtureSync('<vaadin-date-time-picker></vaadin-date-time-picker>');
+    await nextRender();
+    datePicker = dateTimePicker.querySelector('[slot=date-picker]');
+    timePicker = dateTimePicker.querySelector('[slot=time-picker]');
+  });
+
+  describe('in the overlay', () => {
+    beforeEach(async () => {
+      dateTimePicker.dateMetadataProvider = disableFifteenth;
+      dateTimePicker.initialPosition = '2024-01-15';
+      // The time half is filled, so picking a date completes the value.
+      timePicker.value = '10:00';
+      datePicker.opened = true;
+      await untilRendered(() => getDateCell(15)?.hasAttribute('disabled'));
+    });
+
+    it('should disable a provider-disabled date', () => {
+      expect(getDateCell(15).hasAttribute('disabled')).to.be.true;
+      expect(getDateCell(16).hasAttribute('disabled')).to.be.false;
+    });
+
+    it('should not commit a provider-disabled date on tap', async () => {
+      tap(getDateCell(15));
+      await nextRender();
+
+      expect(dateTimePicker.value).to.equal('');
+      expect(datePicker.opened).to.be.true;
+    });
+
+    it('should commit a date the provider allows on tap', async () => {
+      tap(getDateCell(16));
+      await nextRender();
+
+      expect(dateTimePicker.value).to.equal('2024-01-16T10:00');
+    });
+  });
+
+  describe('validation', () => {
+    it('should report a provider-disabled value invalid', async () => {
+      dateTimePicker.dateMetadataProvider = disableFifteenth;
+      dateTimePicker.value = '2024-01-15T10:00';
+      await aTimeout(0);
+
+      expect(dateTimePicker.checkValidity()).to.be.false;
+    });
+
+    it('should not become invalid until validated when the provider disables the value', async () => {
+      const provider = deferredProvider();
+      dateTimePicker.dateMetadataProvider = provider;
+      dateTimePicker.value = '2024-01-15T10:00';
+      await aTimeout(0);
+      // Nothing is known about the month yet, so the value is allowed.
+      expect(dateTimePicker.checkValidity()).to.be.true;
+
+      provider.resolveAll();
+      await untilRendered(() => !dateTimePicker.checkValidity());
+
+      // Validity computed from the answer is correct, but the `invalid` state does not follow on its
+      // own: the pickers validate manually, so nothing reports the answer upwards.
+      expect(dateTimePicker.checkValidity()).to.be.false;
+      expect(dateTimePicker.invalid).to.be.false;
+
+      dateTimePicker.validate();
+
+      expect(dateTimePicker.invalid).to.be.true;
+    });
+
+    it('should stay valid for a value the provider allows', async () => {
+      const provider = deferredProvider();
+      dateTimePicker.dateMetadataProvider = provider;
+      dateTimePicker.value = '2024-01-16T10:00';
+      await aTimeout(0);
+
+      provider.resolveAll();
+      await untilRendered(() => datePicker._dateMetadataController.isMonthLoaded(new Date(2024, 0, 16)));
+
+      expect(dateTimePicker.checkValidity()).to.be.true;
+      dateTimePicker.validate();
+      expect(dateTimePicker.invalid).to.be.false;
+    });
+  });
+
+  describe('clearCache', () => {
+    it('should delegate to the date picker', () => {
+      const spy = sinon.spy(datePicker, 'clearCache');
+
+      dateTimePicker.clearCache();
+
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should ask the provider again', async () => {
+      const provider = sinon.stub().returns([]);
+      dateTimePicker.dateMetadataProvider = provider;
+      datePicker.opened = true;
+      await untilRendered(() => provider.called);
+      provider.resetHistory();
+
+      dateTimePicker.clearCache();
+      await nextRender();
+
+      expect(provider).to.be.called;
+    });
+
+    it('should not throw when no provider is set', () => {
+      expect(() => dateTimePicker.clearCache()).to.not.throw();
+    });
+
+    it('should not throw before the pickers exist', () => {
+      const detached = document.createElement('vaadin-date-time-picker');
+
+      expect(() => detached.clearCache()).to.not.throw();
+    });
+  });
+});

--- a/packages/date-time-picker/test/properties.test.js
+++ b/packages/date-time-picker/test/properties.test.js
@@ -206,6 +206,12 @@ function getTimePicker(dateTimePicker) {
       expect(datePicker.showWeekNumbers).to.be.true;
     });
 
+    it('should propagate dateMetadataProvider to date picker', () => {
+      const dateMetadataProvider = () => [];
+      dateTimePicker.dateMetadataProvider = dateMetadataProvider;
+      expect(datePicker.dateMetadataProvider).to.equal(dateMetadataProvider);
+    });
+
     it('should propagate invalid to date and time pickers', async () => {
       dateTimePicker.invalid = true;
       await nextFrame();
@@ -334,5 +340,44 @@ function getTimePicker(dateTimePicker) {
     it('should have initial value for label', () => {
       expect(dateTimePicker.label).to.equal('Birth date and time');
     });
+  });
+});
+
+describe('Initial function property values', () => {
+  const dateMetadataProvider = () => [];
+
+  let dateTimePicker;
+
+  beforeEach(() => {
+    dateTimePicker = document.createElement('vaadin-date-time-picker');
+  });
+
+  afterEach(() => {
+    dateTimePicker.remove();
+  });
+
+  it('should forward the provider assigned before the pickers exist', async () => {
+    dateTimePicker.dateMetadataProvider = dateMetadataProvider;
+
+    document.body.appendChild(dateTimePicker);
+    await nextRender();
+
+    expect(getDatePicker(dateTimePicker).dateMetadataProvider).to.equal(dateMetadataProvider);
+  });
+
+  it('should keep and hoist the provider of a slotted date picker', async () => {
+    const datePicker = document.createElement('vaadin-date-picker');
+    datePicker.setAttribute('slot', 'date-picker');
+    datePicker.dateMetadataProvider = dateMetadataProvider;
+
+    const timePicker = document.createElement('vaadin-time-picker');
+    timePicker.setAttribute('slot', 'time-picker');
+    dateTimePicker.append(datePicker, timePicker);
+
+    document.body.appendChild(dateTimePicker);
+    await nextRender();
+
+    expect(datePicker.dateMetadataProvider).to.equal(dateMetadataProvider);
+    expect(dateTimePicker.dateMetadataProvider).to.equal(dateMetadataProvider);
   });
 });

--- a/packages/date-time-picker/test/typings/date-time-picker.types.ts
+++ b/packages/date-time-picker/test/typings/date-time-picker.types.ts
@@ -3,6 +3,7 @@ import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js
 import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
+import type { DatePickerDateMetadataProvider } from '@vaadin/date-picker/src/vaadin-date-picker.js';
 import type { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
 import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
@@ -71,6 +72,8 @@ assertType<boolean | null | undefined>(picker.autoOpenDisabled);
 assertType<boolean | null | undefined>(picker.autofocus);
 assertType<() => boolean>(picker.validate);
 assertType<() => boolean>(picker.checkValidity);
+assertType<DatePickerDateMetadataProvider | null | undefined>(picker.dateMetadataProvider);
+assertType<() => void>(picker.clearCache);
 
 // I18n
 assertType<DateTimePickerI18n>({});


### PR DESCRIPTION
## Description

Added `dateMetadataProvider` and `clearCache()` to DTP forwarded to the inner date-picker.

Follow-up to https://github.com/vaadin/web-components/pull/12259
Extracted from https://github.com/vaadin/web-components/pull/12041

## Type of change

- Feature