### PR TITLE
test: improve time-picker input value commit test coverage

### DIFF
--- a/packages/time-picker/test/keyboard-navigation.test.js
+++ b/packages/time-picker/test/keyboard-navigation.test.js
@@ -127,9 +127,11 @@ describe('keyboard navigation', () => {
         timePicker.step = 20;
         for (let inc = 1; inc < 4; inc++) {
           expect(inputElement.value).to.be.equal('12.0');
+          expect(timePicker.value).to.be.equal('12:00:00');
           arrowUp(inputElement);
         }
         expect(inputElement.value).to.be.equal('12.1');
+        expect(timePicker.value).to.be.equal('12:01:00');
       });
 
       it('should correctly subtract the step with custom parser and formatter', () => {
@@ -138,9 +140,11 @@ describe('keyboard navigation', () => {
         for (let inc = 1; inc < 4; inc++) {
           arrowDown(inputElement);
           expect(inputElement.value).to.be.equal('11.59');
+          expect(timePicker.value).to.be.equal('11:59:40');
         }
         arrowDown(inputElement);
         expect(inputElement.value).to.be.equal('11.58');
+        expect(timePicker.value).to.be.equal('11:58:40');
       });
     });
   });

--- a/packages/time-picker/test/value-commit.test.js
+++ b/packages/time-picker/test/value-commit.test.js
@@ -367,6 +367,21 @@ describe('value commit', () => {
       });
     });
 
+    describe('overlay', () => {
+      beforeEach(async () => {
+        timePicker.click();
+        await sendKeys({ press: 'ArrowDown' });
+        await sendKeys({ press: 'ArrowDown' });
+      });
+
+      it('should update the input value on selecting the item matching the value', () => {
+        expect(timePicker.inputElement.value).to.equal('01:00');
+        getAllItems(timePicker)[0].click();
+        expect(timePicker.inputElement.value).to.equal('00:00');
+        expectNoValueCommit();
+      });
+    });
+
     describe('parsable input entered', () => {
       beforeEach(async () => {
         timePicker.inputElement.select();
@@ -440,11 +455,21 @@ describe('value commit', () => {
     it('should clear on clear button click', () => {
       timePicker.$.clearButton.click();
       expectValueCommit('');
+      expect(timePicker.inputElement.value).to.equal('');
     });
 
     it('should clear on Escape', async () => {
       await sendKeys({ press: 'Escape' });
       expectValueCommit('');
+      expect(timePicker.inputElement.value).to.equal('');
+    });
+
+    it('should clear unparsable input on clear button click', async () => {
+      timePicker.inputElement.select();
+      await sendKeys({ type: 'foo' });
+      timePicker.$.clearButton.click();
+      expectValueCommit('');
+      expect(timePicker.inputElement.value).to.equal('');
     });
   });
 

--- a/packages/time-picker/test/value-commit.test.js
+++ b/packages/time-picker/test/value-commit.test.js
@@ -373,7 +373,7 @@ describe('value commit', () => {
         await sendKeys({ press: 'ArrowDown' });
       });
 
-      it('should revert on item selection with click matching the value', () => {
+      it('should revert on item selection with click matching the value', async () => {
         await sendKeys({ press: 'ArrowDown' });
         expect(timePicker.inputElement.value).to.equal('01:00');
         getAllItems(timePicker)[0].click();

--- a/packages/time-picker/test/value-commit.test.js
+++ b/packages/time-picker/test/value-commit.test.js
@@ -371,10 +371,10 @@ describe('value commit', () => {
       beforeEach(async () => {
         timePicker.click();
         await sendKeys({ press: 'ArrowDown' });
-        await sendKeys({ press: 'ArrowDown' });
       });
 
-      it('should update the input value on selecting the item matching the value', () => {
+      it('should revert on item selection with click matching the value', () => {
+        await sendKeys({ press: 'ArrowDown' });
         expect(timePicker.inputElement.value).to.equal('01:00');
         getAllItems(timePicker)[0].click();
         expect(timePicker.inputElement.value).to.equal('00:00');


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/12467

Improved time-picker test coverage:

- Added test covering input value after selecting the dropdown item that matches the `value`
- Added test for clearing unparsable input typed when `value` is set on clear button click
- Added assertions for the value arrow key stepping produces with a custom formatter

## Type of change

- Tests
