### PR TITLE
docs: mention dateMetadataProvider in isDateDisabled JSDoc

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -281,6 +281,10 @@ export declare class DatePickerMixinClass {
    * A function to be used to determine whether the user can select a given date.
    * Receives a `DatePickerDate` object of the date to be selected and should return a
    * boolean.
+   *
+   * The function is called once per date and has to answer synchronously. Use
+   * `dateMetadataProvider` when the answer has to be loaded first, or when dates also need
+   * custom part names. A date is disabled when either of the two disables it.
    */
   isDateDisabled: (date: DatePickerDate) => boolean;
 

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -206,6 +206,10 @@ export const DatePickerMixin = (subclass) =>
          * Receives a `DatePickerDate` object of the date to be selected and should return a
          * boolean.
          *
+         * The function is called once per date and has to answer synchronously. Use
+         * `dateMetadataProvider` when the answer has to be loaded first, or when dates also need
+         * custom part names. A date is disabled when either of the two disables it.
+         *
          * @type {function(DatePickerDate): boolean | undefined}
          */
         isDateDisabled: {


### PR DESCRIPTION
The `dateMetadataProvider` description explains how it differs from `isDateDisabled`, but the link only goes one way. A reader who starts from `isDateDisabled` gets no hint that there is an option that can load its answer, or that the two are combined rather than exclusive.

The added paragraph states the two limits that make the provider the better choice — one call per date, and no way to wait for an answer — and that a date is disabled when either of them disables it.

Follow-up to #12259, Part of #1820

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
