### PR TITLE
refactor!: use ISO date strings in dateMetadataProvider API

### DIFF
--- a/dev/playground/date-picker-metadata.html
+++ b/dev/playground/date-picker-metadata.html
@@ -105,8 +105,8 @@
       <p>
         The provider marks a few dates <code>busy</code> and <code>almost-full</code> through <code>part</code>, styled
         below with <code>::part()</code>. Naming a part does not disable a date — the busy ones stay selectable.
-        <em>Book a date</em> marks the next free weekday busy behind the provider, then calls
-        <code>clearCache()</code>, which re-fetches without replacing the provider function.
+        <em>Book a date</em> marks the next free weekday busy behind the provider, then calls <code>clearCache()</code>,
+        which re-fetches without replacing the provider function.
       </p>
       <div class="controls">
         <button id="book" type="button">Book a date</button>
@@ -129,13 +129,23 @@
       const logElement = document.querySelector('#log');
       const MAX_ENTRIES = 50;
 
-      // `month` in a `DatePickerDateRange` is 0-based, so add one to read it as a calendar month.
-      function formatDate({ year, month, day }) {
-        return `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+      // A range and an entry identify a date by an ISO 8601 string, the same format as `value`.
+      function parseISODate(iso) {
+        const [year, month, day] = iso.split('-').map(Number);
+        return new Date(year, month - 1, day);
+      }
+
+      function formatISODate(date) {
+        return [
+          String(date.getFullYear()).padStart(4, '0'),
+          String(date.getMonth() + 1).padStart(2, '0'),
+          String(date.getDate()).padStart(2, '0'),
+        ].join('-');
       }
 
       function countMonths({ start, end }) {
-        return (end.year - start.year) * 12 + (end.month - start.month) + 1;
+        const [first, last] = [parseISODate(start), parseISODate(end)];
+        return (last.getFullYear() - first.getFullYear()) * 12 + (last.getMonth() - first.getMonth()) + 1;
       }
 
       /**
@@ -144,7 +154,7 @@
        */
       function logCall(name, range) {
         const entry = document.createElement('li');
-        const span = `${formatDate(range.start)} → ${formatDate(range.end)}`;
+        const span = `${range.start} → ${range.end}`;
         entry.textContent = `${name}  ${span}  (${countMonths(range)} months)`;
         logElement.prepend(entry);
 
@@ -162,8 +172,8 @@
       /** Every date in the requested range, so a provider can filter it down to the ones it cares about. */
       function datesInRange({ start, end }) {
         const dates = [];
-        const last = new Date(end.year, end.month, end.day);
-        let date = new Date(start.year, start.month, start.day);
+        const last = parseISODate(end);
+        let date = parseISODate(start);
         while (date <= last) {
           dates.push(date);
           date = new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1);
@@ -171,12 +181,8 @@
         return dates;
       }
 
-      function toParts(date) {
-        return { year: date.getFullYear(), month: date.getMonth(), day: date.getDate() };
-      }
-
       function disabledEntry(date) {
-        return { ...toParts(date), disabled: true };
+        return { date: formatISODate(date), disabled: true };
       }
 
       function isWeekend(date) {
@@ -234,19 +240,19 @@
         return dates;
       };
       combined.isDateDisabled = ({ day }) => day === 16;
-      combined.min = formatDate(toParts(new Date()));
-      combined.max = formatDate(toParts(new Date(Date.now() + 90 * 24 * 60 * 60 * 1000)));
+      combined.min = formatISODate(new Date());
+      combined.max = formatISODate(new Date(Date.now() + 90 * 24 * 60 * 60 * 1000));
 
       // Stands in for data that changes behind the provider, keyed by ISO date.
       const booked = new Set();
 
       function bookingEntry(date) {
-        const iso = formatDate(toParts(date));
+        const iso = formatISODate(date);
         if (booked.has(iso)) {
-          return { ...toParts(date), part: 'busy' };
+          return { date: iso, part: 'busy' };
         }
         // Fridays fill up first, so mark them without disabling anything.
-        return date.getDay() === 5 ? { ...toParts(date), part: 'almost-full' } : null;
+        return date.getDay() === 5 ? { date: iso, part: 'almost-full' } : null;
       }
 
       const parts = document.querySelector('#parts');
@@ -262,8 +268,8 @@
         // The next weekday that is not booked yet.
         do {
           date.setDate(date.getDate() + 1);
-        } while (isWeekend(date) || booked.has(formatDate(toParts(date))));
-        booked.add(formatDate(toParts(date)));
+        } while (isWeekend(date) || booked.has(formatISODate(date)));
+        booked.add(formatISODate(date));
         // Same provider function, new answer: `clearCache()` is what makes it visible.
         parts.clearCache();
       });

--- a/packages/date-picker/ARCHITECTURE.md
+++ b/packages/date-picker/ARCHITECTURE.md
@@ -275,18 +275,17 @@ loading and `isLoading()` stays true, until the cache is cleared.
 
 ### When the provider is written wrong
 
-A result that is not an array, and an entry that does not describe a real date, are reported rather than
+A result that is not an array, and an entry whose `date` is not a real date, are reported rather than
 ignored: ignoring them would present a provider bug as "nothing is disabled".
 
-Entries are checked by rebuilding the date and comparing it back, which catches a month outside 0–11, a day
-outside its month, and February 30 alike — each would otherwise be stored under a key that no lookup can
-produce. A month given 1-based cannot be caught this way, being a valid month number, so the 0-based
-contract is stated on the provider type instead.
+An entry's date goes through the same parser as `value`, `min` and `max`, so one format is accepted
+everywhere and a date that does not exist is rejected there rather than here. February 30 would otherwise be
+stored as the 2nd of March, under a key no lookup for the 30th can produce.
 
-The three fields are type-checked before that, which is not redundant. A value that cannot be coerced to a
-number (e.g. bigint) throws while the date is being rebuilt; because the answer is applied inside the
-error handling above, one such entry would discard the whole range and have it requested again on every
-navigation, instead of costing only itself.
+What the parser does not do is check its argument is a string, since it documents one. An entry comes from
+outside, so the check is made here: coercion can itself throw — a `Symbol` or a throwing `toString` does —
+and the answer is applied inside the error handling above, so one such entry would discard the whole range
+and have it requested again on every navigation instead of costing only itself.
 
 Both are mistakes in how the provider is written rather than runtime failures, so they are warned about
 once instead of once per request, which would otherwise repeat on every scroll. The trade is that the
@@ -302,6 +301,6 @@ message states the contract instead of naming the offending entry.
   different microtasks after a provider resolves. Do not assert the overlay's state straight after awaiting
   a calendar update; await the date-picker instead.
 - A provider's answer is awaited even when it is a plain array, so what it resolves has to be awaited before
-  being asserted. What the provider was *asked* can be asserted right away.
-- Provider ranges use **0-indexed months** and cover whole blocks, so a range starts on 1 January and ends
-  on 31 December of the years it spans.
+  being asserted. What the provider was _asked_ can be asserted right away.
+- Provider ranges cover whole blocks, so a range starts on 1 January and ends on 31 December of the years
+  it spans.

--- a/packages/date-picker/src/vaadin-date-metadata-controller.d.ts
+++ b/packages/date-picker/src/vaadin-date-metadata-controller.d.ts
@@ -12,8 +12,8 @@ import type { DatePickerDateMetadata, DatePickerDateMetadataProvider } from './v
  *
  * The provider is called for a range of months and may return an array
  * synchronously or a `Promise`, so results from a server (Flow) or a remote
- * availability service can be awaited. Each returned entry is a `DatePickerDate`
- * extended with metadata fields, e.g. `{ year, month, day, disabled: true }`.
+ * availability service can be awaited. The range and each returned entry identify
+ * a date by an ISO 8601 string, e.g. `{ date: '2026-01-01', disabled: true }`.
  *
  * `ARCHITECTURE.md` in this package records the reasoning behind the request,
  * caching, notification and failure behavior.

--- a/packages/date-picker/src/vaadin-date-metadata-controller.js
+++ b/packages/date-picker/src/vaadin-date-metadata-controller.js
@@ -6,14 +6,7 @@
 import { microTask } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { issueWarning } from '@vaadin/component-base/src/warnings.js';
-import {
-  createDate,
-  extractDateParts,
-  lastOfMonth,
-  monthDate,
-  monthIndex,
-  monthIndexOf,
-} from './vaadin-date-picker-helper.js';
+import { formatISODate, lastOfMonth, monthDate, monthIndex, parseDate } from './vaadin-date-picker-helper.js';
 
 // Counted from January of year 0, so a block is one calendar year.
 const BLOCK_MONTHS = 12;
@@ -24,12 +17,10 @@ function blockStart(month) {
 
 const PENDING_MONTH = Object.freeze({ pending: true });
 
-function isValidEntry(entry) {
-  if (!entry || !Number.isInteger(entry.year) || !Number.isInteger(entry.month) || !Number.isInteger(entry.day)) {
-    return false;
-  }
-  const date = createDate(entry.year, entry.month, entry.day);
-  return date.getFullYear() === entry.year && date.getMonth() === entry.month && date.getDate() === entry.day;
+// The date of an entry, or `undefined` when its `date` is not one. Checked for being a string first,
+// since coercing another type to one can throw, and an entry comes from outside.
+function entryDate(entry) {
+  return typeof entry?.date === 'string' ? parseDate(entry.date) : undefined;
 }
 
 function groupEntriesByMonth(months, entries) {
@@ -37,10 +28,11 @@ function groupEntriesByMonth(months, entries) {
 
   if (Array.isArray(entries)) {
     entries.forEach((entry) => {
-      if (isValidEntry(entry)) {
-        result.get(monthIndexOf(entry.year, entry.month))?.set(entry.day, entry);
+      const date = entryDate(entry);
+      if (date) {
+        result.get(monthIndex(date))?.set(date.getDate(), entry);
       } else {
-        issueWarning('Ignored `dateMetadataProvider` entries with an invalid year, month (0-11) or day.');
+        issueWarning('Ignored `dateMetadataProvider` entries whose `date` is not an ISO 8601 date.');
       }
     });
   } else if (entries != null) {
@@ -56,8 +48,8 @@ function groupEntriesByMonth(months, entries) {
  *
  * The provider is called for a range of months and may return an array
  * synchronously or a `Promise`, so results from a server (Flow) or a remote
- * availability service can be awaited. Each returned entry is a `DatePickerDate`
- * extended with metadata fields, e.g. `{ year, month, day, disabled: true }`.
+ * availability service can be awaited. The range and each returned entry identify
+ * a date by an ISO 8601 string, e.g. `{ date: '2026-01-01', disabled: true }`.
  *
  * `ARCHITECTURE.md` in this package records the reasoning behind the request,
  * caching, notification and failure behavior.
@@ -235,8 +227,8 @@ export class DateMetadataController {
     this.#notify();
 
     const range = {
-      start: extractDateParts(monthDate(months[0])),
-      end: extractDateParts(lastOfMonth(monthDate(months.at(-1)))),
+      start: formatISODate(monthDate(months[0])),
+      end: formatISODate(lastOfMonth(monthDate(months.at(-1)))),
     };
 
     let entries;

--- a/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -24,19 +24,23 @@ export interface DatePickerDate {
  */
 export interface DatePickerDateRange {
   /**
-   * The first date of the range (inclusive).
+   * The first date of the range (inclusive), as an ISO 8601 date.
    */
-  start: DatePickerDate;
+  start: string;
   /**
-   * The last date of the range (inclusive).
+   * The last date of the range (inclusive), as an ISO 8601 date.
    */
-  end: DatePickerDate;
+  end: string;
 }
 
 /**
  * Metadata for a single date, returned by `dateMetadataProvider`.
  */
-export interface DatePickerDateMetadata extends DatePickerDate {
+export interface DatePickerDateMetadata {
+  /**
+   * The date the metadata applies to in ISO 8601 format.
+   */
+  date: string;
   /**
    * Whether the date cannot be selected.
    */
@@ -302,11 +306,11 @@ export declare class DatePickerMixinClass {
    *
    * ```js
    * [
-   *   // month is 0-based: January = 0 and December = 11.
-   *   { year: 2026, month: 0, day: 1, disabled: true },
+   *   // The date is an ISO 8601 string.
+   *   { date: '2026-01-01', disabled: true },
    *
    *   // Adds a custom part name to the date.
-   *   { year: 2026, month: 0, day: 2, part: 'busy' },
+   *   { date: '2026-01-02', part: 'busy' },
    * ]
    * ```
    *

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -230,11 +230,11 @@ export const DatePickerMixin = (subclass) =>
          *
          * ```js
          * [
-         *   // month is 0-based: January = 0 and December = 11.
-         *   { year: 2026, month: 0, day: 1, disabled: true },
+         *   // The date is an ISO 8601 string.
+         *   { date: '2026-01-01', disabled: true },
          *
          *   // Adds a custom part name to the date.
-         *   { year: 2026, month: 0, day: 2, part: 'busy' },
+         *   { date: '2026-01-02', part: 'busy' },
          * ]
          * ```
          *

--- a/packages/date-picker/test/date-metadata-clear-cache.test.js
+++ b/packages/date-picker/test/date-metadata-clear-cache.test.js
@@ -2,7 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
-import { getDateCell, getMonthCalendar, open } from './helpers.js';
+import { getDateCell, getMonthCalendar, isoDate, open } from './helpers.js';
 
 describe('dateMetadataProvider clearCache', () => {
   let datePicker, overlayContent, year, month;
@@ -43,7 +43,7 @@ describe('dateMetadataProvider clearCache', () => {
 
   it('should reflect metadata that changed behind the provider', async () => {
     let disabledDay = 10;
-    datePicker.dateMetadataProvider = () => [{ year, month, day: disabledDay, disabled: true }];
+    datePicker.dateMetadataProvider = () => [{ date: isoDate(year, month, disabledDay), disabled: true }];
     await open(datePicker);
     overlayContent = datePicker._overlayContent;
     await untilRendered(() => getCell(10)?.hasAttribute('disabled'));
@@ -70,7 +70,7 @@ describe('dateMetadataProvider clearCache', () => {
 
   it('should re-validate the value while the overlay is closed', async () => {
     let disabled = false;
-    datePicker.dateMetadataProvider = () => (disabled ? [{ year: 2024, month: 0, day: 15, disabled: true }] : []);
+    datePicker.dateMetadataProvider = () => (disabled ? [{ date: '2024-01-15', disabled: true }] : []);
     datePicker.value = '2024-01-15';
     await aTimeout(0);
     expect(datePicker.invalid).to.be.false;

--- a/packages/date-picker/test/date-metadata-controller.test.js
+++ b/packages/date-picker/test/date-metadata-controller.test.js
@@ -34,8 +34,8 @@ describe('DateMetadataController', () => {
     expect(provider).to.be.calledOnce;
     // A block is one calendar year, so asking about March 2023 asks about all of 2023.
     expect(provider.firstCall.args[0]).to.eql({
-      start: { year: 2023, month: 0, day: 1 },
-      end: { year: 2023, month: 11, day: 31 },
+      start: '2023-01-01',
+      end: '2023-12-31',
     });
   });
 
@@ -46,13 +46,13 @@ describe('DateMetadataController', () => {
 
     // Rounding towards zero instead of down would land in the block after this one.
     expect(provider.firstCall.args[0]).to.eql({
-      start: { year: -1, month: 0, day: 1 },
-      end: { year: -1, month: 11, day: 31 },
+      start: '-000001-01-01',
+      end: '-000001-12-31',
     });
   });
 
   it('should mark the requested months as loaded and expose disabled dates', async () => {
-    controller.setProvider(() => [{ year: 2023, month: 2, day: 15, disabled: true }]);
+    controller.setProvider(() => [{ date: '2023-03-15', disabled: true }]);
     loadMonth(2023, 2);
     await aTimeout(0);
 
@@ -64,8 +64,8 @@ describe('DateMetadataController', () => {
 
   it('should return the entry the provider supplied', async () => {
     controller.setProvider(() => [
-      { year: 2023, month: 2, day: 10, occupancy: 'high' },
-      { year: 2023, month: 2, day: 15, disabled: true },
+      { date: '2023-03-10', occupancy: 'high' },
+      { date: '2023-03-15', disabled: true },
     ]);
     loadMonth(2023, 2);
     await aTimeout(0);
@@ -119,8 +119,8 @@ describe('DateMetadataController', () => {
     // 2023 is already loaded, so only the block it reaches into is requested.
     expect(provider).to.be.calledOnce;
     expect(provider.firstCall.args[0]).to.eql({
-      start: { year: 2024, month: 0, day: 1 },
-      end: { year: 2024, month: 11, day: 31 },
+      start: '2024-01-01',
+      end: '2024-12-31',
     });
   });
 
@@ -135,13 +135,13 @@ describe('DateMetadataController', () => {
 
     expect(provider).to.be.calledOnce;
     expect(provider.firstCall.args[0]).to.eql({
-      start: { year: 2025, month: 0, day: 1 },
-      end: { year: 2025, month: 11, day: 31 },
+      start: '2025-01-01',
+      end: '2025-12-31',
     });
   });
 
   it('should clear the cache when the provider changes', async () => {
-    controller.setProvider(() => [{ year: 2023, month: 2, day: 15, disabled: true }]);
+    controller.setProvider(() => [{ date: '2023-03-15', disabled: true }]);
     loadMonth(2023, 2);
     await aTimeout(0);
     expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.true;
@@ -163,7 +163,7 @@ describe('DateMetadataController', () => {
 
     // Provider changes (reset) before the first request resolves.
     controller.setProvider(() => []);
-    resolveStale([{ year: 2023, month: 2, day: 15, disabled: true }]);
+    resolveStale([{ date: '2023-03-15', disabled: true }]);
     await aTimeout(0);
 
     expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.false;
@@ -183,8 +183,8 @@ describe('DateMetadataController', () => {
 
     expect(provider).to.be.calledOnce;
     expect(provider.firstCall.args[0]).to.eql({
-      start: { year: 2024, month: 0, day: 1 },
-      end: { year: 2024, month: 11, day: 31 },
+      start: '2024-01-01',
+      end: '2024-12-31',
     });
   });
 
@@ -201,8 +201,8 @@ describe('DateMetadataController', () => {
 
     expect(provider).to.be.calledOnce;
     expect(provider.firstCall.args[0]).to.eql({
-      start: { year: 2023, month: 0, day: 1 },
-      end: { year: 2025, month: 11, day: 31 },
+      start: '2023-01-01',
+      end: '2025-12-31',
     });
   });
 
@@ -215,7 +215,7 @@ describe('DateMetadataController', () => {
         return new Promise(() => {});
       }
       answered = true;
-      return [{ year: 2023, month: 6, day: 15, disabled: true }];
+      return [{ date: '2023-07-15', disabled: true }];
     });
 
     loadMonth(2023, 6); // Jan 2023 - Jan 2024
@@ -248,7 +248,7 @@ describe('DateMetadataController', () => {
       expect(controller.isLoading()).to.be.true;
       expect(controller.isMonthLoaded(new Date(2023, 2, 1))).to.be.false;
 
-      resolveProvider([{ year: 2023, month: 2, day: 15, disabled: true }]);
+      resolveProvider([{ date: '2023-03-15', disabled: true }]);
       await aTimeout(0);
 
       expect(controller.isLoading()).to.be.false;
@@ -272,7 +272,7 @@ describe('DateMetadataController', () => {
 
   describe('nullish dates', () => {
     beforeEach(async () => {
-      controller.setProvider(() => [{ year: 2023, month: 2, day: 15, disabled: true }]);
+      controller.setProvider(() => [{ date: '2023-03-15', disabled: true }]);
       loadMonth(2023, 2);
       await aTimeout(0);
     });
@@ -395,7 +395,7 @@ describe('DateMetadataController', () => {
         if (fail) {
           throw new Error('provider failed');
         }
-        return [{ year: 2023, month: 2, day: 15, disabled: true }];
+        return [{ date: '2023-03-15', disabled: true }];
       });
       controller.setProvider(provider);
       loadMonth(2023, 2);
@@ -459,7 +459,7 @@ describe('DateMetadataController', () => {
       loadMonth(2023, 2);
       element.requestUpdate.resetHistory();
 
-      resolveProvider([{ year: 2023, month: 2, day: 15, disabled: true }]);
+      resolveProvider([{ date: '2023-03-15', disabled: true }]);
       await aTimeout(0);
 
       expect(element.requestUpdate).to.be.called;
@@ -486,7 +486,7 @@ describe('DateMetadataController', () => {
 
   describe('detached host', () => {
     it('should keep the resolved cache when the host reconnects', async () => {
-      const provider = stubProvider([{ year: 2023, month: 2, day: 15, disabled: true }]);
+      const provider = stubProvider([{ date: '2023-03-15', disabled: true }]);
       loadMonth(2023, 2);
       await aTimeout(0);
       provider.resetHistory();
@@ -512,7 +512,7 @@ describe('DateMetadataController', () => {
       // Detached while the request is on its way: discarding the answer would only re-fetch the
       // same range once the host came back.
       host.isConnected = false;
-      resolveProvider([{ year: 2023, month: 2, day: 15, disabled: true }]);
+      resolveProvider([{ date: '2023-03-15', disabled: true }]);
       await aTimeout(0);
 
       expect(controller.isMonthLoaded(new Date(2023, 2, 1))).to.be.true;
@@ -532,7 +532,7 @@ describe('DateMetadataController', () => {
 
     it('should report the current state again once the host is reconnected', async () => {
       host.isConnected = false;
-      controller.setProvider(() => [{ year: 2023, month: 2, day: 15, disabled: true }]);
+      controller.setProvider(() => [{ date: '2023-03-15', disabled: true }]);
       // Resolves while detached, so the host is never told about it.
       loadMonth(2023, 2);
       await aTimeout(0);
@@ -548,14 +548,14 @@ describe('DateMetadataController', () => {
 
   describe('years below 100', () => {
     it('should resolve metadata for a year below 100', async () => {
-      const provider = stubProvider([{ year: 50, month: 6, day: 15, disabled: true }]);
+      const provider = stubProvider([{ date: '0050-07-15', disabled: true }]);
 
       loadMonth(50, 6);
       await aTimeout(0);
 
       expect(provider.firstCall.args[0]).to.eql({
-        start: { year: 50, month: 0, day: 1 },
-        end: { year: 50, month: 11, day: 31 },
+        start: '0050-01-01',
+        end: '0050-12-31',
       });
       expect(controller.isMonthLoaded(createDate(50, 6, 1))).to.be.true;
       expect(controller.isDateDisabled(createDate(50, 6, 15))).to.be.true;
@@ -568,8 +568,8 @@ describe('DateMetadataController', () => {
     // months must not be trusted before that month is loaded in its own right.
     beforeEach(async () => {
       controller.setProvider(() => [
-        { year: 2023, month: 2, day: 15, disabled: true },
-        { year: 2024, month: 0, day: 5, disabled: true },
+        { date: '2023-03-15', disabled: true },
+        { date: '2024-01-05', disabled: true },
       ]);
       loadMonth(2023, 2); // Sep 2022 - Sep 2023
       await aTimeout(0);
@@ -597,7 +597,7 @@ describe('DateMetadataController', () => {
       let call = 0;
       controller.setProvider(() => {
         call += 1;
-        return call === 1 ? [] : [{ year: 2026, month: 2, day: 10, disabled: true }];
+        return call === 1 ? [] : [{ date: '2026-03-10', disabled: true }];
       });
       loadMonth(2026, 2);
       await aTimeout(0);
@@ -611,7 +611,7 @@ describe('DateMetadataController', () => {
     });
   });
 
-  describe('entries that are not a real date', () => {
+  describe('entry date validation', () => {
     beforeEach(() => {
       sinon.stub(console, 'warn');
     });
@@ -623,17 +623,29 @@ describe('DateMetadataController', () => {
 
     [
       { name: 'a missing date', entry: { disabled: true } },
-      { name: 'a non-integer day', entry: { year: 2024, month: 0, day: '15' } },
-      { name: 'a month above 11', entry: { year: 2024, month: 12, day: 15 } },
-      { name: 'a negative month', entry: { year: 2024, month: -1, day: 15 } },
-      { name: 'a day above the month length', entry: { year: 2024, month: 0, day: 32 } },
-      { name: 'a zero day', entry: { year: 2024, month: 0, day: 0 } },
-      { name: 'a day that does not exist in that month', entry: { year: 2023, month: 1, day: 29 } },
-      // Throws when coerced to a number, rather than merely describing no real date.
-      { name: 'a bigint month', entry: { year: 2024, month: 0n, day: 15 } },
+      { name: 'a date that is not a string', entry: { date: 20240115 } },
+      // Coercing these to a string throws, which would discard the whole range rather than the entry.
+      { name: 'a date that is a symbol', entry: { date: Symbol('2024-01-15') } },
+      {
+        name: 'a date that throws when coerced',
+        entry: {
+          date: {
+            toString: () => {
+              throw new Error('should not be coerced');
+            },
+          },
+        },
+      },
+      { name: 'a date in another format', entry: { date: '15/01/2024' } },
+      { name: 'a date with a time part', entry: { date: '2024-01-15T00:00:00' } },
+      { name: 'a month above 12', entry: { date: '2024-13-15' } },
+      { name: 'a zero month', entry: { date: '2024-00-15' } },
+      { name: 'a day above the month length', entry: { date: '2024-01-32' } },
+      { name: 'a zero day', entry: { date: '2024-01-00' } },
+      { name: 'a day that does not exist in that month', entry: { date: '2023-02-29' } },
     ].forEach(({ name, entry }) => {
       it(`should warn about and ignore ${name}`, async () => {
-        controller.setProvider(() => [entry, { year: 2024, month: 0, day: 20, disabled: true }]);
+        controller.setProvider(() => [entry, { date: '2024-01-20', disabled: true }]);
         loadMonth(2024, 0);
         await aTimeout(0);
 
@@ -643,12 +655,30 @@ describe('DateMetadataController', () => {
     });
 
     it('should accept the last day of a leap February', async () => {
-      controller.setProvider(() => [{ year: 2024, month: 1, day: 29, disabled: true }]);
+      controller.setProvider(() => [{ date: '2024-02-29', disabled: true }]);
       loadMonth(2024, 1);
       await aTimeout(0);
 
       expect(console.warn).to.not.be.called;
       expect(controller.isDateDisabled(new Date(2024, 1, 29))).to.be.true;
+    });
+
+    it('should accept a month and day without a leading zero', async () => {
+      controller.setProvider(() => [{ date: '2024-1-5', disabled: true }]);
+      loadMonth(2024, 0);
+      await aTimeout(0);
+
+      expect(console.warn).to.not.be.called;
+      expect(controller.isDateDisabled(new Date(2024, 0, 5))).to.be.true;
+    });
+
+    it('should accept a signed year', async () => {
+      controller.setProvider(() => [{ date: '-0001-01-15', disabled: true }]);
+      loadMonth(-1, 0);
+      await aTimeout(0);
+
+      expect(console.warn).to.not.be.called;
+      expect(controller.isDateDisabled(createDate(-1, 0, 15))).to.be.true;
     });
 
     it('should warn only once however many requests return invalid entries', async () => {
@@ -661,7 +691,7 @@ describe('DateMetadataController', () => {
     });
 
     it('should not warn for a well-formed result', async () => {
-      controller.setProvider(() => [{ year: 2024, month: 0, day: 15, disabled: true }]);
+      controller.setProvider(() => [{ date: '2024-01-15', disabled: true }]);
       loadMonth(2024, 0);
       await aTimeout(0);
 
@@ -672,7 +702,7 @@ describe('DateMetadataController', () => {
   describe('re-resolving a month', () => {
     it('should answer from the provider again after the cache is cleared', async () => {
       let disabledDay = 15;
-      controller.setProvider(() => [{ year: 2023, month: 2, day: disabledDay, disabled: true }]);
+      controller.setProvider(() => [{ date: `2023-03-${disabledDay}`, disabled: true }]);
       loadMonth(2023, 2);
       await aTimeout(0);
       expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.true;
@@ -691,7 +721,7 @@ describe('DateMetadataController', () => {
 
   describe('provider identity', () => {
     it('should not reset the cache when the same provider is set again', async () => {
-      const provider = stubProvider([{ year: 2023, month: 2, day: 15, disabled: true }]);
+      const provider = stubProvider([{ date: '2023-03-15', disabled: true }]);
       loadMonth(2023, 2);
       await aTimeout(0);
       provider.resetHistory();
@@ -732,8 +762,8 @@ describe('DateMetadataController', () => {
       // Everything in the pending block is skipped; only the next block is a second call.
       expect(provider).to.be.calledTwice;
       expect(provider.secondCall.args[0]).to.eql({
-        start: { year: 2024, month: 0, day: 1 },
-        end: { year: 2024, month: 11, day: 31 },
+        start: '2024-01-01',
+        end: '2024-12-31',
       });
     });
 
@@ -764,8 +794,8 @@ describe('DateMetadataController', () => {
 
         // A block ends on 31 December, so a leap year does not change where the range ends.
         expect(provider.firstCall.args[0]).to.eql({
-          start: { year, month: 0, day: 1 },
-          end: { year, month: 11, day: 31 },
+          start: `${year}-01-01`,
+          end: `${year}-12-31`,
         });
       });
     });

--- a/packages/date-picker/test/date-metadata-parts.test.js
+++ b/packages/date-picker/test/date-metadata-parts.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-date-picker.js';
-import { getDateCell, getMonthCalendar, open } from './helpers.js';
+import { getDateCell, getMonthCalendar, isoDate, open } from './helpers.js';
 
 describe('dateMetadataProvider part names', () => {
   let datePicker, overlayContent, year, month;
@@ -27,21 +27,21 @@ describe('dateMetadataProvider part names', () => {
   });
 
   it('should add a single part name to the date', async () => {
-    await openWithProvider(() => [{ year, month, day: 10, part: 'busy' }]);
+    await openWithProvider(() => [{ date: isoDate(year, month, 10), part: 'busy' }]);
 
     expect(getCell(10).part.contains('busy')).to.be.true;
     expect(getCell(11).part.contains('busy')).to.be.false;
   });
 
   it('should add several space-separated part names', async () => {
-    await openWithProvider(() => [{ year, month, day: 10, part: 'busy almost-full' }]);
+    await openWithProvider(() => [{ date: isoDate(year, month, 10), part: 'busy almost-full' }]);
 
     expect(getCell(10).part.contains('busy')).to.be.true;
     expect(getCell(10).part.contains('almost-full')).to.be.true;
   });
 
   it('should keep the built-in parts alongside the custom ones', async () => {
-    await openWithProvider(() => [{ year, month, day: 10, part: 'busy', disabled: true }]);
+    await openWithProvider(() => [{ date: isoDate(year, month, 10), part: 'busy', disabled: true }]);
 
     expect(getCell(10).part.contains('date')).to.be.true;
     expect(getCell(10).part.contains('disabled')).to.be.true;

--- a/packages/date-picker/test/date-metadata-provider.test.js
+++ b/packages/date-picker/test/date-metadata-provider.test.js
@@ -3,8 +3,8 @@ import { fixtureSync, listenOnce, nextRender, nextUpdate, tap } from '@vaadin/te
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
 import { DateMetadataController } from '../src/vaadin-date-metadata-controller.js';
-import { formatISODate } from '../src/vaadin-date-picker-helper.js';
-import { getCalendars, getDateCell, getDateCells, getMonthCalendar, open } from './helpers.js';
+import { formatISODate, monthIndex, parseDate } from '../src/vaadin-date-picker-helper.js';
+import { getCalendars, getDateCell, getDateCells, getMonthCalendar, isoDate, isoDateInMonth, open } from './helpers.js';
 
 describe('dateMetadataProvider integration', () => {
   let datePicker, overlayContent, today, year, month;
@@ -36,20 +36,18 @@ describe('dateMetadataProvider integration', () => {
     await nextRender();
   }
 
-  // A provider that disables the 15th of every month in the requested range.
-  function disableFifteenth({ start, end }) {
-    const disabled = [];
-    const first = new Date(start.year, start.month, start.day);
-    const last = new Date(end.year, end.month, end.day);
-    const days = Math.round((last - first) / (24 * 60 * 60 * 1000));
-    for (let i = 0; i <= days; i++) {
-      const date = new Date(first.getFullYear(), first.getMonth(), first.getDate() + i);
-      if (date.getDate() === 15) {
-        disabled.push({ year: date.getFullYear(), month: date.getMonth(), day: date.getDate(), disabled: true });
+  // A provider that disables the given day of every month in the requested range.
+  function disableDay(day) {
+    return ({ start, end }) => {
+      const disabled = [];
+      for (let month = monthIndex(parseDate(start)); month <= monthIndex(parseDate(end)); month++) {
+        disabled.push({ date: isoDateInMonth(month, day), disabled: true });
       }
-    }
-    return disabled;
+      return disabled;
+    };
   }
+
+  const disableFifteenth = disableDay(15);
 
   function deferredProvider() {
     let resolveProvider;
@@ -262,13 +260,14 @@ describe('dateMetadataProvider integration', () => {
   // `new Date(50, ...)` would move a two-digit year into the 1950s, which would break both the range
   // the provider is asked about and the dates the metadata is matched against.
   it('should request and disable the dates of a year below 100', async () => {
-    const provider = sinon.stub().returns([{ year: 50, month: 5, day: 15, disabled: true }]);
+    const provider = sinon.stub().returns([{ date: '0050-06-15', disabled: true }]);
     datePicker.initialPosition = '0050-06-01';
     await openWithProvider(provider);
 
     const { start, end } = provider.firstCall.args[0];
-    expect(start.year).to.be.within(49, 50);
-    expect(end.year).to.be.within(50, 51);
+    // Either block can be the one asked about; either way the year is padded, not read as 1950.
+    expect(start).to.be.oneOf(['0049-01-01', '0050-01-01']);
+    expect(end).to.be.oneOf(['0050-12-31', '0051-12-31']);
     expect(isDisabled(getVisibleCell(15, 50, 5))).to.be.true;
     expect(isDisabled(getVisibleCell(16, 50, 5))).to.be.false;
   });
@@ -394,7 +393,7 @@ describe('dateMetadataProvider integration', () => {
 
   describe('today button', () => {
     function todayMetadata() {
-      return { year, month, day: today.getDate(), disabled: true };
+      return { date: isoDate(year, month, today.getDate()), disabled: true };
     }
 
     it('should disable the today button once the provider reports today as disabled', async () => {
@@ -505,7 +504,7 @@ describe('dateMetadataProvider integration', () => {
     });
 
     it('should consult a provider set before connecting when the overlay opens', async () => {
-      const provider = sinon.stub().returns([{ year, month, day: 15, disabled: true }]);
+      const provider = sinon.stub().returns([{ date: isoDate(year, month, 15), disabled: true }]);
       element = document.createElement('vaadin-date-picker');
       element.dateMetadataProvider = provider;
       document.body.appendChild(element);
@@ -523,8 +522,7 @@ describe('dateMetadataProvider integration', () => {
       expect(isDisabled(getVisibleCell(15))).to.be.true;
 
       // Assigning a new function drops the cache, which has to be refilled for what is on screen.
-      datePicker.dateMetadataProvider = ({ start, end }) =>
-        disableFifteenth({ start, end }).map((entry) => ({ ...entry, day: 16 }));
+      datePicker.dateMetadataProvider = disableDay(16);
       await untilRendered(() => {
         const cell = getVisibleCell(16);
         return cell && isDisabled(cell);

--- a/packages/date-picker/test/date-metadata-validation.test.js
+++ b/packages/date-picker/test/date-metadata-validation.test.js
@@ -2,8 +2,8 @@ import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, enter, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
-import { monthDate, monthIndexOf } from '../src/vaadin-date-picker-helper.js';
-import { setInputValue } from './helpers.js';
+import { monthIndex, parseDate } from '../src/vaadin-date-picker-helper.js';
+import { isoDateInMonth, setInputValue } from './helpers.js';
 
 describe('dateMetadataProvider validation', () => {
   let datePicker;
@@ -12,12 +12,9 @@ describe('dateMetadataProvider validation', () => {
   // months the request happens to cover.
   function disableFifteenth() {
     return ({ start, end }) => {
-      const first = monthIndexOf(start.year, start.month);
-      const last = monthIndexOf(end.year, end.month);
       const dates = [];
-      for (let month = first; month <= last; month++) {
-        const date = monthDate(month);
-        dates.push({ year: date.getFullYear(), month: date.getMonth(), day: 15, disabled: true });
+      for (let month = monthIndex(parseDate(start)); month <= monthIndex(parseDate(end)); month++) {
+        dates.push({ date: isoDateInMonth(month, 15), disabled: true });
       }
       return dates;
     };
@@ -80,8 +77,8 @@ describe('dateMetadataProvider validation', () => {
     expect(datePicker.dateMetadataProvider).to.be.calledOnce;
     // Requests cover whole blocks, so the range is the calendar year holding the value.
     const range = datePicker.dateMetadataProvider.firstCall.args[0];
-    expect(range.start).to.eql({ year: 2024, month: 0, day: 1 });
-    expect(range.end).to.eql({ year: 2024, month: 11, day: 31 });
+    expect(range.start).to.equal('2024-01-01');
+    expect(range.end).to.equal('2024-12-31');
   });
 
   it('should request metadata again on value set after the provider settled', async () => {
@@ -222,7 +219,7 @@ describe('dateMetadataProvider validation', () => {
       const parent = datePicker.parentNode;
       parent.removeChild(datePicker);
       // Answered while detached, so the host was never told about it.
-      resolveProvider([{ year: 2024, month: 0, day: 15, disabled: true }]);
+      resolveProvider([{ date: '2024-01-15', disabled: true }]);
       await aTimeout(0);
       expect(datePicker.invalid).to.be.false;
 
@@ -237,7 +234,7 @@ describe('dateMetadataProvider validation', () => {
       await aTimeout(0);
 
       datePicker.value = '';
-      resolveProvider([{ year: 2024, month: 0, day: 15, disabled: true }]);
+      resolveProvider([{ date: '2024-01-15', disabled: true }]);
       await aTimeout(0);
 
       expect(datePicker.checkValidity()).to.be.true;

--- a/packages/date-picker/test/dom/month-calendar.test.js
+++ b/packages/date-picker/test/dom/month-calendar.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import '../../src/vaadin-month-calendar.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 import { DateMetadataController } from '../../src/vaadin-date-metadata-controller.js';
-import { getDefaultI18n } from '../helpers.js';
+import { getDefaultI18n, isoDate } from '../helpers.js';
 
 describe('vaadin-month-calendar', () => {
   let monthCalendar, clock;
@@ -89,7 +89,7 @@ describe('vaadin-month-calendar', () => {
           const dates = [];
           for (let day = 1; day <= 29; day++) {
             if (day % 2) {
-              dates.push({ year: month.getFullYear(), month: month.getMonth(), day, disabled: true });
+              dates.push({ date: isoDate(month.getFullYear(), month.getMonth(), day), disabled: true });
             }
           }
           return dates;

--- a/packages/date-picker/test/helpers.js
+++ b/packages/date-picker/test/helpers.js
@@ -1,5 +1,6 @@
 import { fire, makeSoloTouchEvent, nextRender } from '@vaadin/testing-helpers';
 import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { createDate, formatISODate, monthDate } from '../src/vaadin-date-picker-helper.js';
 
 export function activateScroller(scroller) {
   scroller.active = true;
@@ -207,6 +208,31 @@ export function getFocusedCell(root) {
   if (focusableCell && isElementFocused(focusableCell)) {
     return focusableCell;
   }
+}
+
+/**
+ * The ISO date of the given day. Formatting through the component's own helpers keeps a year below
+ * 100 or before 0 in the form it parses back.
+ *
+ * @param {number} year
+ * @param {number} month Zero-based month
+ * @param {number} day
+ * @return {string}
+ */
+export function isoDate(year, month, day) {
+  return formatISODate(createDate(year, month, day));
+}
+
+/**
+ * The ISO date of the given day of the month with the given index.
+ *
+ * @param {number} monthIndex
+ * @param {number} day
+ * @return {string}
+ */
+export function isoDateInMonth(monthIndex, day) {
+  const first = monthDate(monthIndex);
+  return isoDate(first.getFullYear(), first.getMonth(), day);
 }
 
 /**

--- a/packages/date-picker/test/typings/date-picker.types.ts
+++ b/packages/date-picker/test/typings/date-picker.types.ts
@@ -72,17 +72,15 @@ assertType<DatePickerDateMetadataProvider | null | undefined>(datePicker.dateMet
 // Assigning a provider checks that the range is inferred and that each accepted return shape fits.
 datePicker.dateMetadataProvider = (range) => {
   assertType<DatePickerDateRange>(range);
-  assertType<DatePickerDate>(range.start);
-  assertType<DatePickerDate>(range.end);
-  return [{ year: range.start.year, month: range.start.month, day: range.start.day, disabled: true }];
+  assertType<string>(range.start);
+  assertType<string>(range.end);
+  return [{ date: range.start, disabled: true }];
 };
 datePicker.dateMetadataProvider = async () => await Promise.resolve([]);
 datePicker.dateMetadataProvider = () => undefined;
 
-const dateMetadata: DatePickerDateMetadata = { year: 2024, month: 0, day: 1, disabled: true };
-assertType<number>(dateMetadata.year);
-assertType<number>(dateMetadata.month);
-assertType<number>(dateMetadata.day);
+const dateMetadata: DatePickerDateMetadata = { date: '2024-01-01', disabled: true };
+assertType<string>(dateMetadata.date);
 assertType<boolean | undefined>(dateMetadata.disabled);
 assertType<boolean | null | undefined>(datePicker.showWeekNumbers);
 assertType<boolean | null | undefined>(datePicker.autoOpenDisabled);
@@ -108,14 +106,14 @@ assertType<DatePickerI18n>({});
 assertType<DatePickerI18n>({ cancel: 'cancel' });
 
 // Date metadata
-assertType<DatePickerDateRange>({ start: { year: 2024, month: 0, day: 1 }, end: { year: 2024, month: 0, day: 31 } });
-assertType<DatePickerDateMetadata>({ year: 2024, month: 0, day: 1 });
-assertType<DatePickerDateMetadata>({ year: 2024, month: 0, day: 1, disabled: true });
-assertType<DatePickerDateMetadata>({ year: 2024, month: 0, day: 1, part: 'busy almost-full' });
+assertType<DatePickerDateRange>({ start: '2024-01-01', end: '2024-01-31' });
+assertType<DatePickerDateMetadata>({ date: '2024-01-01' });
+assertType<DatePickerDateMetadata>({ date: '2024-01-01', disabled: true });
+assertType<DatePickerDateMetadata>({ date: '2024-01-01', part: 'busy almost-full' });
 assertType<() => void>(datePicker.clearCache);
 assertType<DatePickerDateMetadataProvider>((range) => {
-  assertType<DatePickerDate>(range.start);
-  assertType<DatePickerDate>(range.end);
+  assertType<string>(range.start);
+  assertType<string>(range.end);
   return [];
 });
 assertType<DatePickerDateMetadataProvider>(async () => await Promise.resolve([]));

--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.d.ts
@@ -141,11 +141,11 @@ export declare class DateTimePickerMixinClass {
    *
    * ```js
    * [
-   *   // month is 0-based: January = 0 and December = 11.
-   *   { year: 2026, month: 0, day: 1, disabled: true },
+   *   // The date is an ISO 8601 string.
+   *   { date: '2026-01-01', disabled: true },
    *
    *   // Adds a custom part name to the date.
-   *   { year: 2026, month: 0, day: 2, part: 'busy' },
+   *   { date: '2026-01-02', part: 'busy' },
    * ]
    * ```
    *

--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
@@ -195,11 +195,11 @@ export const DateTimePickerMixin = (superClass) =>
          *
          * ```js
          * [
-         *   // month is 0-based: January = 0 and December = 11.
-         *   { year: 2026, month: 0, day: 1, disabled: true },
+         *   // The date is an ISO 8601 string.
+         *   { date: '2026-01-01', disabled: true },
          *
          *   // Adds a custom part name to the date.
-         *   { year: 2026, month: 0, day: 2, part: 'busy' },
+         *   { date: '2026-01-02', part: 'busy' },
          * ]
          * ```
          *

--- a/packages/date-time-picker/test/date-metadata.test.js
+++ b/packages/date-time-picker/test/date-metadata.test.js
@@ -8,7 +8,7 @@ describe('dateMetadataProvider', () => {
 
   // The 15th of January 2024 is disabled, whatever range the provider is asked about.
   function disableFifteenth() {
-    return [{ year: 2024, month: 0, day: 15, disabled: true }];
+    return [{ date: '2024-01-15', disabled: true }];
   }
 
   function deferredProvider() {


### PR DESCRIPTION
## Description

Fixes #12423

`dateMetadataProvider` was called with `{ year, month, day }` objects and returned entries in the same shape. That is a format used nowhere else in the API, and it carries a 0-based month while every data source a provider draws from is 1-based. The range and the entries now identify a date by an ISO 8601 string, the same format as `value`, `min` and `max`:

```js
datePicker.dateMetadataProvider = async ({ start, end }) => {
  const rows = await fetch(`/availability?from=${start}&to=${end}`).then((r) => r.json());
  return rows.map((row) => ({ date: row.day, disabled: true }));
};
```

## Why not the keyed object

The controller re-keys the answer into its own `Map` either way, so keying the input buys nothing internally. It also costs the common case: `rows.map(...)` is the natural shape for query results, `Object.fromEntries(rows.map(...))` is not, and an unnormalized key would silently never match with no entry to warn about. Duplicates are already well defined today — the last entry wins.

## Entry validation

An entry's date goes through the same parser as `value`, `min` and `max`. Parsing alone is not enough, because a month or day past its end is normalized into the next one, so `2026-02-30` would be stored as the 2nd of March under a key no lookup for the 30th can produce. The month and day are compared back to the string, matched from its end so that the year's width and sign do not matter.

## Follow-ups

- The Flow connector and `DatePicker.requestDateMetadata` must change in the same release. Both currently convert between the two shapes — `toISODate` on the way in, three `node.put` calls with a `getMonthValue() - 1` on the way out — and both conversions can go away.
- Worth landing before 25.3.0 final. The API exists only in `25.3.0-alpha9`/`alpha10`, so it is free to change now and a breaking change afterwards.

Part of #12423

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
