### PR TITLE
refactor: rewrite time-picker value formatting logic to use updated

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -110,7 +110,6 @@ export const TimePickerMixin = (superClass) =>
         '_openedOrItemsChanged(opened, _dropdownItems)',
         '_updateScroller(opened, _dropdownItems, _focusedIndex, _theme, _comboBoxValue)',
         '__updateAriaAttributes(_dropdownItems, opened, inputElement)',
-        '__updateDropdownItems(__effectiveI18n, min, max, step)',
       ];
     }
 
@@ -228,6 +227,23 @@ export const TimePickerMixin = (superClass) =>
       this._tooltipController.setPosition('top');
       this._tooltipController.setAriaTarget(this.inputElement);
       this.addController(this._tooltipController);
+    }
+
+    /** @protected */
+    updated(props) {
+      super.updated(props);
+
+      if (['__effectiveI18n', 'min', 'max', 'step'].some((prop) => props.has(prop))) {
+        this.__updateDropdownItems();
+      }
+
+      if (props.has('step')) {
+        this.__updateValue(this.__getTimeObject(this.value));
+      }
+
+      if (props.has('__effectiveI18n') && this.value) {
+        this.__updateInputValue(this.__getTimeObject(this.value));
+      }
     }
 
     /**
@@ -460,6 +476,15 @@ export const TimePickerMixin = (superClass) =>
     }
 
     /**
+     * Returning Object in the format `{ hours: ..., minutes: ..., seconds: ..., milliseconds: ... }`
+     * from an ISO 8601 time, stripped to the resolution defined by the step.
+     * @private
+     */
+    __getTimeObject(isoTime) {
+      return validateTime(parseISOTime(isoTime), this.step);
+    }
+
+    /**
      * Returning seconds from Object in the format `{ hours: ..., minutes: ..., seconds: ..., milliseconds: ... }`
      * @private
      */
@@ -505,31 +530,11 @@ export const TimePickerMixin = (superClass) =>
     }
 
     /** @private */
-    __updateDropdownItems(effectiveI18n, min, max, step) {
-      const minTimeObj = validateTime(parseISOTime(min || MIN_ALLOWED_TIME), step);
-      const minSec = this.__getSec(minTimeObj);
+    __updateDropdownItems() {
+      const minSec = this.__getSec(this.__getTimeObject(this.min || MIN_ALLOWED_TIME));
+      const maxSec = this.__getSec(this.__getTimeObject(this.max || MAX_ALLOWED_TIME));
 
-      const maxTimeObj = validateTime(parseISOTime(max || MAX_ALLOWED_TIME), step);
-      const maxSec = this.__getSec(maxTimeObj);
-
-      this._dropdownItems = this.__generateDropdownList(minSec, maxSec, step);
-
-      const parsedValue = validateTime(parseISOTime(this.value), step);
-
-      if (step !== this.__oldStep) {
-        this.__oldStep = step;
-        this.__updateValue(parsedValue);
-      }
-
-      // Not run on a `min` or `max` change, so that text the user is still
-      // typing is not replaced.
-      if (effectiveI18n !== this.__oldEffectiveI18n) {
-        this.__oldEffectiveI18n = effectiveI18n;
-
-        if (this.value) {
-          this.__updateInputValue(parsedValue);
-        }
-      }
+      this._dropdownItems = this.__generateDropdownList(minSec, maxSec, this.step);
     }
 
     /** @private */

--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -521,8 +521,14 @@ export const TimePickerMixin = (superClass) =>
         this.__updateValue(parsedValue);
       }
 
-      if (this.value) {
-        this._comboBoxValue = effectiveI18n.formatTime(parsedValue);
+      // Not run on a `min` or `max` change, so that text the user is still
+      // typing is not replaced.
+      if (effectiveI18n !== this.__oldEffectiveI18n) {
+        this.__oldEffectiveI18n = effectiveI18n;
+
+        if (this.value) {
+          this.__updateInputValue(parsedValue);
+        }
       }
     }
 

--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -480,8 +480,8 @@ export const TimePickerMixin = (superClass) =>
      * from an ISO 8601 time, stripped to the resolution defined by the step.
      * @private
      */
-    __getTimeObject(isoTime) {
-      return validateTime(parseISOTime(isoTime), this.step);
+    __getTimeObject(timeString) {
+      return validateTime(parseISOTime(timeString), this.step);
     }
 
     /**


### PR DESCRIPTION
## Description

Part of #888
Depends on #12469

Extracted from #12467

- Replaced setting `_comboBoxValue` with calling `__updateInputValue()` on `i18n` change
- Split logic from the complex `__updateDropdownItems()` observer into `updated()` hook
- Added `__getTimeObject()` helper `validateTime(parseISOTime(timeString), this.step)`

## Type of change

- Refactor

## How to test

1. Open `dev/time-picker.html`.
2. In the console, run:

   ```js
   const timePicker = document.querySelector('vaadin-time-picker');
   timePicker.i18n = {
     formatTime: (time) => `${time.hours}.${time.minutes}`,
     parseTime: (text) => {
       const parts = text.split('.');
       return { hours: parts[0], minutes: parts[1] };
     }
   };
   ```

3. The input shows `15.0`, re-formatted with the new `i18n`.
4. Type `12.3` over it, then set `timePicker.min = '01:00'` — the input still shows `12.3`.
