### PR TITLE
test: improve DirMixin coverage with PolymerElement

### DIFF
--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -38,6 +38,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@polymer/polymer": "^3.0.0",
     "@vaadin/chai-plugins": "25.3.0-alpha10",
     "@vaadin/test-runner-commands": "25.3.0-alpha10",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/component-base/src/dir-mixin.js
+++ b/packages/component-base/src/dir-mixin.js
@@ -106,6 +106,10 @@ export const DirMixin = (superClass) =>
       this.__unsubscribe();
     }
 
+    // The two overrides below are only invoked by Polymer's property reflection.
+    // Vaadin components no longer extend `PolymerElement`, but some add-ons still
+    // apply this mixin to `PolymerElement`, so the overrides are kept for them.
+
     /** @protected */
     _valueToNodeAttribute(node, value, attribute) {
       // Override default Polymer attribute reflection to match native behavior of HTMLElement.dir property

--- a/packages/component-base/test/dir-mixin.test.js
+++ b/packages/component-base/test/dir-mixin.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { LitElement } from 'lit';
 import { DirMixin } from '../src/dir-mixin.js';
 import { PolylitMixin } from '../src/polylit-mixin.js';
@@ -13,213 +14,226 @@ class DirMixinLitElement extends DirMixin(PolylitMixin(LitElement)) {
 
 customElements.define(DirMixinLitElement.is, DirMixinLitElement);
 
-describe('DirMixin', () => {
-  const tag = `dir-mixin-lit-element`;
+// Some add-ons still apply the mixin to `PolymerElement`, which relies on the
+// `_valueToNodeAttribute` and `_attributeToProperty` overrides in the mixin.
+class DirMixinPolymerElement extends DirMixin(PolymerElement) {
+  static get is() {
+    return 'dir-mixin-polymer-element';
+  }
+}
 
-  describe('Native HTMLElement.dir API', () => {
-    let element;
+customElements.define(DirMixinPolymerElement.is, DirMixinPolymerElement);
 
-    beforeEach(async () => {
-      element = document.createElement(tag);
-      document.body.appendChild(element);
-      await nextRender();
+[
+  { base: 'Lit', tag: DirMixinLitElement.is },
+  { base: 'Polymer', tag: DirMixinPolymerElement.is },
+].forEach(({ base, tag }) => {
+  describe(`DirMixin (${base})`, () => {
+    describe('Native HTMLElement.dir API', () => {
+      let element;
+
+      beforeEach(async () => {
+        element = document.createElement(tag);
+        document.body.appendChild(element);
+        await nextRender();
+      });
+
+      afterEach(() => {
+        document.body.removeChild(element);
+      });
+
+      it('should match native behavior for initial values of property and attribute', () => {
+        expect(element.dir).to.equal('');
+        expect(element.hasAttribute('dir')).to.be.false;
+      });
+
+      it('should match native behavior when setting property', async () => {
+        element.dir = 'rtl';
+        await nextUpdate(element);
+        expect(element.dir).to.equal('rtl');
+        expect(element.getAttribute('dir')).to.equal('rtl');
+      });
+
+      it('should match native behavior when setting attribute', async () => {
+        element.setAttribute('dir', 'rtl');
+        await nextUpdate(element);
+        expect(element.dir).to.equal('rtl');
+        expect(element.getAttribute('dir')).to.equal('rtl');
+      });
+
+      it('should match native behavior when clearing property', async () => {
+        element.dir = 'rtl';
+        await nextUpdate(element);
+
+        element.dir = '';
+        await nextUpdate(element);
+        expect(element.dir).to.equal('');
+        expect(element.hasAttribute('dir')).to.be.false;
+      });
+
+      it('should match native behavior when clearing attribute', async () => {
+        element.setAttribute('dir', 'rtl');
+        await nextUpdate(element);
+
+        element.removeAttribute('dir');
+        await nextUpdate(element);
+        expect(element.dir).to.equal('');
+        expect(element.hasAttribute('dir')).to.be.false;
+      });
+
+      it('should not call removeAttribute twice when clearing value', async () => {
+        element.dir = 'rtl';
+        await nextUpdate(element);
+
+        const spy = sinon.spy(element, 'removeAttribute');
+        element.removeAttribute('dir');
+        await nextUpdate(element);
+        expect(spy.calledOnce).to.be.true;
+      });
     });
 
-    afterEach(() => {
-      document.body.removeChild(element);
-    });
+    describe('Document dir sync', () => {
+      const element = document.createElement(tag);
 
-    it('should match native behavior for initial values of property and attribute', () => {
-      expect(element.dir).to.equal('');
-      expect(element.hasAttribute('dir')).to.be.false;
-    });
+      before(async () => {
+        document.body.appendChild(element);
+        await nextRender();
+      });
 
-    it('should match native behavior when setting property', async () => {
-      element.dir = 'rtl';
-      await nextUpdate(element);
-      expect(element.dir).to.equal('rtl');
-      expect(element.getAttribute('dir')).to.equal('rtl');
-    });
-
-    it('should match native behavior when setting attribute', async () => {
-      element.setAttribute('dir', 'rtl');
-      await nextUpdate(element);
-      expect(element.dir).to.equal('rtl');
-      expect(element.getAttribute('dir')).to.equal('rtl');
-    });
-
-    it('should match native behavior when clearing property', async () => {
-      element.dir = 'rtl';
-      await nextUpdate(element);
-
-      element.dir = '';
-      await nextUpdate(element);
-      expect(element.dir).to.equal('');
-      expect(element.hasAttribute('dir')).to.be.false;
-    });
-
-    it('should match native behavior when clearing attribute', async () => {
-      element.setAttribute('dir', 'rtl');
-      await nextUpdate(element);
-
-      element.removeAttribute('dir');
-      await nextUpdate(element);
-      expect(element.dir).to.equal('');
-      expect(element.hasAttribute('dir')).to.be.false;
-    });
-
-    it('should not call removeAttribute twice when clearing value', async () => {
-      element.dir = 'rtl';
-      await nextUpdate(element);
-
-      const spy = sinon.spy(element, 'removeAttribute');
-      element.removeAttribute('dir');
-      await nextUpdate(element);
-      expect(spy.calledOnce).to.be.true;
-    });
-  });
-
-  describe('Document dir sync', () => {
-    const element = document.createElement(tag);
-
-    before(async () => {
-      document.body.appendChild(element);
-      await nextRender();
-    });
-
-    after(() => {
-      document.body.removeChild(element);
-      document.documentElement.removeAttribute('dir');
-    });
-
-    beforeEach(async () => {
-      // Clean up the dir attribute
-      document.documentElement.removeAttribute('dir');
-      element.removeAttribute('dir');
-      await nextUpdate(element);
-    });
-
-    // Toggle document dir attribute value
-    function setDir(direction) {
-      if (direction) {
-        document.documentElement.setAttribute('dir', direction);
-      } else {
+      after(() => {
+        document.body.removeChild(element);
         document.documentElement.removeAttribute('dir');
-      }
-    }
+      });
 
-    // Check that for each `documentDirections` value set, `element` dir
-    // attribute value equals to the corresponding `elementDirections` value.
-    async function expectDirections(documentDirections, elementDirections) {
-      for (let index = 0; index < documentDirections.length; index++) {
-        setDir(documentDirections[index]);
+      beforeEach(async () => {
+        // Clean up the dir attribute
+        document.documentElement.removeAttribute('dir');
+        element.removeAttribute('dir');
+        await nextUpdate(element);
+      });
+
+      // Toggle document dir attribute value
+      function setDir(direction) {
+        if (direction) {
+          document.documentElement.setAttribute('dir', direction);
+        } else {
+          document.documentElement.removeAttribute('dir');
+        }
+      }
+
+      // Check that for each `documentDirections` value set, `element` dir
+      // attribute value equals to the corresponding `elementDirections` value.
+      async function expectDirections(documentDirections, elementDirections) {
+        for (let index = 0; index < documentDirections.length; index++) {
+          setDir(documentDirections[index]);
+          await Promise.resolve();
+          expect(element.getAttribute('dir')).to.equal(elementDirections[index]);
+        }
+      }
+
+      it('should propagate direction as dir attribute to the element from the documentElement', async () => {
+        await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['rtl', 'ltr', null, 'rtl', null]);
+      });
+
+      it('should preserve direction if was set by the user with setAttribute', async () => {
+        element.setAttribute('dir', 'ltr');
+        await nextUpdate(element);
+
+        await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['ltr', 'ltr', 'ltr', 'ltr', 'ltr']);
+      });
+
+      it('should preserve direction if was set by the user with property', async () => {
+        element.dir = 'ltr';
+        await nextUpdate(element);
+
+        await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['ltr', 'ltr', 'ltr', 'ltr', 'ltr']);
+      });
+
+      it('should subscribe to the changes if set to equal the document direction using setAttribute', async () => {
+        element.setAttribute('dir', 'ltr');
+        await nextUpdate(element);
+
+        await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
+
+        element.setAttribute('dir', 'rtl');
+        await nextUpdate(element);
+
+        await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
+      });
+
+      it('should subscribe to the changes if set to equal the document direction using property', async () => {
+        element.dir = 'ltr';
+        await nextUpdate(element);
+
+        await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
+
+        element.dir = 'rtl';
+        await nextUpdate(element);
+
+        await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
+      });
+
+      it('should subscribe to the changes if attribute removed', async () => {
+        element.setAttribute('dir', 'ltr');
+        await nextUpdate(element);
+
+        await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
+
+        element.removeAttribute('dir');
+        await nextUpdate(element);
+
+        await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
+      });
+
+      it('should subscribe to the changes if property cleared', async () => {
+        element.dir = 'ltr';
+        await nextUpdate(element);
+
+        await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
+
+        element.dir = '';
+        await nextUpdate(element);
+
+        await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
+      });
+
+      it('should unsubscribe if attribute set by the user with setAttribute', async () => {
+        await expectDirections(['rtl', 'ltr', 'rtl'], ['rtl', 'ltr', 'rtl']);
+
+        element.setAttribute('dir', 'ltr');
+        await nextUpdate(element);
+
+        await expectDirections(['ltr', 'rtl', ''], ['ltr', 'ltr', 'ltr']);
+      });
+
+      it('should unsubscribe if attribute set by the user with property', async () => {
+        await expectDirections(['rtl', 'ltr', 'rtl'], ['rtl', 'ltr', 'rtl']);
+
+        element.dir = 'ltr';
+        await nextUpdate(element);
+
+        await expectDirections(['ltr', 'rtl', ''], ['ltr', 'ltr', 'ltr']);
+      });
+
+      it('should clean up the changes after unsubscribing', async () => {
+        // Emulating overlay behavior
+        setDir('rtl');
         await Promise.resolve();
-        expect(element.getAttribute('dir')).to.equal(elementDirections[index]);
-      }
-    }
+        document.body.appendChild(element);
 
-    it('should propagate direction as dir attribute to the element from the documentElement', async () => {
-      await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['rtl', 'ltr', null, 'rtl', null]);
-    });
+        setDir('ltr');
+        await Promise.resolve();
+        expect(element.getAttribute('dir')).to.eql('ltr');
+      });
 
-    it('should preserve direction if was set by the user with setAttribute', async () => {
-      element.setAttribute('dir', 'ltr');
-      await nextUpdate(element);
-
-      await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['ltr', 'ltr', 'ltr', 'ltr', 'ltr']);
-    });
-
-    it('should preserve direction if was set by the user with property', async () => {
-      element.dir = 'ltr';
-      await nextUpdate(element);
-
-      await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['ltr', 'ltr', 'ltr', 'ltr', 'ltr']);
-    });
-
-    it('should subscribe to the changes if set to equal the document direction using setAttribute', async () => {
-      element.setAttribute('dir', 'ltr');
-      await nextUpdate(element);
-
-      await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
-
-      element.setAttribute('dir', 'rtl');
-      await nextUpdate(element);
-
-      await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
-    });
-
-    it('should subscribe to the changes if set to equal the document direction using property', async () => {
-      element.dir = 'ltr';
-      await nextUpdate(element);
-
-      await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
-
-      element.dir = 'rtl';
-      await nextUpdate(element);
-
-      await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
-    });
-
-    it('should subscribe to the changes if attribute removed', async () => {
-      element.setAttribute('dir', 'ltr');
-      await nextUpdate(element);
-
-      await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
-
-      element.removeAttribute('dir');
-      await nextUpdate(element);
-
-      await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
-    });
-
-    it('should subscribe to the changes if property cleared', async () => {
-      element.dir = 'ltr';
-      await nextUpdate(element);
-
-      await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
-
-      element.dir = '';
-      await nextUpdate(element);
-
-      await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
-    });
-
-    it('should unsubscribe if attribute set by the user with setAttribute', async () => {
-      await expectDirections(['rtl', 'ltr', 'rtl'], ['rtl', 'ltr', 'rtl']);
-
-      element.setAttribute('dir', 'ltr');
-      await nextUpdate(element);
-
-      await expectDirections(['ltr', 'rtl', ''], ['ltr', 'ltr', 'ltr']);
-    });
-
-    it('should unsubscribe if attribute set by the user with property', async () => {
-      await expectDirections(['rtl', 'ltr', 'rtl'], ['rtl', 'ltr', 'rtl']);
-
-      element.dir = 'ltr';
-      await nextUpdate(element);
-
-      await expectDirections(['ltr', 'rtl', ''], ['ltr', 'ltr', 'ltr']);
-    });
-
-    it('should clean up the changes after unsubscribing', async () => {
-      // Emulating overlay behavior
-      setDir('rtl');
-      await Promise.resolve();
-      document.body.appendChild(element);
-
-      setDir('ltr');
-      await Promise.resolve();
-      expect(element.getAttribute('dir')).to.eql('ltr');
-    });
-
-    it('should keep custom direction when disconnecting and reconnecting', async () => {
-      element.setAttribute('dir', 'ltr');
-      setDir('rtl');
-      await Promise.resolve();
-      // Disconnect + reconnect
-      document.body.appendChild(element);
-      expect(element.getAttribute('dir')).to.eql('ltr');
+      it('should keep custom direction when disconnecting and reconnecting', async () => {
+        element.setAttribute('dir', 'ltr');
+        setDir('rtl');
+        await Promise.resolve();
+        // Disconnect + reconnect
+        document.body.appendChild(element);
+        expect(element.getAttribute('dir')).to.eql('ltr');
+      });
     });
   });
 });


### PR DESCRIPTION
The `_valueToNodeAttribute` and `_attributeToProperty` overrides in `DirMixin` are only invoked by Polymer's property reflection, so they look like dead code since the Lit migration. However, some add-ons still apply the mixin to `PolymerElement`, for example [vcf-date-range-picker](https://github.com/vaadin-component-factory/vcf-date-range-picker/blob/512c1b4d007118079c12852b6dd71d15263a0ca4/src/vcf-date-range-picker-overlay-content.js#L21), and rely on these overrides. Until now, no test covered this, so removing them did not fail anything.

This PR runs the `DirMixin` test suite against a `PolymerElement` based element in addition to the Lit one, and adds a comment explaining why the overrides are kept.
