### PR TITLE
fix: do not apply focus index while filter is active

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-focus-index-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-focus-index-mixin.js
@@ -24,6 +24,11 @@ export const ComboBoxFocusIndexMixin = (superClass) =>
         return;
       }
 
+      // Ignore while a filter is active, keep the dropdown at the first match.
+      if (this.filter) {
+        return;
+      }
+
       // Defer until the dropdown is open and the items array has been
       // populated. `_onOpened` and `__onDataProviderPageLoaded` re-fire
       // the queued call once those conditions hold.

--- a/packages/combo-box/test/focus-index.test.js
+++ b/packages/combo-box/test/focus-index.test.js
@@ -104,6 +104,26 @@ describe('__focusIndex', () => {
       expect(viewport[0].index).to.equal(0);
     });
 
+    it('should not focus the index while a filter is active', () => {
+      comboBox.opened = true;
+      // Matches every item, so the index is in range of the filtered list
+      comboBox.filter = 'item';
+      flushComboBox(comboBox);
+
+      comboBox.__focusIndex(100);
+      flushComboBox(comboBox);
+
+      expect(comboBox._focusedIndex).to.equal(-1);
+      expect(getViewportItems(comboBox)[0].index).to.equal(0);
+    });
+
+    it('should not queue the index while a filter is active', () => {
+      comboBox.filter = 'item';
+      comboBox.__focusIndex(100);
+
+      expect(comboBox.__pendingFocusIndex).to.be.undefined;
+    });
+
     [-1, Number.NaN, '100', SIZE + 50].forEach((invalidIndex) => {
       it(`should ignore invalid index: ${String(invalidIndex)}`, () => {
         comboBox.opened = true;


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/flow-components/issues/9883
Related to https://github.com/vaadin/flow-components/pull/9891

An index resolved against the unfiltered items lands on an unrelated item once the dropdown is filtered, and closing the dropdown without an explicit selection commits it as the value.

 - `__focusIndex` returns early while `filter` is non-empty, so the dropdown stays at the first matching item
 - The guard runs before the pending-index branch, so the call is neither applied nor queued for a later open
 - `__clearPendingFocusOnFilter` stays: it cancels an already queued index at filter-change time

## Type of change

- Bugfix

## How to test

  1. In `dev/combo-box.html`, replace the `comboBox.dataProvider = ...` block with:
     ```js
     comboBox.items = [...Array(10).keys()]
       .map((i) => `Apple ${i}`)
       .concat([...Array(20).keys()].map((i) => `Banana ${i}`));
     comboBox.value = 'Banana 5';
  2. Run the server and open the dev page
  3. Focus the input with <kbd>Tab</kbd>, select all its text and type B — the overlay opens at "Banana 0".
  4. Run `document.querySelector('vaadin-combo-box').__focusIndex(15)` in the console

**Before**: Wrong item "Banana 15" is highlighted, on outside click value changes to `Banana 15`
**After**: No item is highlighted (expected), on outside click value remains the same.