### PR TITLE
test: cover notification card pointer events while closing

### DIFF
--- a/packages/notification/test/animation.test.js
+++ b/packages/notification/test/animation.test.js
@@ -79,6 +79,23 @@ describe('animated notifications', () => {
       expect(notifications[1]._card.hasAttribute('closing')).to.be.false;
     });
 
+    it('should not allow pointer events on the card while closing', () => {
+      notifications[1].close();
+
+      const overlayPart = notifications[1]._card.shadowRoot.querySelector('[part="overlay"]');
+      expect(getComputedStyle(overlayPart).pointerEvents).to.equal('none');
+    });
+
+    it('should not allow pointer events on the card content while closing', () => {
+      const button = document.createElement('button');
+      button.style.pointerEvents = 'auto';
+      notifications[1]._card.appendChild(button);
+
+      notifications[1].close();
+
+      expect(getComputedStyle(button).pointerEvents).to.equal('none');
+    });
+
     it('should set `opening` attribute and remove later', async () => {
       notifications[1].close();
       await oneEvent(notifications[1]._card, 'animationend');


### PR DESCRIPTION
## Description

Follow-up to #12239

`vaadin-notification-card` is the only consumer of `overlayAnimationStyles` that does not also
include `overlayStyles`, so the rule that blocks interaction while `closing` is set reaches the
card through a path no test covers. Moving or narrowing that rule removes it from the card
silently, with a green CI.

- Added a test asserting `pointer-events` is `none` on the card `[part='overlay']` while the card is closing
- Added a test asserting content of a closing card is not clickable, using a button that opts back in with `pointer-events: auto`, so the assertion pins the `::slotted(*)` half of the rule instead of passing on inheritance alone
- Both tests are placed in the existing `animation` group and reuse the animated notification from its setup

## Type of change

- Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)