### PR TITLE
refactor: rename autoFocusPartialMatch to partialMatchMode

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-items-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-items-mixin.d.ts
@@ -6,7 +6,7 @@
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { ComboBoxBaseMixinClass } from './vaadin-combo-box-base-mixin.js';
 
-export type ComboBoxAutoFocusPartialMatch = 'first-match' | 'none' | 'only-match';
+export type ComboBoxPartialMatchMode = 'first-match' | 'none' | 'only-match';
 
 export declare function ComboBoxItemsMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,
@@ -29,9 +29,9 @@ export declare class ComboBoxItemsMixinClass<TItem> {
    * the dropdown is closed. For example, with `autoOpenDisabled`, typing
    * does not focus or select a match until the dropdown is opened.
    *
-   * @attr {none|first-match|only-match} auto-focus-partial-match
+   * @attr {none|first-match|only-match} partial-match-mode
    */
-  autoFocusPartialMatch: ComboBoxAutoFocusPartialMatch;
+  partialMatchMode: ComboBoxPartialMatchMode;
 
   /**
    * A full set of items to filter the visible options from.

--- a/packages/combo-box/src/vaadin-combo-box-items-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-items-mixin.d.ts
@@ -14,32 +14,6 @@ export declare function ComboBoxItemsMixin<TItem, T extends Constructor<HTMLElem
 
 export declare class ComboBoxItemsMixinClass<TItem> {
   /**
-   * Controls which item is automatically set to be selected, for
-   * example on Enter, when the typed filter only partially matches
-   * its label. The item that will be selected is highlighted in the
-   * dropdown while typing:
-   *
-   * - `none` (default): an item is automatically set to be selected only when the filter matches its label exactly.
-   * - `first-match`: the first item in the filtered results is automatically set to be selected.
-   * - `only-match`: the item is automatically set to be selected when filtering narrows the results to a single item.
-   *
-   * In general, an exact match is always set to be selected and takes
-   * precedence over partial matches, regardless of the mode.
-   *
-   * A partial match is only applied while the dropdown is open. For
-   * example, when auto-open is disabled with `autoOpenDisabled`, typing
-   * does not highlight a match or set it to be selected until the
-   * dropdown is opened.
-   *
-   * This feature cannot be used together with custom values, because a
-   * partial match is also a valid custom value. A partial match is not
-   * applied when custom values are allowed with `allowCustomValue`.
-   *
-   * @attr {none|first-match|only-match} partial-match-mode
-   */
-  partialMatchMode: ComboBoxPartialMatchMode;
-
-  /**
    * A full set of items to filter the visible options from.
    * The items can be of either `String` or `Object` type.
    */
@@ -85,4 +59,30 @@ export declare class ComboBoxItemsMixinClass<TItem> {
    * @attr {string} item-value-path
    */
   itemValuePath: string;
+
+  /**
+   * Controls which item is automatically set to be selected, for
+   * example on Enter, when the typed filter only partially matches
+   * its label. The item that will be selected is highlighted in the
+   * dropdown while typing:
+   *
+   * - `none` (default): an item is automatically set to be selected only when the filter matches its label exactly.
+   * - `first-match`: the first item in the filtered results is automatically set to be selected.
+   * - `only-match`: the item is automatically set to be selected when filtering narrows the results to a single item.
+   *
+   * In general, an exact match is always set to be selected and takes
+   * precedence over partial matches, regardless of the mode.
+   *
+   * A partial match is only applied while the dropdown is open. For
+   * example, when auto-open is disabled with `autoOpenDisabled`, typing
+   * does not highlight a match or set it to be selected until the
+   * dropdown is opened.
+   *
+   * This feature cannot be used together with custom values, because a
+   * partial match is also a valid custom value. A partial match is not
+   * applied when custom values are allowed with `allowCustomValue`.
+   *
+   * @attr {none|first-match|only-match} partial-match-mode
+   */
+  partialMatchMode: ComboBoxPartialMatchMode;
 }

--- a/packages/combo-box/src/vaadin-combo-box-items-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-items-mixin.d.ts
@@ -14,20 +14,26 @@ export declare function ComboBoxItemsMixin<TItem, T extends Constructor<HTMLElem
 
 export declare class ComboBoxItemsMixinClass<TItem> {
   /**
-   * Controls whether an item whose label partially matches the typed
-   * filter is automatically focused. The focused item is highlighted
-   * in the dropdown while typing and is selected when committing the
-   * value, for example on Enter press:
+   * Controls which item is automatically set to be selected, for
+   * example on Enter, when the typed filter only partially matches
+   * its label. The item that will be selected is highlighted in the
+   * dropdown while typing:
    *
-   * - `none` (default): do not focus partial matches.
-   * - `first-match`: focus the first item in the filtered results.
-   * - `only-match`: focus the item when filtering narrows the results to a single item.
+   * - `none` (default): an item is automatically set to be selected only when the filter matches its label exactly.
+   * - `first-match`: the first item in the filtered results is automatically set to be selected.
+   * - `only-match`: the item is automatically set to be selected when filtering narrows the results to a single item.
    *
-   * An item whose label matches the filter exactly is always focused,
-   * regardless of this property. Matching is case-insensitive. A partial
-   * match is not focused when `allowCustomValue` is enabled, or while
-   * the dropdown is closed. For example, with `autoOpenDisabled`, typing
-   * does not focus or select a match until the dropdown is opened.
+   * In general, an exact match is always set to be selected and takes
+   * precedence over partial matches, regardless of the mode.
+   *
+   * A partial match is only applied while the dropdown is open. For
+   * example, when auto-open is disabled with `autoOpenDisabled`, typing
+   * does not highlight a match or set it to be selected until the
+   * dropdown is opened.
+   *
+   * This feature cannot be used together with custom values, because a
+   * partial match is also a valid custom value. A partial match is not
+   * applied when custom values are allowed with `allowCustomValue`.
    *
    * @attr {none|first-match|only-match} partial-match-mode
    */

--- a/packages/combo-box/src/vaadin-combo-box-items-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-items-mixin.js
@@ -78,9 +78,9 @@ export const ComboBoxItemsMixin = (superClass) =>
          * the dropdown is closed. For example, with `autoOpenDisabled`, typing
          * does not focus or select a match until the dropdown is opened.
          *
-         * @attr {none|first-match|only-match} auto-focus-partial-match
+         * @attr {none|first-match|only-match} partial-match-mode
          */
-        autoFocusPartialMatch: {
+        partialMatchMode: {
           type: String,
           value: 'none',
         },
@@ -334,10 +334,7 @@ export const ComboBoxItemsMixin = (superClass) =>
         return -1;
       }
 
-      if (
-        this.autoFocusPartialMatch === 'first-match' ||
-        (this.autoFocusPartialMatch === 'only-match' && items.length === 1)
-      ) {
+      if (this.partialMatchMode === 'first-match' || (this.partialMatchMode === 'only-match' && items.length === 1)) {
         // Skip an item that is not yet loaded. Once the item is loaded,
         // the focused index is updated again.
         return items[0] instanceof ComboBoxPlaceholder ? -1 : 0;

--- a/packages/combo-box/src/vaadin-combo-box-items-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-items-mixin.js
@@ -63,35 +63,6 @@ export const ComboBoxItemsMixin = (superClass) =>
         },
 
         /**
-         * Controls which item is automatically set to be selected, for
-         * example on Enter, when the typed filter only partially matches
-         * its label. The item that will be selected is highlighted in the
-         * dropdown while typing:
-         *
-         * - `none` (default): an item is automatically set to be selected only when the filter matches its label exactly.
-         * - `first-match`: the first item in the filtered results is automatically set to be selected.
-         * - `only-match`: the item is automatically set to be selected when filtering narrows the results to a single item.
-         *
-         * In general, an exact match is always set to be selected and takes
-         * precedence over partial matches, regardless of the mode.
-         *
-         * A partial match is only applied while the dropdown is open. For
-         * example, when auto-open is disabled with `autoOpenDisabled`, typing
-         * does not highlight a match or set it to be selected until the
-         * dropdown is opened.
-         *
-         * This feature cannot be used together with custom values, because a
-         * partial match is also a valid custom value. A partial match is not
-         * applied when custom values are allowed with `allowCustomValue`.
-         *
-         * @attr {none|first-match|only-match} partial-match-mode
-         */
-        partialMatchMode: {
-          type: String,
-          value: 'none',
-        },
-
-        /**
          * Filtering string the user has typed into the input field.
          */
         filter: {
@@ -139,6 +110,35 @@ export const ComboBoxItemsMixin = (superClass) =>
           type: String,
           value: 'value',
           sync: true,
+        },
+
+        /**
+         * Controls which item is automatically set to be selected, for
+         * example on Enter, when the typed filter only partially matches
+         * its label. The item that will be selected is highlighted in the
+         * dropdown while typing:
+         *
+         * - `none` (default): an item is automatically set to be selected only when the filter matches its label exactly.
+         * - `first-match`: the first item in the filtered results is automatically set to be selected.
+         * - `only-match`: the item is automatically set to be selected when filtering narrows the results to a single item.
+         *
+         * In general, an exact match is always set to be selected and takes
+         * precedence over partial matches, regardless of the mode.
+         *
+         * A partial match is only applied while the dropdown is open. For
+         * example, when auto-open is disabled with `autoOpenDisabled`, typing
+         * does not highlight a match or set it to be selected until the
+         * dropdown is opened.
+         *
+         * This feature cannot be used together with custom values, because a
+         * partial match is also a valid custom value. A partial match is not
+         * applied when custom values are allowed with `allowCustomValue`.
+         *
+         * @attr {none|first-match|only-match} partial-match-mode
+         */
+        partialMatchMode: {
+          type: String,
+          value: 'none',
         },
       };
     }

--- a/packages/combo-box/src/vaadin-combo-box-items-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-items-mixin.js
@@ -63,20 +63,26 @@ export const ComboBoxItemsMixin = (superClass) =>
         },
 
         /**
-         * Controls whether an item whose label partially matches the typed
-         * filter is automatically focused. The focused item is highlighted
-         * in the dropdown while typing and is selected when committing the
-         * value, for example on Enter press:
+         * Controls which item is automatically set to be selected, for
+         * example on Enter, when the typed filter only partially matches
+         * its label. The item that will be selected is highlighted in the
+         * dropdown while typing:
          *
-         * - `none` (default): do not focus partial matches.
-         * - `first-match`: focus the first item in the filtered results.
-         * - `only-match`: focus the item when filtering narrows the results to a single item.
+         * - `none` (default): an item is automatically set to be selected only when the filter matches its label exactly.
+         * - `first-match`: the first item in the filtered results is automatically set to be selected.
+         * - `only-match`: the item is automatically set to be selected when filtering narrows the results to a single item.
          *
-         * An item whose label matches the filter exactly is always focused,
-         * regardless of this property. Matching is case-insensitive. A partial
-         * match is not focused when `allowCustomValue` is enabled, or while
-         * the dropdown is closed. For example, with `autoOpenDisabled`, typing
-         * does not focus or select a match until the dropdown is opened.
+         * In general, an exact match is always set to be selected and takes
+         * precedence over partial matches, regardless of the mode.
+         *
+         * A partial match is only applied while the dropdown is open. For
+         * example, when auto-open is disabled with `autoOpenDisabled`, typing
+         * does not highlight a match or set it to be selected until the
+         * dropdown is opened.
+         *
+         * This feature cannot be used together with custom values, because a
+         * partial match is also a valid custom value. A partial match is not
+         * applied when custom values are allowed with `allowCustomValue`.
          *
          * @attr {none|first-match|only-match} partial-match-mode
          */

