### PR TITLE
fix: re-measure item height when date picker overlay reopens

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -268,6 +268,8 @@ export const DatePickerOverlayContentMixin = (superClass) =>
 
     reset() {
       this._closeYearScroller();
+      this._monthScroller?.reset();
+      this._yearScroller?.reset();
     }
 
     /**

--- a/packages/date-picker/src/vaadin-infinite-scroller.js
+++ b/packages/date-picker/src/vaadin-infinite-scroller.js
@@ -153,7 +153,7 @@ export class InfiniteScroller extends HTMLElement {
       this.$.scroller.scrollTop = this.itemHeight * (index - this._firstIndex) + this._buffers[0].translateY;
     } else {
       this._initialIndex = ~~index;
-      this._reset();
+      this.reset();
       this._scrollDisabled = true;
       this.$.scroller.scrollTop += (index % 1) * this.itemHeight;
       this._scrollDisabled = false;
@@ -239,7 +239,7 @@ export class InfiniteScroller extends HTMLElement {
       });
 
       if (!this._buffers[0].translateY) {
-        this._reset();
+        this.reset();
       }
 
       this._initDone = true;
@@ -266,7 +266,7 @@ export class InfiniteScroller extends HTMLElement {
     if (scrollTop < this._bufferHeight || scrollTop > this._initialScroll * 2 - this._bufferHeight) {
       // Scrolled near the end/beginning of the scrollable area -> reset.
       this._initialIndex = ~~this.position;
-      this._reset();
+      this.reset();
     }
 
     // Check if we scrolled enough to translate the buffer positions.
@@ -292,8 +292,18 @@ export class InfiniteScroller extends HTMLElement {
     });
   }
 
-  /** @private */
-  _reset() {
+  /**
+   * Resets the scroller to the last starting index, and re-measures the
+   * item height in case the computed value of the CSS custom property
+   * has changed.
+   */
+  reset() {
+    if (!this._activated || !this.isConnected) {
+      return;
+    }
+
+    this._itemHeightVal = null;
+
     this._scrollDisabled = true;
     this.$.scroller.scrollTop = this._initialScroll;
     this._buffers[0].translateY = this._initialScroll - this._bufferHeight;

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -343,4 +343,25 @@ describe('dropdown', () => {
       expect(input.inputMode).to.equal('');
     });
   });
+
+  describe('item height', () => {
+    it('should update month scroller item height when it changes between opens', async () => {
+      await open(datePicker);
+      const scroller = datePicker._overlayContent._monthScroller;
+      const initialItemHeight = scroller.itemHeight;
+
+      datePicker.close();
+      await nextRender();
+
+      // Enabling week numbers changes the item height defined in CSS
+      datePicker.showWeekNumbers = true;
+      datePicker.i18n = { ...datePicker.i18n, firstDayOfWeek: 1 };
+      await open(datePicker);
+
+      expect(scroller.itemHeight).to.be.above(initialItemHeight);
+
+      const wrapper = scroller.querySelector('div[slot]');
+      expect(wrapper.getBoundingClientRect().height).to.be.closeTo(scroller.itemHeight, 0.1);
+    });
+  });
 });

--- a/packages/date-picker/test/scroller.test.js
+++ b/packages/date-picker/test/scroller.test.js
@@ -124,6 +124,25 @@ describe('vaadin-infinite-scroller', () => {
       });
     });
   });
+
+  describe('item height change', () => {
+    beforeEach(() => {
+      scroller.style.setProperty('--vaadin-infinite-scroller-item-height', '50px');
+    });
+
+    it('should re-measure item height on reset', () => {
+      scroller.reset();
+      expect(scroller.itemHeight).to.equal(50);
+      expect(getFirstVisibleItem(scroller).clientHeight).to.equal(50);
+      expect(scroller._buffers[1].translateY - scroller._buffers[0].translateY).to.equal(50 * scroller.bufferSize);
+    });
+
+    it('should keep position mapping consistent after reset', () => {
+      scroller.reset();
+      scroller.position = 5.5;
+      verifyPosition();
+    });
+  });
 });
 
 describe('fractional item size', () => {


### PR DESCRIPTION
The date picker's infinite scroller resolves `--vaadin-infinite-scroller-item-height` to pixels once and caches the value forever. When the computed value changes while the dropdown is closed, for example after switching the theme on the fly or enabling week numbers, the next open renders months at their new height inside a layout based on the old height, and the months overlap.

The scroller's `_reset()` is now a public `reset()` that re-measures the item height, and the overlay content calls it on both scrollers on every open. `reset()` does nothing before the scroller is activated, since activation performs the initial measurement and layout, and nothing while the scroller is detached, where the custom property computes to an empty value and the resulting `NaN` would break scroll and animation callbacks that can still run after detach.

Fixes #12321