### PR TITLE
fix: do not parse a date string that describes no real date

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-helper.js
+++ b/packages/date-picker/src/vaadin-date-picker-helper.js
@@ -262,21 +262,38 @@ export function getAdjustedYear(referenceDate, year, month = 0, day = 1) {
 
 const ISO_DATE = /^([-+]\d{1,6}|\d{2,4})-(\d{1,2})-(\d{1,2})$/u;
 
-/**
- * Parse date string of one of the following date formats:
- * - ISO 8601 `"YYYY-MM-DD"`
- * - Extended ISO 8601 with a signed year, e.g. `"+012026-MM-DD"` or `"-0001-MM-DD"`
- * @param {!string} str Date string to parse
- * @return {Date} Parsed date in system timezone
- */
-export function parseDate(str) {
+// The parts of a date string in a format the parsers accept, as written, or `undefined` for anything
+// else. Only a string is matched, since coercing another type to one can throw.
+function parseParts(str) {
   // Parsing with RegExp to ensure correct format
-  const parts = ISO_DATE.exec(str);
+  const parts = typeof str === 'string' ? ISO_DATE.exec(str) : null;
   if (!parts) {
     return undefined;
   }
 
-  return createDate(parseInt(parts[1], 10), parseInt(parts[2], 10) - 1, parseInt(parts[3], 10));
+  return { year: parseInt(parts[1], 10), month: parseInt(parts[2], 10) - 1, day: parseInt(parts[3], 10) };
+}
+
+/**
+ * Parse date string of one of the following date formats:
+ * - ISO 8601 `"YYYY-MM-DD"`
+ * - Extended ISO 8601 with a signed year, e.g. `"+012026-MM-DD"` or `"-0001-MM-DD"`
+ *
+ * A date that does not exist, such as `"2026-02-30"`, is not parsed. Building it would carry the
+ * surplus into the next month or year and answer with a date that was never asked for.
+ *
+ * @param {!string} str Date string to parse
+ * @return {Date} Parsed date in system timezone
+ */
+export function parseDate(str) {
+  const parts = parseParts(str);
+  if (!parts) {
+    return undefined;
+  }
+
+  const date = createDate(parts.year, parts.month, parts.day);
+
+  return date.getMonth() === parts.month && date.getDate() === parts.day ? date : undefined;
 }
 
 /**
@@ -287,22 +304,23 @@ export function parseDate(str) {
  * Uses UTC date components to allow handling date instances independently of
  * the system time-zone.
  *
+ * A date that does not exist, such as `"2026-02-30"`, is not parsed, as in `parseDate`.
+ *
  * @param {!string} str Date string to parse
  * @return {Date} Parsed date in UTC timezone
  */
 export function parseUTCDate(str) {
-  // Parsing with RegExp to ensure correct format
-  const parts = ISO_DATE.exec(str);
+  const parts = parseParts(str);
   if (!parts) {
     return undefined;
   }
 
   const date = new Date(Date.UTC(0, 0)); // Wrong date (1900-01-01), but with midnight in UTC
-  date.setUTCFullYear(parseInt(parts[1], 10));
-  date.setUTCMonth(parseInt(parts[2], 10) - 1);
-  date.setUTCDate(parseInt(parts[3], 10));
+  date.setUTCFullYear(parts.year);
+  date.setUTCMonth(parts.month);
+  date.setUTCDate(parts.day);
 
-  return date;
+  return date.getUTCMonth() === parts.month && date.getUTCDate() === parts.day ? date : undefined;
 }
 
 function formatISODateBase(dateParts) {

--- a/packages/date-picker/src/vaadin-date-picker-helper.js
+++ b/packages/date-picker/src/vaadin-date-picker-helper.js
@@ -262,11 +262,10 @@ export function getAdjustedYear(referenceDate, year, month = 0, day = 1) {
 
 const ISO_DATE = /^([-+]\d{1,6}|\d{2,4})-(\d{1,2})-(\d{1,2})$/u;
 
-// The parts of a date string in a format the parsers accept, as written, or `undefined` for anything
-// else. Only a string is matched, since coercing another type to one can throw.
+// The parts of a date string in a format the parsers accept, as written.
 function parseParts(str) {
   // Parsing with RegExp to ensure correct format
-  const parts = typeof str === 'string' ? ISO_DATE.exec(str) : null;
+  const parts = ISO_DATE.exec(str);
   if (!parts) {
     return undefined;
   }

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -63,7 +63,7 @@ export const datePickerI18nDefaults = Object.freeze({
       date = parseInt(parts[1]);
       year = parseInt(parts[2]);
       if (parts[2].length < 3 && year >= 0) {
-        const usedReferenceDate = this.referenceDate ? parseDate(this.referenceDate) : new Date();
+        const usedReferenceDate = parseDate(this.referenceDate) || new Date();
         year = getAdjustedYear(usedReferenceDate, year, month, date);
       }
     } else if (parts.length === 2) {

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -37,6 +37,17 @@ describe('basic features', () => {
     expect(parseDate('+12026-01-01')).to.eql(createDate(12026, 0, 1));
   });
 
+  it('should not parse a date that does not exist', () => {
+    // Building it would carry the surplus into the next month or year.
+    expect(parseDate('2026-02-30')).to.be.undefined;
+    expect(parseDate('2023-02-29')).to.be.undefined;
+    expect(parseDate('2026-13-01')).to.be.undefined;
+    expect(parseDate('2026-00-01')).to.be.undefined;
+    expect(parseDate('2026-01-32')).to.be.undefined;
+    expect(parseDate('2026-01-00')).to.be.undefined;
+    expect(parseDate('2024-02-29')).to.eql(createDate(2024, 1, 29));
+  });
+
   it('should have default value', () => {
     expect(datePicker.value).to.equal('');
   });
@@ -168,6 +179,16 @@ describe('basic features', () => {
       datePicker.value = '-2026-03-15';
 
       expect(datePicker._selectedDate).to.eql(createDate(-2026, 2, 15));
+    });
+
+    it('should not accept a date that does not exist', () => {
+      datePicker.value = '2026-01-15';
+
+      datePicker.value = '2026-02-30';
+
+      // Reverted rather than answered with the 2nd of March.
+      expect(datePicker.value).to.equal('2026-01-15');
+      expect(datePicker._selectedDate).to.eql(createDate(2026, 0, 15));
     });
 
     it('should not accept non-ISO formats', () => {

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -38,7 +38,6 @@ describe('basic features', () => {
   });
 
   it('should not parse a date that does not exist', () => {
-    // Building it would carry the surplus into the next month or year.
     expect(parseDate('2026-02-30')).to.be.undefined;
     expect(parseDate('2023-02-29')).to.be.undefined;
     expect(parseDate('2026-13-01')).to.be.undefined;
@@ -186,7 +185,6 @@ describe('basic features', () => {
 
       datePicker.value = '2026-02-30';
 
-      // Reverted rather than answered with the 2nd of March.
       expect(datePicker.value).to.equal('2026-01-15');
       expect(datePicker._selectedDate).to.eql(createDate(2026, 0, 15));
     });

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -439,7 +439,8 @@ describe('keyboard', () => {
       await sendKeys({ type: '1/15/24' });
       await untilOverlayRendered(datePicker);
 
-      expect(focusedDate().getFullYear()).to.equal(getAdjustedYear(new Date(), 24, 0, 15));
+      const result = focusedDate();
+      expect(result.getFullYear()).to.equal(getAdjustedYear(new Date(), 24, 0, 15));
     });
 
     it('should throw when passing a year < 0', () => {

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -433,6 +433,15 @@ describe('keyboard', () => {
       expect(result.getDate()).to.equal(9);
     });
 
+    it('should parse short year against today for non-parsable reference date', async () => {
+      datePicker.i18n = { ...datePicker.i18n, referenceDate: '2026-02-30' };
+
+      await sendKeys({ type: '1/15/24' });
+      await untilOverlayRendered(datePicker);
+
+      expect(focusedDate().getFullYear()).to.equal(getAdjustedYear(new Date(), 24, 0, 15));
+    });
+
     it('should throw when passing a year < 0', () => {
       expect(() => getAdjustedYear(today, -1, 1, 1)).to.throw(Error);
     });

--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -239,6 +239,15 @@ describe('validation', () => {
       expect(datePicker.invalid).to.be.true;
     });
 
+    it('should be invalid when trying to commit a date that does not exist', async () => {
+      setInputValue(datePicker, '2/31/2022');
+      await untilOverlayRendered(datePicker);
+      enter(input);
+      await nextUpdate(datePicker);
+      expect(datePicker.value).to.equal('');
+      expect(datePicker.invalid).to.be.true;
+    });
+
     describe('autoOpenDisabled', () => {
       beforeEach(() => {
         datePicker.autoOpenDisabled = true;

--- a/packages/date-time-picker/test/basic.test.js
+++ b/packages/date-time-picker/test/basic.test.js
@@ -264,6 +264,13 @@ describe('Basic features', () => {
       expect(dateTimePicker.__selectedDateTime).to.eql(date);
     });
 
+    it('should not accept a date that does not exist', () => {
+      dateTimePicker.value = '2026-02-30T08:30';
+
+      expect(dateTimePicker.value).to.equal('');
+      expect(dateTimePicker.__selectedDateTime).to.equal('');
+    });
+
     it('should not accept non-ISO formats', () => {
       const invalidValues = [
         '03/02/01T08:30',


### PR DESCRIPTION
`parseDate` built a date from the month and day as given, and building one past the end of its month carries the surplus into the next one. So a date that does not exist was accepted as a different date. Measured on `main`:

| set | resulting `value` |
| --- | --- |
| `'2026-02-30'` | `'2026-03-02'` |
| `'2026-13-01'` | `'2027-01-01'` |
| `'2026-01-32'` | `'2026-02-01'` |
| `'2026-00-10'` | `'2025-12-10'` |
| `'2026-01-00'` | `'2025-12-31'` |

The property was rewritten to a date the application never asked for, and `value-changed` fired with it. A constraint shifted the same way: `min = '2026-02-30'` gave a minimum of 2 March, so 1 March was reported invalid.

Such a string is now not parsed. That routes it into the path an unparsable value already takes in `_valueChanged` — the previous value is kept — so it behaves like the non-ISO formats that are already rejected. Typing one reports bad input instead of jumping to another month, which is what `<input type="date">` does. `parseUTCDate` matches, so the same holds for `<vaadin-date-time-picker>`.

## Trade-off worth a look

A `min` or `max` that does not parse is not applied at all, so an impossible one now leaves the field unconstrained where it used to constrain the wrong day. Neither is good; this one is at least the same rule that already governs every other unparsable `min`. The remedy for both is the warning on an unsupported format asked for in #3942, which is not part of this change.

## Flow

Nothing to change on the Flow side:

- `value`, `min` and `max` come from `LocalDate.toString()`, and `LocalDate` cannot hold a date that does not exist, so the server can never send one.
- The connector's `i18n.parseDate` runs `date-fns` `parse` and returns parts only when `isValid` passes, so the parts it hands to the web component always describe a real date.
- `correctFullYear` calls the web component's parser on `datepicker.value`, which the component itself formatted, so it is always a real date.

One pre-existing connector bug is worth reporting separately: `formatDate` builds an unpadded `${year}-${month + 1}-${day}` and feeds it to the same parser, which does not accept a one-digit unsigned year. For a year below 10 it therefore gets `undefined` and passes it to `dateFnsFormat`. That is the same unpadded round-trip behind the years 0-9 half of #1789, and it is unaffected by this change.

Related to #3942

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
