### PR TITLE
fix: do not fire change for time-picker value set programmatically

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -582,7 +582,8 @@ export const TimePickerMixin = (superClass) =>
      * @override
      */
     _valueChanged(value, oldValue) {
-      const parsedObj = (this.__memoValue = parseISOTime(value));
+      // Strip value to the step resolution before marking as committed.
+      const parsedObj = (this.__memoValue = this.__getTimeObject(value));
       const newValue = formatISOTime(parsedObj) || '';
 
       // Mark value set programmatically by the user

--- a/packages/time-picker/test/value-commit.test.js
+++ b/packages/time-picker/test/value-commit.test.js
@@ -479,6 +479,15 @@ describe('value commit', () => {
       expect(timePicker.inputElement.value).to.equal('10:00:00');
     });
 
+    it('should strip milliseconds without commit on Enter if value was set programmatically', async () => {
+      timePicker.value = '10:00:00.500';
+      valueChangedSpy.resetHistory();
+      await sendKeys({ press: 'Enter' });
+      expectNoValueCommit();
+      expect(timePicker.value).to.equal('10:00:00');
+      expect(timePicker.inputElement.value).to.equal('10:00:00');
+    });
+
     describe('with arrow key committed', () => {
       beforeEach(async () => {
         await sendKeys({ press: 'ArrowDown' });


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/12467

Depends on #12468

A `value` finer than the `step` allows, e.g. `10:00:30` with the default step, was marked as committed before being stripped to `10:00`, so the next commit attempt fired `change` for a value the user never entered.

- Stripped the value to the step resolution before marking it as committed in `_valueChanged`, reusing the `__getTimeObject()` helper added in #12468
- Added test for committing a value set programmatically with milliseconds that the `step` strips

## Type of change

- Bugfix

## How to test

1. Open `dev/time-picker.html`
2. In the browser console, run:
   ```js
   const timePicker = document.querySelector('vaadin-time-picker');
   timePicker.addEventListener('change', () => console.log('change'));
   timePicker.value = '10:00:30';
   ```
3. The field shows `10:00`
4. Click the field, then click outside it
5. Nothing is logged
