### PR TITLE
test: cover grid mixin gaps found by mutation testing

### DIFF
--- a/packages/grid/test/basic.test.js
+++ b/packages/grid/test/basic.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextResize, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './grid-test-styles.js';
 import '../all-imports.js';
@@ -33,6 +33,30 @@ describe('basic features', () => {
     });
     flushGrid(grid);
     await nextFrame();
+  });
+
+  it('should have allRowsVisible set to false by default', () => {
+    expect(grid.allRowsVisible).to.be.false;
+  });
+
+  it('should update first and last column parts for newly created rows', async () => {
+    const initialRowCount = getPhysicalItems(grid).length;
+
+    // Grow the grid so that the virtualizer creates and initializes new rows
+    grid.style.height = '500px';
+    await nextResize(grid);
+    flushGrid(grid);
+
+    const rows = getPhysicalItems(grid);
+    expect(rows.length).to.be.greaterThan(initialRowCount);
+    const newRowCell = rows[rows.length - 1].firstElementChild;
+    expect(newRowCell.getAttribute('part')).to.contain('first-column-cell');
+    expect(newRowCell.getAttribute('part')).to.contain('last-column-cell');
+  });
+
+  it('should allow touch scrolling by clearing the gesture touch-action', () => {
+    expect(getComputedStyle(grid).touchAction).to.equal('auto');
+    expect(getComputedStyle(grid.$.scroller).touchAction).to.equal('auto');
   });
 
   it('should notify `size` property', () => {

--- a/packages/grid/test/column-reordering.test.js
+++ b/packages/grid/test/column-reordering.test.js
@@ -12,6 +12,7 @@ import {
   dragStart,
   flushGrid,
   getContainerCell,
+  getPhysicalItems,
   getRowCells,
   getRows,
   infiniteDataProvider,
@@ -315,6 +316,17 @@ describe('reordering simple grid', () => {
   describe('basic reordering', () => {
     it('should reorder the columns', () => {
       dragAndDropOver(headerContent[0], headerContent[1]);
+      expectVisualOrder(grid, [2, 1]);
+    });
+
+    it('should use the visual order for cells of newly created rows', () => {
+      dragAndDropOver(headerContent[0], headerContent[1]);
+      const initialRowCount = getPhysicalItems(grid).length;
+
+      // Grow the grid so that the virtualizer creates and initializes new rows
+      grid.size = 2;
+      expect(getPhysicalItems(grid).length).to.be.above(initialRowCount);
+
       expectVisualOrder(grid, [2, 1]);
     });
 

--- a/packages/grid/test/drag-and-drop.test.js
+++ b/packages/grid/test/drag-and-drop.test.js
@@ -187,6 +187,16 @@ describe('drag and drop', () => {
         expect(getContent(0).hasAttribute(cellDraggableAttribute)).to.be.false;
         expect(getContent(1).getAttribute(cellDraggableAttribute)).to.equal('true');
       });
+
+      it('should set the drag marker on cells of a newly added column', () => {
+        const column = document.createElement('vaadin-grid-column');
+        column.renderer = (root, _, model) => {
+          root.textContent = model.index;
+        };
+        grid.appendChild(column);
+        flushGrid(grid);
+        expect(getBodyCellContent(grid, 0, 2).getAttribute(cellDraggableAttribute)).to.equal('true');
+      });
     });
 
     describe('dragstart', () => {

--- a/packages/grid/test/hidden-grid.test.js
+++ b/packages/grid/test/hidden-grid.test.js
@@ -4,7 +4,7 @@ import { fixtureSync, nextFrame, nextRender, nextResize } from '@vaadin/testing-
 import sinon from 'sinon';
 import './grid-test-styles.js';
 import '../src/vaadin-grid.js';
-import { fire, flushGrid, getBodyCellContent, getHeaderCell, infiniteDataProvider } from './helpers.js';
+import { fire, flushGrid, getBodyCellContent, getCell, getHeaderCell, infiniteDataProvider } from './helpers.js';
 
 describe('hidden grid', () => {
   let grid;
@@ -78,6 +78,22 @@ describe('hidden grid', () => {
       // Show grid again, should retain scroll position
       grid.removeAttribute('hidden');
       expect(grid.$.table.scrollTop).to.equal(300);
+    });
+
+    it('should reset the body tab stop after rows change while hidden', async () => {
+      // Make a cell further down the body tab stop
+      getCell(grid, 10).focus();
+
+      grid.hidden = true;
+      grid.size = 1;
+      flushGrid(grid);
+
+      grid.hidden = false;
+      await nextResize(grid);
+      await nextFrame();
+
+      // The tab stop should have moved to a cell of the only remaining row
+      expect(getCell(grid, 0).tabIndex).to.equal(0);
     });
   });
 });

--- a/packages/grid/test/hidden-grid.test.js
+++ b/packages/grid/test/hidden-grid.test.js
@@ -81,16 +81,20 @@ describe('hidden grid', () => {
     });
 
     it('should reset the body tab stop after rows change while hidden', async () => {
+      // Wait for the grid to be observed as visible before hiding it
+      await nextResize(grid);
+
       // Make a cell further down the body tab stop
       getCell(grid, 10).focus();
 
       grid.hidden = true;
+      await nextResize(grid);
+
       grid.size = 1;
       flushGrid(grid);
 
       grid.hidden = false;
       await nextResize(grid);
-      await nextFrame();
 
       // The tab stop should have moved to a cell of the only remaining row
       expect(getCell(grid, 0).tabIndex).to.equal(0);

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -2025,6 +2025,49 @@ describe('hierarchical data', () => {
   });
 });
 
+describe('hierarchical data - collapse with focus', () => {
+  const items = [{ name: 'parent', children: true }, { name: 'sibling 1' }, { name: 'sibling 2' }];
+
+  function smallTreeDataProvider({ parentItem, page, pageSize }, callback) {
+    if (parentItem) {
+      const children = Array.from({ length: 50 }, (_, i) => ({ name: `child ${i}` }));
+      const offset = page * pageSize;
+      callback(children.slice(offset, offset + pageSize), children.length);
+    } else {
+      callback(items, items.length);
+    }
+  }
+
+  beforeEach(() => {
+    grid = fixtureSync(`
+      <vaadin-grid style="width: 200px; height: 300px;">
+        <vaadin-grid-tree-column path="name" item-has-children-path="children"></vaadin-grid-tree-column>
+      </vaadin-grid>
+    `);
+    grid.dataProvider = smallTreeDataProvider;
+    grid.expandedItems = [items[0]];
+    flushGrid(grid);
+  });
+
+  it('should keep the same item focused when the focused row is hidden on collapse', () => {
+    // Scroll to the end where the sibling rows following the expanded subtree are rendered
+    grid.scrollToIndex(52);
+    flushGrid(grid);
+
+    const row = getPhysicalItems(grid).find((row) => row._item.name === 'sibling 1');
+    row.firstElementChild.focus();
+
+    // Collapsing hides the previously focused row and renders the item on another row
+    grid.collapseItem(items[0]);
+    flushGrid(grid);
+
+    const focusedCell = grid.shadowRoot.activeElement;
+    expect(focusedCell.localName).to.equal('td');
+    expect(focusedCell.parentElement.hidden).to.be.false;
+    expect(focusedCell.parentElement._item.name).to.equal('sibling 1');
+  });
+});
+
 describe('empty state', () => {
   function getEmptyState() {
     return grid.querySelector('[slot="empty-state"]');

--- a/test/integration/grid-tooltip.test.js
+++ b/test/integration/grid-tooltip.test.js
@@ -18,6 +18,7 @@ import sinon from 'sinon';
 import '@vaadin/grid/src/vaadin-grid.js';
 import { flushGrid, getCell, getContainerCell } from '@vaadin/grid/test/helpers.js';
 import { Tooltip } from '@vaadin/tooltip/src/vaadin-tooltip.js';
+import { resetGlobalTooltipState } from '@vaadin/tooltip/src/vaadin-tooltip-mixin.js';
 import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
 
 function getHeaderCell(grid, index = 0) {
@@ -271,6 +272,11 @@ describe('tooltip', () => {
           await nextRender();
         });
 
+        afterEach(() => {
+          // Showing a tooltip warms up the global state shared by all tooltips
+          resetGlobalTooltipState();
+        });
+
         it('should not show tooltip when cell not fully visible at the start', async () => {
           grid.$.table.scrollLeft = isRTL ? -150 : 150;
           await nextRender();
@@ -283,6 +289,18 @@ describe('tooltip', () => {
         it('should not show tooltip when cell not fully visible at the end', () => {
           mouseenter(getCell(grid, 1));
           expect(tooltip.opened).to.be.false;
+        });
+
+        it('should show tooltip on a frozen cell', async () => {
+          grid.querySelector('vaadin-grid-column').frozen = true;
+          await nextRender();
+
+          grid.$.table.scrollLeft = isRTL ? -100 : 100;
+          await nextRender();
+          flushGrid(grid);
+
+          mouseenter(getCell(grid, 0));
+          expect(tooltip.opened).to.be.true;
         });
 
         it('should not show tooltip when cell is partially covered by frozen cell', async () => {


### PR DESCRIPTION
## Description

Line-removal mutation testing on `packages/grid/src/vaadin-grid-mixin.js` (remove one line, run the suite, see if anything fails) surfaced lines that no test asserts on. This adds one test case per genuine gap — each verified to fail while its line is removed and pass on pristine source.

Most gaps share a root cause: the behavior is only observable on rows the virtualizer creates *after* the initial render, so each of those tests first grows the grid and then asserts on the newly created rows. Two others were only reachable in narrower setups: the focus restoration path needs tree data, since collapsing an expanded subtree is what drops the flat size below the physical row count and hides the row holding focus, and the body tab stop reset needs the rows to change while the grid is hidden.

### Line to test case

| Line in `vaadin-grid-mixin.js` | Covered by |
| --- | --- |
| 118 — `allRowsVisible` default `value: false` | `basic features > should have allRowsVisible set to false by default` |
| 221, 222 — `setTouchAction(this / this.$.scroller, '')` | `basic features > should allow touch scrolling by clearing the gesture touch-action` |
| 514 — `_updateFirstAndLastColumnForRow(row)` in `__initRow` | `basic features > should update first and last column parts for newly created rows` |
| 448 — `.toSorted((a, b) => a._order - b._order)` in `__initRow` | `basic reordering > should use the visual order for cells of newly created rows` |
| 570 — `__updateRow(row)` in `_renderColumnTree` | `draggable > accessible name workaround > should set the drag marker on cells of a newly added column` |
| 258 — `_resetKeyboardNavigation()` in `updated()` | `hiding the grid > should reset the body tab stop after rows change while hidden` |
| 280, 281, 290, 319 — `__getBodyCellCoordinates` / `__focusBodyCell` in `_flatSizeChanged` | `hierarchical data - collapse with focus > should keep the same item focused when the focused row is hidden on collapse` |
| 703 — frozen-cell `return true` in `__isCellFullyVisible` | `cell not fully visible > should show tooltip on a frozen cell` |

Line numbers refer to `main` at the time of writing.

The integration test also adds an `afterEach` calling `resetGlobalTooltipState()`, since showing a tooltip warms up state that is global to all tooltips and would otherwise leak into later tests.

## Type of change

- Tests