### PR TITLE
refactor: remove obsolete rAF deferral for grid scrolling attribute

### DIFF
--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -226,13 +226,8 @@ export const ScrollMixin = (superClass) =>
 
     /** @private */
     _scheduleScrolling() {
-      if (!this._scrollingFrame) {
-        // Defer setting state attributes to avoid Edge hiccups
-        this._scrollingFrame = requestAnimationFrame(() => this.$.scroller.toggleAttribute('scrolling', true));
-      }
+      this.$.scroller.toggleAttribute('scrolling', true);
       this._debounceScrolling = Debouncer.debounce(this._debounceScrolling, timeOut.after(timeouts.SCROLLING), () => {
-        cancelAnimationFrame(this._scrollingFrame);
-        delete this._scrollingFrame;
         this.$.scroller.toggleAttribute('scrolling', false);
       });
     }

--- a/packages/grid/test/scrolling-mode.test.js
+++ b/packages/grid/test/scrolling-mode.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, listenOnce, nextFrame, nextRender, nextResize } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender, nextResize } from '@vaadin/testing-helpers';
 import './grid-test-styles.js';
 import '../src/vaadin-grid.js';
 import { flushGrid, infiniteDataProvider, scrollToEnd } from './helpers.js';
@@ -35,16 +35,12 @@ describe('scrolling mode', () => {
     expect(grid.scrollHeight - grid.clientHeight).to.equal(0);
   });
 
-  it('should defer adding scrolling state attributes', (done) => {
+  it('should toggle scrolling state attribute on scroll', () => {
     const scroller = grid.$.scroller;
-    listenOnce(grid.$.table, 'scroll', () => {
-      expect(scroller.hasAttribute('scrolling')).to.be.false;
-      requestAnimationFrame(() => {
-        expect(scroller.hasAttribute('scrolling')).to.be.true;
-        done();
-      });
-    });
     grid.$.table.dispatchEvent(new CustomEvent('scroll'));
+    expect(scroller.hasAttribute('scrolling')).to.be.true;
+    grid._debounceScrolling.flush();
+    expect(scroller.hasAttribute('scrolling')).to.be.false;
   });
 
   describe('overflow attribute', () => {


### PR DESCRIPTION
## Description

The `requestAnimationFrame` deferral in `_scheduleScrolling` was added in 2018 to work around scroll jank in the legacy EdgeHTML browser. The original reason is gone: no styles select on `[scrolling]` anymore, and the attribute is only read by the tooltip logic that skips showing tooltips while scrolling. Setting the attribute synchronously also removes the need for the `cancelAnimationFrame` cleanup, which existed because a scroll in a hidden tab could leave a stale rAF that set the attribute back after the debouncer had already removed it.

- Set the `scrolling` attribute on the scroller synchronously on scroll instead of deferring it with `requestAnimationFrame`
- Updated the scrolling-mode test to expect the attribute to be set synchronously and removed after the debounce

## Type of change

- Refactor

## How to test

1. Open `dev/grid.html`
2. In browser devtools, find the `#scroller` element inside the grid's shadow DOM
3. Scroll the grid body
4. The `scrolling` attribute should appear on the scroller while scrolling and disappear about half a second after scrolling stops