### PR TITLE
fix: avoid NaN aria-rowindex on footer rows without data

### DIFF
--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -76,8 +76,13 @@ export const A11yMixin = (superClass) =>
 
     /** @private */
     __a11yUpdateFooterRows() {
+      // The size is undefined until a data provider or items are assigned
+      const bodyRowCount = this.size || 0;
       iterateChildren(this.$.footer, (footerRow, index) => {
-        footerRow.setAttribute('aria-rowindex', this.__a11yGetHeaderRowCount(this._columnTree) + this.size + index + 1);
+        footerRow.setAttribute(
+          'aria-rowindex',
+          this.__a11yGetHeaderRowCount(this._columnTree) + bodyRowCount + index + 1,
+        );
       });
     }
 

--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -20,7 +20,7 @@ export const A11yMixin = (superClass) =>
       };
     }
     static get observers() {
-      return ['__a11yUpdateGridSize(size, _columnTree, __emptyState)', '__a11yI18nChanged(__effectiveI18n)'];
+      return ['__a11yUpdateGridSize(_flatSize, _columnTree, __emptyState)', '__a11yI18nChanged(__effectiveI18n)'];
     }
 
     /** @private */
@@ -44,14 +44,14 @@ export const A11yMixin = (superClass) =>
     }
 
     /** @private */
-    __a11yUpdateGridSize(size, _columnTree, emptyState) {
-      if (size === undefined || _columnTree === undefined) {
+    __a11yUpdateGridSize(flatSize, _columnTree, emptyState) {
+      if (flatSize === undefined || _columnTree === undefined) {
         return;
       }
 
       const headerRowsCount = this.__a11yGetHeaderRowCount(_columnTree);
       const footerRowsCount = this.__a11yGetFooterRowCount(_columnTree);
-      const bodyRowsCount = emptyState ? 1 : size;
+      const bodyRowsCount = emptyState ? 1 : flatSize;
       const rowsCount = bodyRowsCount + headerRowsCount + footerRowsCount;
 
       this.$.table.setAttribute('aria-rowcount', rowsCount);
@@ -76,8 +76,7 @@ export const A11yMixin = (superClass) =>
 
     /** @private */
     __a11yUpdateFooterRows() {
-      // The size is undefined until a data provider or items are assigned
-      const bodyRowCount = this.size || 0;
+      const bodyRowCount = this._flatSize || 0;
       iterateChildren(this.$.footer, (footerRow, index) => {
         footerRow.setAttribute(
           'aria-rowindex',

--- a/packages/grid/src/vaadin-grid-header-footer-rendering-mixin.js
+++ b/packages/grid/src/vaadin-grid-header-footer-rendering-mixin.js
@@ -90,7 +90,7 @@ export const HeaderFooterRenderingMixin = (superClass) =>
       this.#renderFooter(sortedColumnTree);
 
       this._resetKeyboardNavigation();
-      this.__a11yUpdateGridSize(this.size, this._columnTree, this.__emptyState);
+      this.__a11yUpdateGridSize(this._flatSize, this._columnTree, this.__emptyState);
     }
 
     #renderHeader(columnTree) {

--- a/packages/grid/test/accessibility.test.js
+++ b/packages/grid/test/accessibility.test.js
@@ -385,6 +385,17 @@ describe('accessibility', () => {
       // Header row + zero body rows -> the footer row is the second row
       expect(grid.$.footer.children[0].getAttribute('aria-rowindex')).to.equal('2');
     });
+
+    it('should have aria-rowindex on footer rows with a lazy data provider', () => {
+      // The size is only provided through the data provider callback
+      grid.dataProvider = (_params, callback) => {
+        callback([{ name: 'foo' }, { name: 'bar' }], 2);
+      };
+      flushGrid(grid);
+
+      // Header row + two body rows -> the footer row is the fourth row
+      expect(grid.$.footer.children[0].getAttribute('aria-rowindex')).to.equal('4');
+    });
   });
 
   describe('path and header', () => {

--- a/packages/grid/test/accessibility.test.js
+++ b/packages/grid/test/accessibility.test.js
@@ -368,6 +368,25 @@ describe('accessibility', () => {
     });
   });
 
+  describe('columns without data', () => {
+    beforeEach(() => {
+      grid = fixtureSync('<vaadin-grid></vaadin-grid>');
+      const column = document.createElement('vaadin-grid-column');
+      column.header = 'Header';
+      column.footerRenderer = (root) => {
+        root.textContent = 'footer';
+      };
+      grid.appendChild(column);
+      flushGrid(grid);
+    });
+
+    it('should have aria-rowindex on header and footer rows before data is set', () => {
+      expect(grid.$.header.children[0].getAttribute('aria-rowindex')).to.equal('1');
+      // Header row + zero body rows -> the footer row is the second row
+      expect(grid.$.footer.children[0].getAttribute('aria-rowindex')).to.equal('2');
+    });
+  });
+
   describe('path and header', () => {
     let col;
 


### PR DESCRIPTION
## Description

The footer row `aria-rowindex` was computed from the grid `size`, which is undefined until data is assigned — so a grid with footer renderers exposed `aria-rowindex="NaN"` on its footer rows. `size` also stays undefined with lazy data providers that only report the size through the data provider callback, and it does not include expanded tree sub-rows, while body rows use flat indexes for `aria-rowindex`.

- Changed `__a11yUpdateGridSize` and `__a11yUpdateFooterRows` to use `_flatSize` instead of `size`, so `aria-rowcount` and the footer row `aria-rowindex` match the flat indexes used by body rows
- Footer rows now get a valid `aria-rowindex` before data is set, with lazy data providers, and with expanded tree rows
- `aria-rowcount` is now also set for grids whose `size` property is never assigned
- Added tests for a grid without data and for a grid with a lazy data provider

## Type of change

- Bugfix