### PR TITLE
chore: move code-review concurrency check to job level

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -15,12 +15,6 @@ on:
     types: [opened, ready_for_review, review_requested]
     branches: [main]
 
-# One review per PR at a time; a re-trigger queues instead of aborting a run
-# that may be mid-posting.
-concurrency:
-  group: code-review-${{ github.event.issue.number || github.event.pull_request.number }}
-  cancel-in-progress: false
-
 env:
   PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
 
@@ -69,6 +63,16 @@ jobs:
   review:
     needs: check
     if: needs.check.outputs.eligible == 'true'
+    # One review per PR at a time; a re-trigger queues instead of aborting a run
+    # that may be mid-posting. Group is enforced on the job level instead of the
+    # workflow: newer workflow runs in the same group cancel previous ones that 
+    # haven't started yet. This can lead to a scenario where opening a PR and
+    # assigning reviewers at the same time can cause workflows that would pass
+    # the check pre-condition to get canceled by workflows whose condition would
+    # not pass.
+    concurrency:
+      group: code-review-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
When multiple workflows are scheduled at the same time, GitHub cancels previous workflows that have not started yet when they use the same concurrency group. This can lead to a scenario where a code-review workflow that would not pass the pre-condition on the `check` job cancels a previously scheduled job that would have passed the check. For example:
- A workflow is scheduled by opening the PR, its pre-condition would allow it to run
- More workflows are scheduled by assigning code reviewers, which are not eligible to run because they do not assign `vaadin-review-bot`
- The workflows scheduled from assigning code reviewers cancel the pending workflow from opening the PR
- The result is no code review runs at all

This change moves the concurrency group to the job level instead. This way every workflow at least runs the pre-conditions in `check`, leaving only the single eligible workflow to actually run the `review` job.

There's still an edge-case where opening a PR and assigning `vaadin-review-bot` at the same time results in duplicate reviews. That was already the case before this change and can be addressed later.
