### PR TITLE
refactor!: set time-picker value from input text explicitly

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -95,7 +95,6 @@ export const TimePickerMixin = (superClass) =>
         _comboBoxValue: {
           type: String,
           sync: true,
-          observer: '__comboBoxValueChanged',
         },
 
         /** @private */
@@ -238,7 +237,12 @@ export const TimePickerMixin = (superClass) =>
       }
 
       if (props.has('step')) {
-        this.__updateValue(this.__getTimeObject(this.value));
+        const time = this.__getTimeObject(this.value);
+        this.value = formatISOTime(time);
+        // Always update the input value, even if the component value hasn't
+        // changed, so that the text matches the step interval. For example,
+        // if the step is 3600 "10:00:50" should become "10:00".
+        this.__updateInputValue(time);
       }
 
       if (props.has('__effectiveI18n') && this.value) {
@@ -318,8 +322,7 @@ export const TimePickerMixin = (superClass) =>
      * @override
      */
     _onClearAction() {
-      this._comboBoxValue = '';
-      this._inputElementValue = '';
+      this.__setValueFromText('');
 
       this.__commitValueChange();
     }
@@ -333,14 +336,12 @@ export const TimePickerMixin = (superClass) =>
       if (this._focusedIndex > -1) {
         // Commit value based on focused index
         const focusedItem = this._dropdownItems[this._focusedIndex];
-        const itemValue = this._getItemLabel(focusedItem);
-        this._inputElementValue = itemValue;
-        this._comboBoxValue = itemValue;
+        this.__setValueFromTime(parseISOTime(focusedItem.value));
         this._focusedIndex = -1;
-      } else if (this._inputElementValue === '' || this._inputElementValue === undefined) {
-        this._comboBoxValue = '';
-      } else {
-        this._comboBoxValue = this._inputElementValue;
+      } else if (this._inputElementValue !== this._comboBoxValue) {
+        // Committing text that did not change would parse and format it again,
+        // and set the value from the result, so skip it.
+        this.__setValueFromText(this._inputElementValue || '');
       }
 
       this.__commitValueChange();
@@ -420,12 +421,12 @@ export const TimePickerMixin = (superClass) =>
       const objWithStep = this.__addStep(this.__getMsec(this.__memoValue), step, true);
       this.__memoValue = objWithStep;
 
-      // Setting `_comboBoxValue` property triggers the synchronous
-      // observer where the value can be parsed again, so we set
-      // this flag to ensure it does not alter the value.
-      this.__useMemo = true;
-      this._comboBoxValue = this.__effectiveI18n.formatTime(objWithStep);
-      this.__useMemo = false;
+      // Only commit when the formatted text changes, so that a step finer than
+      // the formatter can show does not move the value on its own, see #6397.
+      const text = this.__effectiveI18n.formatTime(objWithStep) || '';
+      if (text !== this._comboBoxValue) {
+        this.__setValueFromTime(objWithStep);
+      }
 
       this.__commitValueChange();
     }
@@ -584,7 +585,7 @@ export const TimePickerMixin = (superClass) =>
     _valueChanged(value, oldValue) {
       // Strip value to the step resolution before marking as committed.
       const parsedObj = (this.__memoValue = this.__getTimeObject(value));
-      const newValue = formatISOTime(parsedObj) || '';
+      const newValue = formatISOTime(parsedObj);
 
       // Mark value set programmatically by the user
       // as committed for the change event detection.
@@ -599,68 +600,67 @@ export const TimePickerMixin = (superClass) =>
       } else if (value !== newValue) {
         // Value can be parsed (e.g. 12 -> 12:00), adjust.
         this.value = newValue;
-      } else if (this.__keepInvalidInput) {
-        // User input could not be parsed and was reset
-        // to empty string, do not update input value.
-        delete this.__keepInvalidInput;
-      } else {
+      } else if (!this.__keepCommittedValue) {
         this.__updateInputValue(parsedObj);
       }
 
       this._toggleHasValue(this._hasValue);
     }
 
