### PR TITLE
fix: suppress pointer-events on overlays slotted content

### DIFF
--- a/packages/overlay/src/styles/vaadin-overlay-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-base-styles.js
@@ -56,6 +56,11 @@ const overlayBase = css`
     display: none !important;
   }
 
+  :host([suppressed]) [part='overlay'],
+  :host([suppressed]) ::slotted(*) {
+    pointer-events: none !important;
+  }
+
   [part='overlay'] {
     color: var(--vaadin-overlay-text-color, var(--vaadin-text-color));
     background: var(--vaadin-overlay-background, var(--vaadin-background-color));

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -463,7 +463,7 @@ export const OverlayMixin = (superClass) =>
     _finishClosing() {
       this._detachOverlay();
       this._removeAttachedInstance();
-      this.$.overlay.style.removeProperty('pointer-events');
+      this.toggleAttribute('suppressed', false);
       setOverlayStateAttribute(this, 'closing', false);
       this.dispatchEvent(new CustomEvent('vaadin-overlay-closed'));
     }

--- a/packages/overlay/src/vaadin-overlay-stack-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-stack-mixin.js
@@ -106,10 +106,10 @@ export const OverlayStackMixin = (superClass) =>
         document.body.style.pointerEvents = 'none';
       }
 
-      // Disable pointer events in other attached overlays
+      // Suppress pointer events in other attached overlays
       getAttachedInstances().forEach((el) => {
         if (el !== this) {
-          el.$.overlay.style.pointerEvents = 'none';
+          el.toggleAttribute('suppressed', true);
         }
       });
     }
@@ -122,7 +122,7 @@ export const OverlayStackMixin = (superClass) =>
         delete this._previousDocumentPointerEvents;
       }
 
-      // Restore pointer events in the previous overlay(s)
+      // Stop suppressing pointer events in the previous overlay(s)
       const instances = getAttachedInstances();
 
       let el;
@@ -132,7 +132,7 @@ export const OverlayStackMixin = (superClass) =>
           // Skip the current instance
           continue;
         }
-        el.$.overlay.style.removeProperty('pointer-events');
+        el.toggleAttribute('suppressed', false);
         if (!el.modeless) {
           // Stop after the last modal
           break;

--- a/packages/overlay/test/animations.test.js
+++ b/packages/overlay/test/animations.test.js
@@ -290,7 +290,7 @@ function afterOverlayClosingFinished(overlay, callback) {
 
     it('should remove pointer events on previously opened overlay', (done) => {
       afterOverlayClosingFinished(overlays[0], () => {
-        expect(overlays[0].$.overlay.style.pointerEvents).to.equal('');
+        expect(getComputedStyle(overlays[0].$.overlay).pointerEvents).to.equal('auto');
         done();
       });
       overlays[0].querySelector('button').click();
@@ -317,8 +317,8 @@ function afterOverlayClosingFinished(overlay, callback) {
 
     it('should not remove pointer events on last opened overlay', (done) => {
       afterOverlayOpeningFinished(overlays[1], () => {
-        expect(overlays[0].$.overlay.style.pointerEvents).to.equal('none');
-        expect(overlays[1].$.overlay.style.pointerEvents).to.equal('');
+        expect(getComputedStyle(overlays[0].$.overlay).pointerEvents).to.equal('none');
+        expect(getComputedStyle(overlays[1].$.overlay).pointerEvents).to.equal('auto');
         done();
       });
       overlays[0].opened = true;
@@ -349,11 +349,11 @@ function afterOverlayClosingFinished(overlay, callback) {
 
     it('should restore pointer events on the remaining overlay', (done) => {
       afterOverlayOpeningFinished(overlays[2], async () => {
-        expect(overlays[0].$.overlay.style.pointerEvents).to.equal('none');
+        expect(getComputedStyle(overlays[0].$.overlay).pointerEvents).to.equal('none');
         overlays[1].opened = false;
         overlays[2].opened = false;
         await nextFrame();
-        expect(overlays[0].$.overlay.style.pointerEvents).to.equal('');
+        expect(getComputedStyle(overlays[0].$.overlay).pointerEvents).to.equal('auto');
         done();
       });
       overlays[0].opened = true;
@@ -393,8 +393,8 @@ function afterOverlayClosingFinished(overlay, callback) {
 
     it('should not remove pointer events on last opened overlay with animated content', (done) => {
       afterOverlayOpeningFinished(overlays[1], () => {
-        expect(overlays[0].$.overlay.style.pointerEvents).to.equal('none');
-        expect(overlays[1].$.overlay.style.pointerEvents).to.equal('');
+        expect(getComputedStyle(overlays[0].$.overlay).pointerEvents).to.equal('none');
+        expect(getComputedStyle(overlays[1].$.overlay).pointerEvents).to.equal('auto');
         done();
       });
       overlays[0].opened = true;

--- a/packages/overlay/test/pointer-events.test.js
+++ b/packages/overlay/test/pointer-events.test.js
@@ -114,6 +114,31 @@ describe('pointer-events', () => {
       // (in this case overlay 1 at step 3)
       expect(getComputedStyle(overlay1.$.overlay).pointerEvents).to.equal('auto');
     });
+
+    it('should disable pointer events on slotted content of the covered overlay', () => {
+      const button = document.createElement('button');
+      button.setAttribute('style', 'pointer-events: auto');
+      overlay1.appendChild(button);
+
+      overlay1.opened = true;
+
+      overlay2.opened = true;
+
+      expect(getComputedStyle(button).pointerEvents).to.equal('none');
+    });
+
+    it('should restore pointer events on slotted content when the top overlay closes', () => {
+      const button = document.createElement('button');
+      button.setAttribute('style', 'pointer-events: auto');
+      overlay1.appendChild(button);
+
+      overlay1.opened = true;
+
+      overlay2.opened = true;
+
+      overlay2.opened = false;
+      expect(getComputedStyle(button).pointerEvents).to.equal('auto');
+    });
   });
 
   describe('animated closing', () => {

--- a/packages/vaadin-lumo-styles/src/mixins/overlay.css
+++ b/packages/vaadin-lumo-styles/src/mixins/overlay.css
@@ -50,6 +50,11 @@
     display: none !important;
   }
 
+  :host([suppressed]) [part='overlay'],
+  :host([suppressed]) ::slotted(*) {
+    pointer-events: none !important;
+  }
+
   [part='overlay'] {
     overflow: auto;
     pointer-events: auto;

--- a/test/integration/dialog-select.test.js
+++ b/test/integration/dialog-select.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { fixtureSync, mousedown, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/dialog';
 import '@vaadin/select';
 
@@ -10,8 +11,17 @@ describe('select in dialog', () => {
   beforeEach(async () => {
     dialog = fixtureSync(`
       <vaadin-dialog modeless header-title="Title">
