### PR TITLE
feat: resolve icon aliases defined with use element in iconset

### DIFF
--- a/packages/icon/src/vaadin-iconset-mixin.js
+++ b/packages/icon/src/vaadin-iconset-mixin.js
@@ -23,12 +23,35 @@ function getIconsetName(icon) {
   return parts[0] || 'vaadin';
 }
 
+/**
+ * Get the icon entry for an alias e.g. `<g id="a"><use href="#b"></use></g>`.
+ */
+function getAliasTarget(svg, entries, name) {
+  const use = svg.children.length === 1 && svg.firstElementChild.localName === 'use' ? svg.firstElementChild : null;
+  const href = use?.getAttribute('href');
+  return href?.startsWith('#') ? entries[getIconId(href.slice(1), name)] : null;
+}
+
 function initIconsMap(iconset, name) {
-  iconset._icons = [...iconset.querySelectorAll('[id]')].reduce((map, svg) => {
+  const svgs = [...iconset.querySelectorAll('[id]')];
+
+  const icons = svgs.reduce((map, svg) => {
     const key = getIconId(svg.id, name);
     map[key] = svg;
     return map;
   }, {});
+
+  // Copy to resolve aliases regardless of declaration order.
+  const entries = { ...icons };
+
+  svgs.forEach((svg) => {
+    const target = getAliasTarget(svg, entries, name);
+    if (target) {
+      icons[getIconId(svg.id, name)] = target;
+    }
+  });
+
+  iconset._icons = icons;
 }
 
 export const IconsetMixin = (superClass) =>

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -456,6 +456,23 @@ describe('vaadin-icon', () => {
 
         expectIcon(`<g>${ANGLE_UP}</g>`);
       });
+
+      it('should render the target icon when the icon is an alias', () => {
+        fixtureSync(`
+          <vaadin-iconset name="baz">
+            <svg xmlns="http://www.w3.org/2000/svg">
+              <defs>
+                <g id="baz:angle-up">${ANGLE_UP}</g>
+                <g id="baz:angle-up-alias"><use href="#baz:angle-up"></use></g>
+              </defs>
+            </svg>
+          </vaadin-iconset>
+        `);
+
+        icon.icon = 'baz:angle-up-alias';
+
+        expectIcon(`<g>${ANGLE_UP}</g>`);
+      });
     });
 
     describe('set before attach', () => {


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/12452

- Added support for icon aliases in `Iconset`: an entry that contains a single `<use href="#...">` pointing at another entry now resolves to the entry it points at.
  - This lets an iconset expose a new name for an existing icon without duplicating the SVG content, which is needed to rename icons in `@vaadin/icons` while keeping the old names working.
- An alias must point at a regular icon. Aliases are looked up in a copy of the icon map, so an alias pointing at another alias renders nothing regardless of the order in which the entries are declared.
- Added a test rendering an alias through `vaadin-icon`.

## Type of change

- Feature

## How to test

1. Open `dev/icon.html`.
2. In the browser console, add an iconset with an alias and render it:
   ```js
   document.body.insertAdjacentHTML(
     'beforeend',
     `<vaadin-iconset name="test" size="16">
        <svg><defs>
          <g id="test:caret-down"><path d="M3 4h10l-5 7z"></path></g>
          <g id="test:alias"><use href="#test:caret-down"></use></g>
        </defs></svg>
      </vaadin-iconset>
      <vaadin-icon icon="test:alias"></vaadin-icon>`,
   );
   ```
3. The last icon on the page should render the caret-down shape instead of staying empty.

---

🤖 Generated with Claude Code