--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -30,7 +30,7 @@ export {
   ComboBoxDataProviderCallback,
   ComboBoxDataProviderParams,
 } from './vaadin-combo-box-data-provider-mixin.js';
-export { ComboBoxAutoFocusPartialMatch } from './vaadin-combo-box-items-mixin.js';
+export { ComboBoxPartialMatchMode } from './vaadin-combo-box-items-mixin.js';
 export { ComboBoxDefaultItem, ComboBoxItemModel, ComboBoxRenderer } from './vaadin-combo-box-mixin.js';
 
 /**

--- a/packages/combo-box/test/partial-match-mode.test.js
+++ b/packages/combo-box/test/partial-match-mode.test.js
@@ -4,7 +4,7 @@ import { aTimeout, fixtureSync, nextRender, outsideClick } from '@vaadin/testing
 import '../src/vaadin-combo-box.js';
 import { getFocusedItemIndex } from './helpers.js';
 
-describe('auto-focus-partial-match', () => {
+describe('partial-match-mode', () => {
   let comboBox, inputElement;
 
   beforeEach(async () => {
@@ -25,7 +25,7 @@ describe('auto-focus-partial-match', () => {
     });
 
     it('should be none by default', () => {
-      expect(comboBox.autoFocusPartialMatch).to.equal('none');
+      expect(comboBox.partialMatchMode).to.equal('none');
     });
 
     it('should highlight the exact match', async () => {
@@ -67,7 +67,7 @@ describe('auto-focus-partial-match', () => {
 
   describe('first-match', () => {
     beforeEach(() => {
-      comboBox.autoFocusPartialMatch = 'first-match';
+      comboBox.partialMatchMode = 'first-match';
       comboBox.items = ['apple', 'banana', 'grapefruit', 'grape'];
     });
 
@@ -121,7 +121,7 @@ describe('auto-focus-partial-match', () => {
 
   describe('only-match', () => {
     beforeEach(() => {
-      comboBox.autoFocusPartialMatch = 'only-match';
+      comboBox.partialMatchMode = 'only-match';
       comboBox.items = ['apple', 'banana', 'grapefruit', 'grape'];
     });
 
@@ -158,7 +158,7 @@ describe('auto-focus-partial-match', () => {
   describe('autoOpenDisabled', () => {
     beforeEach(() => {
       comboBox.autoOpenDisabled = true;
-      comboBox.autoFocusPartialMatch = 'first-match';
+      comboBox.partialMatchMode = 'first-match';
       comboBox.items = ['apple', 'banana', 'grapefruit', 'grape'];
     });
 
@@ -200,7 +200,7 @@ describe('auto-focus-partial-match', () => {
     });
 
     it('should highlight the first partial match after the page is loaded', async () => {
-      comboBox.autoFocusPartialMatch = 'first-match';
+      comboBox.partialMatchMode = 'first-match';
 
       await sendKeys({ type: 'gra' });
       await aTimeout(0);
@@ -209,7 +209,7 @@ describe('auto-focus-partial-match', () => {
     });
 
     it('should highlight the only partial match after the page is loaded', async () => {
-      comboBox.autoFocusPartialMatch = 'only-match';
+      comboBox.partialMatchMode = 'only-match';
 
       await sendKeys({ type: 'ban' });
       await aTimeout(0);

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -93,7 +93,7 @@ assertType<() => void>(narrowedComboBox.open);
 assertType<() => void>(narrowedComboBox.requestContentUpdate);
 assertType<boolean>(narrowedComboBox.allowCustomValue);
 assertType<boolean>(narrowedComboBox.autofocus);
-assertType<'first-match' | 'none' | 'only-match'>(narrowedComboBox.autoFocusPartialMatch);
+assertType<'first-match' | 'none' | 'only-match'>(narrowedComboBox.partialMatchMode);
 assertType<boolean>(narrowedComboBox.autoselect);
 assertType<boolean | null | undefined>(narrowedComboBox.autoOpenDisabled);
 assertType<boolean>(narrowedComboBox.opened);

--- a/packages/multi-select-combo-box/test/partial-match-mode.test.js
+++ b/packages/multi-select-combo-box/test/partial-match-mode.test.js
@@ -4,7 +4,7 @@ import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import '../src/vaadin-multi-select-combo-box.js';
 import { getAllItems } from './helpers.js';
 
-describe('auto-focus-partial-match', () => {
+describe('partial-match-mode', () => {
   let comboBox, inputElement;
 
   function getFocusedItemIndex() {
@@ -24,7 +24,7 @@ describe('auto-focus-partial-match', () => {
     });
 
     it('should be none by default', () => {
-      expect(comboBox.autoFocusPartialMatch).to.equal('none');
+      expect(comboBox.partialMatchMode).to.equal('none');
     });
 
     it('should highlight the exact match', async () => {
@@ -60,7 +60,7 @@ describe('auto-focus-partial-match', () => {
 
   describe('first-match', () => {
     beforeEach(() => {
-      comboBox.autoFocusPartialMatch = 'first-match';
+      comboBox.partialMatchMode = 'first-match';
       comboBox.items = ['apple', 'banana', 'grapefruit', 'grape'];
     });
 
@@ -140,7 +140,7 @@ describe('auto-focus-partial-match', () => {
 
   describe('only-match', () => {
     beforeEach(() => {
-      comboBox.autoFocusPartialMatch = 'only-match';
+      comboBox.partialMatchMode = 'only-match';
       comboBox.items = ['apple', 'banana', 'grapefruit', 'grape'];
     });
 
@@ -178,7 +178,7 @@ describe('auto-focus-partial-match', () => {
   describe('autoOpenDisabled', () => {
     beforeEach(() => {
       comboBox.autoOpenDisabled = true;
-      comboBox.autoFocusPartialMatch = 'first-match';
+      comboBox.partialMatchMode = 'first-match';
       comboBox.items = ['apple', 'banana', 'grapefruit', 'grape'];
     });
 

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -89,7 +89,7 @@ assertType<() => boolean>(narrowedComboBox.checkValidity);
 assertType<() => boolean>(narrowedComboBox.validate);
 assertType<boolean>(narrowedComboBox.allowCustomValue);
 assertType<boolean | null | undefined>(narrowedComboBox.autoOpenDisabled);
-assertType<'first-match' | 'none' | 'only-match'>(narrowedComboBox.autoFocusPartialMatch);
+assertType<'first-match' | 'none' | 'only-match'>(narrowedComboBox.partialMatchMode);
 assertType<string>(narrowedComboBox.filter);
 assertType<TestComboBoxItem[] | undefined>(narrowedComboBox.filteredItems);
 assertType<TestComboBoxItem[] | undefined>(narrowedComboBox.items);


### PR DESCRIPTION
## Description

Renames `autoFocusPartialMatch` to `partialMatchMode` as decided in an internal survey

Part of #1280

## Type of change

- Refactor