### PR TITLE
refactor: replace tag name checks with instanceof class checks

### DIFF
--- a/packages/accordion/src/vaadin-accordion-mixin.js
+++ b/packages/accordion/src/vaadin-accordion-mixin.js
@@ -6,6 +6,7 @@
 import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import { KeyboardDirectionMixin } from '@vaadin/a11y-base/src/keyboard-direction-mixin.js';
 import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
+import { AccordionPanel } from './vaadin-accordion-panel.js';
 
 /**
  * A mixin providing common accordion functionality.
@@ -130,7 +131,7 @@ export const AccordionMixin = (superClass) =>
      * @protected
      */
     _filterItems(array) {
-      return array.filter((el) => el instanceof customElements.get('vaadin-accordion-panel'));
+      return array.filter((el) => el instanceof AccordionPanel);
     }
 
     /** @private */

--- a/packages/checkbox-group/src/vaadin-checkbox-group-mixin.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group-mixin.js
@@ -5,6 +5,7 @@
  */
 import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
+import { Checkbox } from '@vaadin/checkbox/src/vaadin-checkbox.js';
 import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
@@ -119,7 +120,7 @@ export const CheckboxGroupMixin = (superclass) =>
      * @private
      */
     __filterCheckboxes(nodes) {
-      return nodes.filter((node) => node.nodeType === Node.ELEMENT_NODE && node.localName === 'vaadin-checkbox');
+      return nodes.filter((node) => node instanceof Checkbox);
     }
 
     /**

--- a/packages/radio-group/src/vaadin-radio-group-mixin.js
+++ b/packages/radio-group/src/vaadin-radio-group-mixin.js
@@ -11,6 +11,7 @@ import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
+import { RadioButton } from './vaadin-radio-button.js';
 
 /**
  * A mixin providing common radio-group functionality.
@@ -153,7 +154,7 @@ export const RadioGroupMixin = (superclass) =>
      * @private
      */
     __filterRadioButtons(nodes) {
-      return nodes.filter((node) => node.nodeType === Node.ELEMENT_NODE && node.localName === 'vaadin-radio-button');
+      return nodes.filter((node) => node instanceof RadioButton);
     }
 
     /**
@@ -168,9 +169,7 @@ export const RadioGroupMixin = (superclass) =>
     _onKeyDown(event) {
       super._onKeyDown(event);
 
-      const radioButton = event
-        .composedPath()
-        .find((node) => node.nodeType === Node.ELEMENT_NODE && node.localName === 'vaadin-radio-button');
+      const radioButton = event.composedPath().find((node) => node instanceof RadioButton);
 
       if (['ArrowLeft', 'ArrowUp'].includes(event.key)) {
         event.preventDefault();


### PR DESCRIPTION
## Description

Replaced hardcoded tag names with `instanceof` checks. Tag names were used for reusing mixins in Polymer and Lit based versions in V24. Using classes also allows extending components with custom tag names e.g. `custom-checkbox`.

## Type of change

- Refactor