### PR TITLE
refactor: add hasNodeContent helper for checking node content

### DIFF
--- a/packages/component-base/src/dom-utils.d.ts
+++ b/packages/component-base/src/dom-utils.d.ts
@@ -62,3 +62,10 @@ export function removeValuesFromAttribute(element: HTMLElement, attr: string, va
  * Returns true if the given node is an empty text node, false otherwise.
  */
 export function isEmptyTextNode(node: Node): boolean;
+
+/**
+ * Returns true if the given node has content of its own: an element with
+ * children, a defined custom element — which may render content in its
+ * shadow root — or a node with non-empty text.
+ */
+export function hasNodeContent(node: Node | null | undefined): boolean;

--- a/packages/component-base/src/dom-utils.js
+++ b/packages/component-base/src/dom-utils.js
@@ -168,3 +168,22 @@ export function removeValuesFromAttribute(element, attr, valuesToRemove) {
 export function isEmptyTextNode(node) {
   return node.nodeType === Node.TEXT_NODE && node.textContent.trim() === '';
 }
+
+/**
+ * Returns true if the given node has content of its own: an element with
+ * children, a defined custom element — which may render content in its
+ * shadow root — or a node with non-empty text.
+ *
+ * @param {Node | null | undefined} node
+ * @return {boolean}
+ */
+export function hasNodeContent(node) {
+  if (!node) {
+    return false;
+  }
+
+  return Boolean(
+    (node.nodeType === Node.ELEMENT_NODE && (customElements.get(node.localName) || node.children.length > 0)) ||
+    node.textContent?.trim(),
+  );
+}

--- a/packages/component-base/src/slot-child-observe-controller.js
+++ b/packages/component-base/src/slot-child-observe-controller.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2022 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { hasNodeContent } from './dom-utils.js';
 import { SlotController } from './slot-controller.js';
 
 /**
@@ -131,24 +132,6 @@ export class SlotChildObserveController extends SlotController {
   }
 
   /**
-   * Returns true if a node is an HTML element with children,
-   * or is a defined custom element, or has non-empty text.
-   *
-   * @param {Node} node
-   * @return {boolean}
-   */
-  #hasContent(node) {
-    if (!node) {
-      return false;
-    }
-
-    return (
-      (node.nodeType === Node.ELEMENT_NODE && (customElements.get(node.localName) || node.children.length > 0)) ||
-      (node.textContent && node.textContent.trim() !== '')
-    );
-  }
-
-  /**
    * Fire an event to notify the controller host about node changes.
    *
    * @param {Node} node
@@ -157,7 +140,7 @@ export class SlotChildObserveController extends SlotController {
   _notifyChange(node) {
     this.dispatchEvent(
       new CustomEvent('slot-content-changed', {
-        detail: { hasContent: this.#hasContent(node), node },
+        detail: { hasContent: hasNodeContent(node), node },
       }),
     );
   }

--- a/packages/component-base/test/dom-utils.test.js
+++ b/packages/component-base/test/dom-utils.test.js
@@ -5,6 +5,7 @@ import {
   getAncestorRootNodes,
   getClosestElement,
   getFlattenedElements,
+  hasNodeContent,
   isEmptyTextNode,
   removeValuesFromAttribute,
   setOrRemoveAttribute,
@@ -229,6 +230,53 @@ describe('dom-utils', () => {
     it('should return false when node has non-empty text content', () => {
       node.textContent = '0';
       expect(isEmptyTextNode(node)).to.be.false;
+    });
+  });
+
+  describe('hasNodeContent', () => {
+    it('should return false for a nullish node', () => {
+      expect(hasNodeContent(null)).to.be.false;
+      expect(hasNodeContent(undefined)).to.be.false;
+    });
+
+    it('should return false for an element with no children and no text', () => {
+      const element = fixtureSync('<div></div>');
+      expect(hasNodeContent(element)).to.be.false;
+    });
+
+    it('should return false for an element with whitespace text only', () => {
+      const element = fixtureSync('<div> </div>');
+      expect(hasNodeContent(element)).to.be.false;
+    });
+
+    it('should return true for an element with non-empty text', () => {
+      const element = fixtureSync('<div>content</div>');
+      expect(hasNodeContent(element)).to.be.true;
+    });
+
+    it('should return true for an element with element children', () => {
+      const element = fixtureSync('<div><span></span></div>');
+      expect(hasNodeContent(element)).to.be.true;
+    });
+
+    it('should return true for an empty defined custom element', () => {
+      // A defined custom element may render content in its shadow root.
+      const tag = defineCE(class extends HTMLElement {});
+      const element = fixtureSync(`<${tag}></${tag}>`);
+      expect(hasNodeContent(element)).to.be.true;
+    });
+
+    it('should return false for an empty undefined custom element', () => {
+      const element = fixtureSync('<x-undefined-element></x-undefined-element>');
+      expect(hasNodeContent(element)).to.be.false;
+    });
+
+    it('should return true for a text node with non-empty text', () => {
+      expect(hasNodeContent(document.createTextNode('content'))).to.be.true;
+    });
+
+    it('should return false for a text node with whitespace text only', () => {
+      expect(hasNodeContent(document.createTextNode(' '))).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Summary
- `SlotChildObserveController` decides whether a slotted node has content (an element with children, a defined custom element that may render in its shadow root, or non-empty text) with a private check that other code cannot reuse. The AI field marker in vaadin/web-components#12436 needs the same rule to judge a field's helper content, and re-implementing it there risks the two copies drifting apart, as noted in the review comment: https://github.com/vaadin/web-components/pull/12436#discussion_r3782691066
- The check is now exported as `hasNodeContent()` from component-base `dom-utils`, used by the controller and covered with unit tests, so the marker (and any future caller) can share the single definition.

Related to #12436

🤖 Generated with [Claude Code](https://claude.com/claude-code)