### PR TITLE
refactor: deprecate DirMixin in favor of native :dir()

### DIFF
--- a/packages/component-base/src/dir-mixin.d.ts
+++ b/packages/component-base/src/dir-mixin.d.ts
@@ -7,9 +7,23 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin to handle `dir` attribute based on the one set on the `<html>` element.
+ *
+ * @deprecated This mixin is deprecated and will be removed in Vaadin 26,
+ * after which components will no longer set the `dir` attribute on themselves.
+ * Use the `:dir(rtl)` CSS selector to style components in right-to-left mode,
+ * and `element.matches(':dir(rtl)')` to detect it in JavaScript.
  */
 export declare function DirMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<DirMixinClass> & T;
 
+/**
+ * @deprecated This mixin is deprecated and will be removed in Vaadin 26,
+ * after which components will no longer set the `dir` attribute on themselves.
+ * Use the `:dir(rtl)` CSS selector to style components in right-to-left mode,
+ * and `element.matches(':dir(rtl)')` to detect it in JavaScript.
+ */
 export declare class DirMixinClass {
+  /**
+   * @deprecated Use `this.matches(':dir(rtl)')` instead.
+   */
   protected readonly __isRTL: boolean;
 }

--- a/packages/component-base/src/dir-mixin.js
+++ b/packages/component-base/src/dir-mixin.js
@@ -33,6 +33,11 @@ directionObserver.observe(document.documentElement, { attributes: true, attribut
 
 /**
  * A mixin to handle `dir` attribute based on the one set on the `<html>` element.
+ *
+ * @deprecated This mixin is deprecated and will be removed in Vaadin 26,
+ * after which components will no longer set the `dir` attribute on themselves.
+ * Use the `:dir(rtl)` CSS selector to style components in right-to-left mode,
+ * and `element.matches(':dir(rtl)')` to detect it in JavaScript.
  */
 export const DirMixin = (superClass) =>
   class VaadinDirMixin extends superClass {
@@ -60,6 +65,7 @@ export const DirMixin = (superClass) =>
     /**
      * @return {boolean}
      * @protected
+     * @deprecated Use `this.matches(':dir(rtl)')` instead.
      */
     get __isRTL() {
       return this.getAttribute('dir') === 'rtl';


### PR DESCRIPTION
DirMixin copies the `dir` attribute from `<html>` onto every component so that styles can use `:host([dir='rtl'])` and code can check the direction. The native CSS `:dir()` selector now covers this without any JavaScript and has been Baseline Widely Available since June 2026.

This change marks the mixin, and its `__isRTL` getter, as deprecated. In Vaadin 26, the mixin will be removed and components will no longer set the `dir` attribute on themselves. Use the `:dir(rtl)` selector in styles and `element.matches(':dir(rtl)')` in JavaScript instead.