-    /** @private */
-    __comboBoxValueChanged(value, oldValue) {
-      if (value === '' && oldValue === undefined) {
+    /**
+     * Sets the value without marking it as committed, so that
+     * `__commitValueChange()` can still detect the change and
+     * fire an event for it.
+     *
+     * @param {string} value
+     * @private
+     */
+    __setUncommittedValue(value) {
+      this.__keepCommittedValue = true;
+      this.value = value;
+      this.__keepCommittedValue = false;
+    }
+
+    /**
+     * Sets the value and the input text from the given time,
+     * stripped to the resolution defined by the step.
+     *
+     * @param {!TimePickerTime} time
+     * @private
+     */
+    __setValueFromTime(time) {
+      const stripped = validateTime(time, this.step);
+      this.__setUncommittedValue(formatISOTime(stripped));
+      this.__updateInputValue(stripped);
+    }
+
+    /**
+     * Sets the value from the given text. When the text can not be parsed as a
+     * time, the value is set to an empty string and the text is left in the
+     * input for the user to correct.
+     *
+     * @param {string} text
+     * @private
+     */
+    __setValueFromText(text) {
+      // Skip parsing an empty field to not call custom `i18n.parseTime` for it.
+      const parsed = text ? this.__effectiveI18n.parseTime(text) : undefined;
+
+      if (parsed) {
+        this.__setValueFromTime(parsed);
         return;
       }
 
-      const parsed = this.__useMemo ? this.__memoValue : this.__effectiveI18n.parseTime(value);
-
-      // Strip parsed time to the resolution defined by the step before formatting
-      // it back, so that the result matches the text shown in the input field.
-      const parsedObj = validateTime(parsed, this.step);
-      const newValue = this.__effectiveI18n.formatTime(parsedObj) || '';
-
-      if (parsedObj) {
-        if (value !== newValue) {
-          this._comboBoxValue = newValue;
-        } else {
-          this.__keepCommittedValue = true;
-          this.__updateValue(parsedObj);
-          this.__keepCommittedValue = false;
-        }
-      } else {
-        // If the user input can not be parsed, set a flag
-        // that prevents `__valueChanged` from removing the input
-        // after setting the value property to an empty string below.
-        if (this.value !== '' && value !== '') {
-          this.__keepInvalidInput = true;
-        }
-
-        this.__keepCommittedValue = true;
-        this.value = '';
-        this.__keepCommittedValue = false;
-      }
-    }
-
-    /** @private */
-    __updateValue(obj) {
-      const timeString = formatISOTime(validateTime(obj, this.step)) || '';
-      this.value = timeString;
-
-      // Always strip the input value to match the step interval, even
-      // if the component value hasn't changed. For example, if the step
-      // is 3600 "10:00:50" should become "10:00".
-      this.__updateInputValue(obj);
+      this.__setUncommittedValue('');
+      this._inputElementValue = text;
+      this._comboBoxValue = text;
     }
 
     /** @private */
     __updateInputValue(obj) {
-      const timeString = this.__effectiveI18n.formatTime(validateTime(obj, this.step)) || '';
-      this._inputElementValue = timeString;
-      this._comboBoxValue = timeString;
+      const text = this.__effectiveI18n.formatTime(obj) || '';
+      this._inputElementValue = text;
+      this._comboBoxValue = text;
     }
 
     /**

--- a/packages/time-picker/test/i18n.test.js
+++ b/packages/time-picker/test/i18n.test.js
@@ -22,20 +22,36 @@ describe('i18n', () => {
   });
 
   describe('parseTime', () => {
-    it('should use custom parser if that exists', () => {
-      timePicker.i18n = { parseTime: sinon.stub().returns({ hours: 12, minutes: 0, seconds: 0 }) };
+    it('should not use custom parser for the value set programmatically', () => {
+      const parseTime = sinon.stub().returns({ hours: 12, minutes: 0, seconds: 0 });
+      timePicker.i18n = { parseTime };
       timePicker.value = '12';
-      expect(timePicker.i18n.parseTime.args[0][0]).to.be.equal('12:00');
+      expect(parseTime).to.be.not.called;
       expect(timePicker.value).to.be.equal('12:00');
     });
 
-    it('should commit the value when the custom parser returns stripped seconds', () => {
+    it('should not use custom parser when committing an empty field', () => {
+      const parseTime = sinon.stub().returns({ hours: 12, minutes: 0, seconds: 0 });
+      timePicker.i18n = { parseTime };
+      setInputValue(timePicker, '10:00');
+      enter(inputElement);
+      parseTime.resetHistory();
+      setInputValue(timePicker, '');
+      enter(inputElement);
+      expect(parseTime).to.be.not.called;
+      expect(timePicker.value).to.be.equal('');
+    });
+
+    it('should use custom parser for the text entered by the user', () => {
       // The step defaults to minute precision, so the seconds are stripped
       // from the value, while the custom parser keeps returning them.
-      timePicker.i18n = { parseTime: () => ({ hours: 12, minutes: 0, seconds: 0 }) };
+      const parseTime = sinon.stub().returns({ hours: 12, minutes: 0, seconds: 0 });
+      timePicker.i18n = { parseTime };
       setInputValue(timePicker, 'noon');
       enter(inputElement);
+      expect(parseTime).to.be.calledWith('noon');
       expect(timePicker.value).to.be.equal('12:00');
+      expect(inputElement.value).to.be.equal('12:00');
     });
 
     it('should not modify the object returned by the custom parser', () => {
@@ -77,6 +93,30 @@ describe('i18n', () => {
       expect(inputElement.value).to.equal('1200');
       expect(timePicker.value).to.equal('12:00');
     });
+
+    it('should use custom formatter once when committing the text entered by the user', () => {
+      const formatTime = sinon.spy((time) => `${time.hours}.${time.minutes}`);
+      timePicker.i18n = { formatTime, parseTime: () => ({ hours: 12, minutes: 0 }) };
+      formatTime.resetHistory();
+      setInputValue(timePicker, 'noon');
+      enter(inputElement);
+      expect(formatTime).to.be.calledOnce;
+      expect(inputElement.value).to.be.equal('12.0');
+    });
+
+    it('should keep the value that is finer than the formatter can show', () => {
+      timePicker.step = 0.5;
+      timePicker.i18n = {
+        formatTime: (time) => `${time.hours}.${time.minutes}`,
+        parseTime: (text) => {
+          const parts = text.split('.');
+          return { hours: parts[0], minutes: parts[1] };
+        },
+      };
+      timePicker.value = '10:00:30';
+      expect(timePicker.value).to.be.equal('10:00:30.000');
+      expect(inputElement.value).to.be.equal('10.0');
+    });
   });
 
   describe('dropdown items', () => {
@@ -92,6 +132,17 @@ describe('i18n', () => {
     it('should select the item matching the value', () => {
       timePicker.value = '10:00';
       expect(timePicker._scroller.selectedItem).to.equal(timePicker._dropdownItems[10]);
+    });
+
+    it('should set the value from the focused item without using the parser', () => {
+      const parseTime = sinon.spy(strictAmPmI18n, 'parseTime');
+      timePicker.open();
+      timePicker._focusedIndex = 10;
+      enter(inputElement);
+      parseTime.restore();
+      expect(parseTime).to.be.not.called;
+      expect(timePicker.value).to.be.equal('10:00');
+      expect(inputElement.value).to.be.equal('10:00 AM');
     });
   });
 

--- a/packages/time-picker/test/value-commit.test.js
+++ b/packages/time-picker/test/value-commit.test.js
@@ -537,4 +537,41 @@ describe('value commit', () => {
       });
     });
   });
+
+  describe('with a formatter coarser than the step', () => {
+    beforeEach(() => {
+      timePicker.step = 0.5;
+      timePicker.i18n = {
+        formatTime: (time) => `${time.hours}.${time.minutes}`,
+        parseTime: (text) => {
+          const parts = text.split('.');
+          return { hours: parts[0], minutes: parts[1] };
+        },
+      };
+      timePicker.value = '10:00:30';
+      valueChangedSpy.resetHistory();
+    });
+
+    it('should not commit but validate on blur', () => {
+      timePicker.blur();
+      expectValidationOnly();
+      expect(timePicker.value).to.equal('10:00:30.000');
+      expect(timePicker.inputElement.value).to.equal('10.0');
+    });
+
+    it('should not commit on Enter', async () => {
+      await sendKeys({ press: 'Enter' });
+      expectNoValueCommit();
+      expect(timePicker.value).to.equal('10:00:30.000');
+      expect(timePicker.inputElement.value).to.equal('10.0');
+    });
+
+    it('should not commit but validate on close with outside click', () => {
+      timePicker.click();
+      outsideClick();
+      expectValidationOnly();
+      expect(timePicker.value).to.equal('10:00:30.000');
+      expect(timePicker.inputElement.value).to.equal('10.0');
+    });
+  });
 });


### PR DESCRIPTION
## Description

Depends on #12495
Part of #888

### Logic restructuring

- Removed the `__comboBoxValueChanged` observer, so that `_comboBoxValue` no longer drives the value and only records the last committed input text
- Added `__setValueFromText()` to turn the input text into a value explicitly, called from `_commitValue()` and `_onClearAction()`, and `__setValueFromTime()` for arrow key stepping and for the selected dropdown item
  - `__setValueFromTime()` strips the time to the resolution defined by `step`, and both set the input text, so the callers no longer assign `_inputElementValue` themselves
- Added `__setUncommittedValue()` as the only place that toggles `__keepCommittedValue`, so that `__commitValueChange()` can still detect the change and fire an event for it
  - Replaces `__updateValue()`, whose remaining caller on `step` change is inlined
- Changed `_commitValue()` to set the value from the ISO time the focused item carries (see #12495) instead of parsing its label, so selecting an item does not call `i18n.parseTime`
- Changed arrow key stepping to pass the stepped time to `__setValueFromTime()` instead of formatting it and parsing it back, which removes the `__useMemo` flag
  - It keeps committing only when the formatted text changes, so a `step` finer than the formatter can show still does not move the value on its own, see #6397
- Changed `_commitValue()` to skip text that did not change, so that a blur or <kbd>Enter</kbd> without edits does not parse and format the text again and set the value from the result
- Folded `__keepInvalidInput` into `__keepCommittedValue`, as both prevented `_valueChanged()` from acting on a change that comes from a commit
- Dropped the `|| ''` fallbacks on `formatISOTime()`, which already returns an empty string for a time object that is not defined

### i18n

- **Behavior change**: `i18n.parseTime` no longer runs when the value is set programmatically or a dropdown item is selected, and on the commit path is only used for text the user entered
- **Behavior change:** custom `i18n.parseTime` no longer receives an empty string when a field that had text is emptied and committed
- **Behavior change**: value set programmatically keeps its precision instead of being reduced to what the formatter can show
- Setting value programmatically: `i18n.formatTime` - 1 call instead of 3, `i18n.parseTime` - 0 calls instead of 1
- Committing typed text calls `i18n.formatTime` once instead of three times
- Added tests for the cases where `i18n.parseTime` is no longer called, including a selected dropdown item, for the value being kept with a formatter coarser than the `step`, and for `i18n.formatTime` running once per commit

> [!WARNING]
> `i18n.parseTime` still receives the output of `i18n.formatTime` from `checkValidity()`, so a custom parser has to keep accepting it. What changes is the commit path, where it now only sees text the user entered.
>
> A value finer than the formatter can show is kept: `value = '10:00:30'` with a formatter that only shows `hh.mm` stays `10:00:30`, where it used to become `10:00:00` and dispatch a `change` event on the next commit.

## Type of change

- Refactor

## How to test

1. Open `dev/time-picker.html`.
2. Type `12` and press <kbd>Enter</kbd> — the input shows `12:00` and the value is `12:00`.
3. Type `foo` and press <kbd>Enter</kbd> — `foo` stays in the input and the field is invalid.
4. Type over the committed value and press <kbd>Escape</kbd> — the input goes back to the committed text.
5. Click the clear button — the input and the value are empty.
6. In the console, set a format that only shows hours and minutes, together with a matching parser and a smaller step:

   ```js
   const timePicker = document.querySelector('vaadin-time-picker');
   timePicker.step = 20;
   timePicker.i18n = {
     formatTime: (time) => `${time.hours}.${time.minutes}`,
     parseTime: (text) => {
       const parts = text.split('.');
       return { hours: parts[0], minutes: parts[1] };
     }
   };
   ```

7. Set `timePicker.value = '12:00:00'` and press <kbd>ArrowUp</kbd> three times — the value stays `12:00:00` for the first two presses and becomes `12:01:00` on the third, matching the input text.

## Note

Decided to keep `_comboBoxValue` for now to reduce the diff, it could be renamed in a follow-up PR.

