### PR TITLE
chore: remove no longer needed eslint-plugin-es-x

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,6 @@
 import prettier from 'eslint-config-vaadin/prettier';
 import testing from 'eslint-config-vaadin/testing';
 import typescript from 'eslint-config-vaadin/typescript';
-import esX from 'eslint-plugin-es-x';
 import html from 'eslint-plugin-html';
 import noOnlyTests from 'eslint-plugin-no-only-tests';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
@@ -48,7 +47,6 @@ export default [
   ...prettier,
   {
     plugins: {
-      'es-x': esX,
       'no-only-tests': noOnlyTests,
       'simple-import-sort': simpleImportSort,
       'custom-rules': {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@web/test-runner-visual-regression": "^1.0.1",
     "eslint": "^10.8.1",
     "eslint-config-vaadin": "^1.0.0-beta.7",
-    "eslint-plugin-es-x": "^10.0.0",
     "eslint-plugin-html": "^8.1.4",
     "eslint-plugin-no-only-tests": "^3.4.0",
     "eslint-plugin-prettier": "^5.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -666,14 +666,14 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz#10064ee44f4347b90c9a02b446bbf80a91632b12"
   integrity sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==
 
-"@eslint-community/eslint-utils@^4.1.2", "@eslint-community/eslint-utils@^4.7.0", "@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
+"@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
   integrity sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
   dependencies:
     eslint-visitor-keys "^3.4.3"
 
-"@eslint-community/regexpp@^4.12.1", "@eslint-community/regexpp@^4.12.2":
+"@eslint-community/regexpp@^4.12.2":
   version "4.12.2"
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.2.tgz#bccdf615bcf7b6e8db830ec0b8d21c9a25de597b"
   integrity sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
@@ -4622,15 +4622,6 @@ eslint-plugin-chai-friendly@1.2.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-1.2.1.tgz#141392762aa8626ac3d25780a502e625ce74922b"
   integrity sha512-mV3EOJLDr8+L+LS8uCkP711fnNHz+4PsmPyz18xwkvjJwfLRlnx0Eu6CFnb5B+dW5ahoav2jVer2KFYsmIuv3A==
 
-eslint-plugin-es-x@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-es-x/-/eslint-plugin-es-x-10.0.0.tgz#d4d87bb9058eca50f12a8aaa775c9e72fe17b3af"
-  integrity sha512-EWhp0mIEFOxDMndU7OBihmhvBmk49Tn7tYF8yT7tKpDm0Q2QJY2WoVPEVdzk1wyOgeJaBjbbQslD/nzdsiP7sg==
-  dependencies:
-    "@eslint-community/eslint-utils" "^4.1.2"
-    "@eslint-community/regexpp" "^4.12.1"
-    eslint-type-tracer "^0.5.1"
-
 eslint-plugin-html@^8.1.4:
   version "8.1.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-html/-/eslint-plugin-html-8.1.4.tgz#50750ed7e4d396431e268a63c76c23438a15794d"
@@ -4757,13 +4748,6 @@ eslint-scope@^9.1.0, eslint-scope@^9.1.2:
     "@types/estree" "^1.0.8"
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
-
-eslint-type-tracer@^0.5.1:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/eslint-type-tracer/-/eslint-type-tracer-0.5.2.tgz#187e376dcc04a0b2a5254904ca388793d0bd22e5"
-  integrity sha512-YiJmgk6OD1suPB4UC3M/PB+oxahf145jQQ5gFXFk9F9Y7puWwnqGYC2BtTB+FoHqdOohImeTt0rNk0lhhECNaQ==
-  dependencies:
-    "@eslint-community/eslint-utils" "^4.7.0"
 
 eslint-visitor-keys@^3.4.3:
   version "3.4.3"


### PR DESCRIPTION
## Description

This plugin was added in https://github.com/vaadin/web-components/pull/5833 to disallow optional chaining. Corresponding rules have been removed in https://github.com/vaadin/web-components/pull/11622 after migrating to CEM. Let's drop the plugin entirely for now as we use modern syntax like private `#` fields nowadays.

## Type of change

- Internal change