### PR TITLE
feat: add defaultTime property to date-time-picker

### DIFF
--- a/dev/playground/date-time-picker.html
+++ b/dev/playground/date-time-picker.html
@@ -76,5 +76,10 @@
       <h2 class="heading">Date metadata provider</h2>
       <vaadin-date-time-picker id="metadata" label="Weekends disabled"></vaadin-date-time-picker>
     </section>
+
+    <section class="section">
+      <h2 class="heading">Default time</h2>
+      <vaadin-date-time-picker label="Appointment" default-time="09:00"></vaadin-date-time-picker>
+    </section>
   </body>
 </html>

--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.d.ts
@@ -120,6 +120,25 @@ export declare class DateTimePickerMixinClass {
   initialPosition: string | null | undefined;
 
   /**
+   * The time part to set automatically when the user commits a date while
+   * the time picker is empty. Supported time formats are in ISO 8601:
+   *
+   * - `hh:mm` (default)
+   * - `hh:mm:ss`
+   * - `hh:mm:ss.fff`
+   *
+   * The time part is set when a date is committed while the time picker
+   * is empty — never for programmatic or initial values. A value outside
+   * `min` / `max` is applied as-is and makes the field invalid.
+   *
+   * When not set, selecting a date leaves the time part empty. A string
+   * that is not a valid ISO 8601 time is ignored and logs a warning.
+   *
+   * @attr {string} default-time
+   */
+  defaultTime: string | null | undefined;
+
+  /**
    * Set true to display ISO-8601 week numbers in the calendar. Notice that
    * displaying week numbers is only supported when `i18n.firstDayOfWeek`
    * is 1 (Monday).

--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.d.ts
@@ -121,11 +121,11 @@ export declare class DateTimePickerMixinClass {
 
   /**
    * The time part to set automatically when the user commits a date while
-   * the time picker is empty. Supported time formats are in ISO 8601:
+   * the time picker is empty.
    *
-   * - `hh:mm` (default)
-   * - `hh:mm:ss`
-   * - `hh:mm:ss.fff`
+   * Supports same time formats as the `value` property, without the date
+   * part. Precision exceeding the one defined by `step` is discarded,
+   * e.g. `09:30:45` is applied as `09:30` with the default `step`.
    *
    * The time part is set when a date is committed while the time picker
    * is empty — never for programmatic or initial values. A value outside

--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
@@ -9,6 +9,7 @@ import { setOrRemoveAttribute } from '@vaadin/component-base/src/dom-utils.js';
 import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
+import { issueWarning } from '@vaadin/component-base/src/warnings.js';
 import {
   dateEquals,
   formatUTCISODate,
@@ -905,7 +906,7 @@ export const DateTimePickerMixin = (superClass) =>
 
       const timeObj = parseISOTime(this.defaultTime);
       if (!timeObj) {
-        console.warn(
+        issueWarning(
           `<vaadin-date-time-picker> Ignored "defaultTime" that is not a valid ISO 8601 time: ${this.defaultTime}`,
         );
         return '';

--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
@@ -171,11 +171,11 @@ export const DateTimePickerMixin = (superClass) =>
 
         /**
          * The time part to set automatically when the user commits a date while
-         * the time picker is empty. Supported time formats are in ISO 8601:
+         * the time picker is empty.
          *
-         * - `hh:mm` (default)
-         * - `hh:mm:ss`
-         * - `hh:mm:ss.fff`
+         * Supports same time formats as the `value` property, without the date
+         * part. Precision exceeding the one defined by `step` is discarded,
+         * e.g. `09:30:45` is applied as `09:30` with the default `step`.
          *
          * The time part is set when a date is committed while the time picker
          * is empty — never for programmatic or initial values. A value outside

--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
@@ -170,6 +170,28 @@ export const DateTimePickerMixin = (superClass) =>
         },
 
         /**
+         * The time part to set automatically when the user commits a date while
+         * the time picker is empty. Supported time formats are in ISO 8601:
+         *
+         * - `hh:mm` (default)
+         * - `hh:mm:ss`
+         * - `hh:mm:ss.fff`
+         *
+         * The time part is set when a date is committed while the time picker
+         * is empty — never for programmatic or initial values. A value outside
+         * `min` / `max` is applied as-is and makes the field invalid.
+         *
+         * When not set, selecting a date leaves the time part empty. A string
+         * that is not a valid ISO 8601 time is ignored and logs a warning.
+         *
+         * @attr {string} default-time
+         */
+        defaultTime: {
+          type: String,
+          sync: true,
+        },
+
+        /**
          * Set true to display ISO-8601 week numbers in the calendar. Notice that
          * displaying week numbers is only supported when `i18n.firstDayOfWeek`
          * is 1 (Monday).
@@ -526,6 +548,17 @@ export const DateTimePickerMixin = (superClass) =>
     __changeEventHandler(event) {
       event.stopPropagation();
 
+      if (
+        event.target === this.__datePicker &&
+        this.__datePicker.value &&
+        !(this.__timePicker.value || this.__timePicker.__unparsableValue)
+      ) {
+        const defaultTime = this.__normalizeDefaultTime();
+        if (defaultTime) {
+          this.__timePicker.value = defaultTime;
+        }
+      }
+
       const isAlreadyInvalid = this.invalid;
       const filledPickers = this.__filledPickers;
       if (filledPickers.length === 1 && filledPickers[0].checkValidity() && !isAlreadyInvalid) {
@@ -836,23 +869,49 @@ export const DateTimePickerMixin = (superClass) =>
     }
 
     /**
+     * Time object to string (ISO time)
+     * @param {object} timeObj
+     * @return {string} e.g. 'hh:mm', 'hh:mm:ss', 'hh:mm:ss.fff' (depending on precision defined by "step" property)
+     * @private
+     */
+    __formatTimeISO(timeObj) {
+      return formatISOTime(validateTime(timeObj, this.step));
+    }
+
+    /**
      * Date object to string (ISO time)
      * @param {Date} date
      * @return {string} e.g. 'hh:mm', 'hh:mm:ss', 'hh:mm:ss.fff' (depending on precision defined by "step" property)
      * @private
      */
     __dateToIsoTimeString(date) {
-      return formatISOTime(
-        validateTime(
-          {
-            hours: date.getUTCHours(),
-            minutes: date.getUTCMinutes(),
-            seconds: date.getUTCSeconds(),
-            milliseconds: date.getUTCMilliseconds(),
-          },
-          this.step,
-        ),
-      );
+      return this.__formatTimeISO({
+        hours: date.getUTCHours(),
+        minutes: date.getUTCMinutes(),
+        seconds: date.getUTCSeconds(),
+        milliseconds: date.getUTCMilliseconds(),
+      });
+    }
+
+    /**
+     * `defaultTime` to string (ISO time), or an empty string when unset or unparsable.
+     * @return {string}
+     * @private
+     */
+    __normalizeDefaultTime() {
+      if (!this.defaultTime) {
+        return '';
+      }
+
+      const timeObj = parseISOTime(this.defaultTime);
+      if (!timeObj) {
+        console.warn(
+          `<vaadin-date-time-picker> Ignored "defaultTime" that is not a valid ISO 8601 time: ${this.defaultTime}`,
+        );
+        return '';
+      }
+
+      return this.__formatTimeISO(timeObj);
     }
 
     /**

--- a/packages/date-time-picker/test/typings/date-time-picker.types.ts
+++ b/packages/date-time-picker/test/typings/date-time-picker.types.ts
@@ -66,6 +66,7 @@ assertType<string | null | undefined>(picker.label);
 assertType<string | null | undefined>(picker.datePlaceholder);
 assertType<string | null | undefined>(picker.timePlaceholder);
 assertType<string | null | undefined>(picker.initialPosition);
+assertType<string | null | undefined>(picker.defaultTime);
 assertType<number | null | undefined>(picker.step);
 assertType<boolean | null | undefined>(picker.showWeekNumbers);
 assertType<boolean | null | undefined>(picker.autoOpenDisabled);

--- a/packages/date-time-picker/test/validation.test.js
+++ b/packages/date-time-picker/test/validation.test.js
@@ -2,6 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-date-time-picker.js';
+import { changeInputValue } from './helpers.js';
 
 class DateTimePicker2020Element extends customElements.get('vaadin-date-time-picker') {
   checkValidity() {
@@ -245,5 +246,35 @@ describe('custom validator', () => {
     dateTimePicker.value = '2020-02-02T20:20';
     expect(dateTimePicker.validate()).to.equal(true);
     expect(dateTimePicker.invalid).to.equal(false);
+  });
+});
+
+describe('defaultTime', () => {
+  let dateTimePicker, datePicker, timePicker;
+
+  beforeEach(async () => {
+    dateTimePicker = fixtureSync('<vaadin-date-time-picker default-time="09:30"></vaadin-date-time-picker>');
+    await nextRender();
+    datePicker = dateTimePicker.querySelector('[slot=date-picker]');
+    timePicker = dateTimePicker.querySelector('[slot=time-picker]');
+  });
+
+  it('should be valid when the default time is applied', () => {
+    dateTimePicker.required = true;
+    changeInputValue(datePicker, '2001-01-01');
+
+    expect(dateTimePicker.value).to.equal('2001-01-01T09:30');
+    expect(dateTimePicker.validate()).to.be.true;
+    expect(dateTimePicker.invalid).to.be.false;
+  });
+
+  it('should be invalid when the default time is outside min/max', () => {
+    dateTimePicker.min = '2001-01-01T10:00';
+    dateTimePicker.max = '2001-01-01T20:00';
+    changeInputValue(datePicker, '2001-01-01');
+
+    expect(timePicker.value).to.equal('09:30');
+    expect(dateTimePicker.validate()).to.be.false;
+    expect(dateTimePicker.invalid).to.be.true;
   });
 });

--- a/packages/date-time-picker/test/value-commit.test.js
+++ b/packages/date-time-picker/test/value-commit.test.js
@@ -3,6 +3,7 @@ import { sendKeys, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-date-time-picker.js';
+import { clearWarnings } from '@vaadin/component-base/src/warnings.js';
 import { changeInputValue } from './helpers.js';
 
 function describeForEachPicker(title, fn) {
@@ -523,6 +524,7 @@ describe('value commit', () => {
 
       afterEach(() => {
         console.warn.restore();
+        clearWarnings();
       });
 
       it('should warn and not fill the time picker on date-picker Enter', async () => {

--- a/packages/date-time-picker/test/value-commit.test.js
+++ b/packages/date-time-picker/test/value-commit.test.js
@@ -419,4 +419,121 @@ describe('value commit', () => {
       expect(changeSpy).to.be.not.called;
     });
   });
+
+  describe('defaultTime', () => {
+    beforeEach(() => {
+      dateTimePicker.defaultTime = '09:30';
+    });
+
+    it('should fill the time picker and commit on date-picker Enter', async () => {
+      await enterInput(datePicker, '1/1/2001');
+      await sendKeys({ press: 'Enter' });
+      await expectValueCommit();
+      expect(timePicker.value).to.equal('09:30');
+      expect(dateTimePicker.value).to.equal('2001-01-01T09:30');
+    });
+
+    it('should fill the time picker before dispatching change', async () => {
+      let valueOnChange;
+      dateTimePicker.addEventListener('change', () => {
+        valueOnChange = dateTimePicker.value;
+      });
+
+      await enterInput(datePicker, '1/1/2001');
+      await sendKeys({ press: 'Enter' });
+      await nextRender();
+
+      expect(valueOnChange).to.equal('2001-01-01T09:30');
+    });
+
+    it('should commit on date-picker outside click while time-picker is empty', async () => {
+      await enterInput(datePicker, '1/1/2001');
+      outsideClick();
+      await expectValueCommit();
+      expect(dateTimePicker.value).to.equal('2001-01-01T09:30');
+    });
+
+    it('should fill the time picker on date-picker Tab when auto-open is disabled', async () => {
+      dateTimePicker.autoOpenDisabled = true;
+      await enterInput(datePicker, '1/1/2001');
+      await sendKeys({ press: 'Tab' });
+      await expectValueCommit();
+      expect(timePicker.value).to.equal('09:30');
+    });
+
+    it('should re-insert the default time on committing another date after the time picker is cleared', async () => {
+      await enterInput(datePicker, '1/1/2001');
+      await sendKeys({ press: 'Enter' });
+      await expectValueCommit();
+      await clearInput(timePicker);
+      await sendKeys({ press: 'Enter' });
+      resetSpyHistories();
+
+      await enterInput(datePicker, '1/2/2001');
+      await sendKeys({ press: 'Enter' });
+      await expectValueCommit();
+      expect(dateTimePicker.value).to.equal('2001-01-02T09:30');
+    });
+
+    it('should not overwrite the time picker value on date-picker Enter', async () => {
+      timePicker.value = '10:00';
+      await enterInput(datePicker, '1/1/2001');
+      await sendKeys({ press: 'Enter' });
+      await expectValueCommit();
+      expect(timePicker.value).to.equal('10:00');
+      expect(dateTimePicker.value).to.equal('2001-01-01T10:00');
+    });
+
+    it('should not overwrite unparsable time-picker input on date-picker Enter', async () => {
+      await enterUnparsableInput(timePicker);
+      await enterInput(datePicker, '1/1/2001');
+      await sendKeys({ press: 'Enter' });
+      await nextRender();
+      expect(timePicker.value).to.equal('');
+      expect(dateTimePicker.value).to.equal('');
+      expect(changeSpy).to.be.not.called;
+    });
+
+    it('should not fill the time picker on programmatic date-picker value change', async () => {
+      datePicker.value = '2001-01-01';
+      await expectNoValueCommit();
+      expect(timePicker.value).to.equal('');
+    });
+
+    it('should apply the default time with the precision defined by step', async () => {
+      dateTimePicker.step = 1;
+      await enterInput(datePicker, '1/1/2001');
+      await sendKeys({ press: 'Enter' });
+      await expectValueCommit();
+      expect(timePicker.value).to.equal('09:30:00');
+    });
+
+    it('should truncate the default time exceeding the precision defined by step', async () => {
+      dateTimePicker.defaultTime = '09:30:45';
+      await enterInput(datePicker, '1/1/2001');
+      await sendKeys({ press: 'Enter' });
+      await expectValueCommit();
+      expect(timePicker.value).to.equal('09:30');
+    });
+
+    describe('unparsable defaultTime', () => {
+      beforeEach(() => {
+        sinon.stub(console, 'warn');
+      });
+
+      afterEach(() => {
+        console.warn.restore();
+      });
+
+      it('should warn and not fill the time picker on date-picker Enter', async () => {
+        dateTimePicker.defaultTime = '25:99';
+        await enterInput(datePicker, '1/1/2001');
+        await sendKeys({ press: 'Enter' });
+        await expectNoValueCommit();
+        expect(timePicker.value).to.equal('');
+        expect(console.warn).to.be.calledOnce;
+        expect(console.warn.firstCall.args[0]).to.include('defaultTime');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Description

Part of #668

Based on the prototype in https://github.com/vaadin/web-components/issues/668#issuecomment-5341211727

- Added a `defaultTime` property that fills the time part when the user commits a date while the time picker is empty.
- The applied time follows the precision defined by `step`, a more precise value is truncated.
- An already filled or unparsable time part is never overwritten.
- The time part is only filled on a committed date, not for programmatic or initial values.
- A value outside `min` / `max` is applied as-is and makes the field invalid.
- An invalid `defaultTime` is ignored and logs a warning.
- Extracted `__formatTimeISO()` shared by the new normalization and `__dateToIsoTimeString()`.

## Type of change

- Feature

## How to test

1. Run `yarn start` and open `/dev/playground/date-time-picker.html`, then scroll to the **Default time** section.
2. Pick a date in the *Appointment* field — the time field fills with `09:00` and the field gets a complete value.
3. Enter a time first, then change the date — the entered time is kept.
4. Clear the time, then pick a different date — the default is applied again.
5. Set `step` to `1` in the console and pick a date — the applied time becomes `09:00:00`.
6. Set `default-time="foo"` in the console and pick a date — the time stays empty and a warning is logged.
