### PR TITLE
fix: keep time-picker value stable with a custom time parser

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker-helper.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker-helper.d.ts
@@ -25,6 +25,9 @@ export function parseISOTime(timeString: string): TimePickerTime | undefined;
 
 /**
  * A function to validate the time object based on the given step.
+ *
+ * Returns a new object, so that a time object owned by the caller, such as one
+ * returned by the `i18n.parseTime` function, is left as it is.
  */
 export function validateTime(
   timeObject: TimePickerTime | undefined,

--- a/packages/time-picker/src/vaadin-time-picker-helper.js
+++ b/packages/time-picker/src/vaadin-time-picker-helper.js
@@ -75,17 +75,25 @@ function getStepSegment(stepValue) {
 /**
  * A function to validate the time object based on the given step.
  *
+ * Returns a new object, so that a time object owned by the caller, such as one
+ * returned by the `i18n.parseTime` function, is left as it is.
+ *
  * @param {object} timeObject
  * @param {number} step
  * @return {object | undefined}
  */
 export function validateTime(timeObject, step) {
-  if (timeObject) {
-    const stepSegment = getStepSegment(step);
-    timeObject.hours = parseInt(timeObject.hours);
-    timeObject.minutes = parseInt(timeObject.minutes || 0);
-    timeObject.seconds = stepSegment < 3 ? undefined : parseInt(timeObject.seconds || 0);
-    timeObject.milliseconds = stepSegment < 4 ? undefined : parseInt(timeObject.milliseconds || 0);
+  if (!timeObject) {
+    return timeObject;
   }
-  return timeObject;
+
+  const stepSegment = getStepSegment(step);
+
+  return {
+    ...timeObject,
+    hours: parseInt(timeObject.hours),
+    minutes: parseInt(timeObject.minutes || 0),
+    seconds: stepSegment < 3 ? undefined : parseInt(timeObject.seconds || 0),
+    milliseconds: stepSegment < 4 ? undefined : parseInt(timeObject.milliseconds || 0),
+  };
 }

--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -604,7 +604,11 @@ export const TimePickerMixin = (superClass) =>
         return;
       }
 
-      const parsedObj = this.__useMemo ? this.__memoValue : this.__effectiveI18n.parseTime(value);
+      const parsed = this.__useMemo ? this.__memoValue : this.__effectiveI18n.parseTime(value);
+
+      // Strip parsed time to the resolution defined by the step before formatting
+      // it back, so that the result matches the text shown in the input field.
+      const parsedObj = validateTime(parsed, this.step);
       const newValue = this.__effectiveI18n.formatTime(parsedObj) || '';
 
       if (parsedObj) {

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -414,6 +414,33 @@ describe('time-picker', () => {
         expect(inputElement.value).to.be.equal('8:00 AM');
       });
     });
+
+    it('should commit the value when the custom parser returns stripped seconds', () => {
+      // The step defaults to minute precision, so the seconds are stripped
+      // from the value, while the custom parser keeps returning them.
+      timePicker.i18n = { parseTime: () => ({ hours: 12, minutes: 0, seconds: 0 }) };
+      setInputValue(timePicker, 'noon');
+      enter(inputElement);
+      expect(timePicker.value).to.be.equal('12:00');
+    });
+
+    it('should not modify the object returned by the custom parser', () => {
+      const parsed = { hours: 8, minutes: 0, seconds: 0, milliseconds: 0 };
+      timePicker.i18n = { formatTime: strictAmPmI18n.formatTime, parseTime: () => parsed };
+      setInputValue(timePicker, '8:00 AM');
+      enter(inputElement);
+      expect(parsed).to.deep.equal({ hours: 8, minutes: 0, seconds: 0, milliseconds: 0 });
+    });
+
+    it('should not fail when the custom parser returns a frozen object', () => {
+      timePicker.i18n = {
+        formatTime: strictAmPmI18n.formatTime,
+        parseTime: () => Object.freeze({ hours: 8, minutes: 0, seconds: 0, milliseconds: 0 }),
+      };
+      setInputValue(timePicker, '8:00 AM');
+      enter(inputElement);
+      expect(timePicker.value).to.be.equal('08:00');
+    });
   });
 
   describe('helper text', () => {


### PR DESCRIPTION
Fixes #911

Follow-up to #12402 

The parsed time was formatted back without applying the step resolution first, so the result did not match the text shown in the input field. When a custom `parseTime` returns seconds that the step strips, the two texts keep replacing each other until the stack runs out, which is the error from the report:

```
'12:00' -> parseTime -> { hours: 12, minutes: 0, seconds: 0 }
        -> formatTime -> '12:00:00' -> stripped back to '12:00'
```

This stays hidden when `parseTime` returns the same object on every call, as the Flow connector does, because `validateTime` then updates that object in place and the second pass sees the stripped one. Which is the other half of the report: the component modifies the object it gets from `parseTime`. A cached object loses its seconds, and a frozen object throws `TypeError: Cannot assign to read only property 'hours'`.

## Changes

The parsed time is stripped to the step resolution before being formatted, so the value settles in a single pass. It is also copied before `validateTime` updates it in place, leaving a time object owned by the `i18n.parseTime` implementation alone.

Both parts are in one commit on purpose: the loop currently ends only because that in-place update happens, so copying the object without the first change brings the loop back.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
