### PR TITLE
refactor: remove redundant calls from grid row rendering

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -510,7 +510,6 @@ export const GridMixin = (superClass) =>
       // Might be empty if only cache was used
       this.appendChild(contentsFragment);
 
-      this._frozenCellsChanged();
       this._updateFirstAndLastColumnForRow(row);
     }
 
@@ -576,10 +575,8 @@ export const GridMixin = (superClass) =>
       this.__initRow(this.$.sizer, columnTree[columnTree.length - 1]);
 
       this._resizeHandler();
-      this._resetKeyboardNavigation();
       this.__a11yUpdateHeaderRows();
       this.__a11yUpdateFooterRows();
-      this.generateCellPartNames();
       this.__updateHeaderAndFooter();
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #12461, #12464

- Removed `_frozenCellsChanged()` from `__initRow`, already triggered by the `column._cells` reassignment.
- Removed `_resetKeyboardNavigation()` and `generateCellPartNames()` from `_renderColumnTree`, already covered by `__renderHeaderFooter()` and `__updateRow`.

## Type of change

- Refactor