+        <button slot="header-content">Action</button>
         <vaadin-select no-vertical-overlap></vaadin-select>
       </vaadin-dialog>
+    `);
+    fixtureSync(`
+      <style>
+        /* Make sendMouseToElement click button */
+        vaadin-dialog::part(header-content) {
+          justify-content: center;
+        }
+      </style>
     `);
     dialog.opened = true;
     await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
@@ -35,6 +45,19 @@ describe('select in dialog', () => {
 
     await sendMouseToElement({ type: 'click', element: title });
 
+    expect(select.opened).to.be.false;
+  });
+
+  it('should not click dialog header button when closing select overlay', async () => {
+    const spy = sinon.spy();
+    dialog.querySelector('button').addEventListener('click', spy);
+
+    // Use header content part instead of the actual slotted button element,
+    // since `getBoundingClientRect()` for the latter returns 0 coordinates.
+    const header = dialog.$.overlay.shadowRoot.querySelector('[part="header-content"]');
+    await sendMouseToElement({ type: 'click', element: header });
+
+    expect(spy).to.be.not.called;
     expect(select.opened).to.be.false;
   });
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/12465

- Added `suppressed` - internal attribute on `vaadin-overlay`, intentionally undocumented for styling.
- Changed `OverlayStackMixin` to set the new attribute rather than modifying inline `style` directly
- Adapted CSS block with `closing` in animation styles to use `suppressed`, moved it to base styles
- Updated Lumo `overlay.css` mixin accordingly - some overlays like dialog are not using base styles
- Improved IT added in https://github.com/vaadin/web-components/pull/8727

## Type of change

- Bugfix

## How to Test

Update `dev/dialog.html` - make both dialogs `modeless`, add snippet below to `dialog2.renderer`:

```js
const select = document.createElement('vaadin-select');
select.label = 'Select';
select.innerHTML = `
  <vaadin-select-list-box slot="overlay">
    <vaadin-select-item value="1">Option 1</vaadin-select-item>
    <vaadin-select-item value="2">Option 2</vaadin-select-item>
    <vaadin-select-item value="3">Option 3</vaadin-select-item>
  </vaadin-select-list-box>
`;
```

Steps to verify the fix works:

1. Open parent dialog, then nested dialog, then its nested select
2. Click on parent dialog header title or the footer "Action" button
3. **Before**: parent dialog is focused. **After**: only select is closed