### PR TITLE
fix: delegate preventScroll focus option to focusElement

### DIFF
--- a/packages/a11y-base/src/delegate-focus-mixin.js
+++ b/packages/a11y-base/src/delegate-focus-mixin.js
@@ -79,7 +79,8 @@ const DelegateFocusMixinImplementation = (superclass) => {
      */
     focus(options) {
       if (this.focusElement && !this.disabled) {
-        this.focusElement.focus();
+        // Only forward the native option, `focusVisible` is handled below.
+        this.focusElement.focus({ preventScroll: !!options?.preventScroll });
 
         // Set focus-ring attribute on programmatic focus by default
         // unless explicitly disabled by `{ focusVisible: false }`.

--- a/packages/a11y-base/test/delegate-focus-mixin.test.js
+++ b/packages/a11y-base/test/delegate-focus-mixin.test.js
@@ -56,6 +56,18 @@ describe('DelegateFocusMixin', () => {
       expect(element.hasAttribute('focused')).to.be.true;
     });
 
+    it('should forward preventScroll option to the input on focus call', () => {
+      const spy = sinon.spy(input, 'focus');
+      element.focus({ preventScroll: true });
+      expect(spy.firstCall.args[0]).to.deep.include({ preventScroll: true });
+    });
+
+    it('should not prevent scroll on the input on focus call by default', () => {
+      const spy = sinon.spy(input, 'focus');
+      element.focus();
+      expect(spy.firstCall.args[0]).to.deep.include({ preventScroll: false });
+    });
+
     it('should blur the input on blur call', () => {
       const spy = sinon.spy(input, 'blur');
       element.focus();


### PR DESCRIPTION
## Description

While we added support for `FocusOptions` in https://github.com/vaadin/web-components/pull/10049, the `preventScroll` option was not delegated. So e.g. calling `textArea.focus({ preventScroll: true })` currently doesn't prevent scroll. This PR fixes that.

## Type of change

- Bugfix