### PR TITLE
refactor: set infinite scroller item height with CSS

### DIFF
--- a/packages/date-picker/src/vaadin-infinite-scroller.js
+++ b/packages/date-picker/src/vaadin-infinite-scroller.js
@@ -37,6 +37,10 @@ template.innerHTML = `
       box-sizing: border-box;
       top: var(--vaadin-infinite-scroller-buffer-offset, 0);
     }
+
+    ::slotted(div) {
+      height: var(--vaadin-infinite-scroller-item-height);
+    }
   </style>
 
   <div id="scroller" tabindex="-1">
@@ -314,7 +318,6 @@ export class InfiniteScroller extends HTMLElement {
     this._buffers.forEach((buffer) => {
       for (let i = 0; i < this.bufferSize; i++) {
         const itemWrapper = document.createElement('div');
-        itemWrapper.style.height = `${this.itemHeight}px`;
         itemWrapper.instance = {};
 
         const slotName = `vaadin-infinite-scroller-item-content-${generateUniqueId()}`;


### PR DESCRIPTION
The infinite scroller sets the height of each item wrapper as an inline style when creating the item pool. The height already comes from the `--vaadin-infinite-scroller-item-height` custom property, so the wrappers can get it directly from CSS. This removes the need to keep inline styles in sync with the property value and prepares for fixing #12321, where the property value changes after a theme switch while the inline heights stay stale.