### PR TITLE
refactor: remove template renderer marker properties from grid

### DIFF
--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -245,17 +245,6 @@ export const ColumnBaseMixin = (superClass) =>
           type: Function,
           computed: '_computeFooterRenderer(footerRenderer, __initialized)',
         },
-
-        /**
-         * An internal property that is mainly used by `vaadin-template-renderer`
-         * to identify grid column elements.
-         *
-         * @private
-         */
-        __gridColumnElement: {
-          type: Boolean,
-          value: true,
-        },
       };
     }
 

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -124,17 +124,6 @@ export const GridMixin = (superClass) =>
           value: false,
         },
 
-        /**
-         * An internal property that is mainly used by `vaadin-template-renderer`
-         * to identify grid elements.
-         *
-         * @private
-         */
-        __gridElement: {
-          type: Boolean,
-          value: true,
-        },
-
         /** @private */
         __hasEmptyStateContent: {
           type: Boolean,


### PR DESCRIPTION
## Description

Removed the `__gridElement` and `__gridColumnElement` properties. They existed only so that `vaadin-template-renderer` could identify grid and grid column elements, but that package was moved to legacy-adapter in #2798 and deleted together with the `vaadin`-prefixed packages in #4844. Nothing in this repo or in flow-components reads these properties anymore.

## Type of change

- Refactor