### PR TITLE
refactor: remove redundant _frozenCellsChanged call in grid

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -576,7 +576,6 @@ export const GridMixin = (superClass) =>
       this.__initRow(this.$.sizer, columnTree[columnTree.length - 1]);
 
       this._resizeHandler();
-      this._frozenCellsChanged();
       this._resetKeyboardNavigation();
       this.__a11yUpdateHeaderRows();
       this.__a11yUpdateFooterRows();


### PR DESCRIPTION
## Description

The explicit `_frozenCellsChanged()` call in `_renderColumnTree` is a no-op. The method only schedules two microtask debouncers, and `__initRow` already ends with an unconditional `_frozenCellsChanged()` call, so the loop over body rows and the sizer row init two statements earlier have already scheduled them. The only statement in between, `_resizeHandler()`, cannot flush the debouncers, so the extra call just cancels and re-enqueues the same pending microtasks.

## Type of change

- Refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)