### PR TITLE
refactor: remove unused _scrollTop accessors from grid scroll mixin

### DIFF
--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -89,19 +89,6 @@ export const ScrollMixin = (superClass) =>
       return this.$.table.scrollLeft;
     }
 
-    /** @private */
-    get _scrollTop() {
-      return this.$.table.scrollTop;
-    }
-
-    /**
-     * Override (from iron-scroll-target-behavior) to avoid document scroll
-     * @private
-     */
-    set _scrollTop(top) {
-      this.$.table.scrollTop = top;
-    }
-
     /** @protected */
     get _lazyColumns() {
       return this.columnRendering === 'lazy';


### PR DESCRIPTION
## Description

The `_scrollTop` getter and setter in the grid scroll mixin have no callers left. The setter was an override for Polymer's `iron-scroll-target-behavior`, which is long gone, and the last consumer was the Firefox scroll restore workaround removed in #10304. Nothing in this repo or in the Flow connector references them anymore.

## Type of change

- Refactor
