### PR TITLE
feat: add --vaadin-message-user-color custom CSS property

### DIFF
--- a/packages/message-list/src/vaadin-message-mixin.d.ts
+++ b/packages/message-list/src/vaadin-message-mixin.d.ts
@@ -56,6 +56,7 @@ export declare class MessageMixinClass {
 
   /**
    * A color index to be used to render the color of the avatar.
+   * Also sets `--vaadin-message-user-color` custom CSS property.
    *
    * @attr {number} user-color-index
    */

--- a/packages/message-list/src/vaadin-message-mixin.js
+++ b/packages/message-list/src/vaadin-message-mixin.js
@@ -85,7 +85,10 @@ export const MessageMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['__avatarChanged(_avatar, userName, userAbbr, userImg, userColorIndex)'];
+      return [
+        '__avatarChanged(_avatar, userName, userAbbr, userImg, userColorIndex)',
+        '__colorIndexChanged(userColorIndex)',
+      ];
     }
 
     /** @protected */
@@ -110,6 +113,15 @@ export const MessageMixin = (superClass) =>
           img: userImg,
           colorIndex: userColorIndex,
         });
+      }
+    }
+
+    /** @private */
+    __colorIndexChanged(userColorIndex) {
+      if (userColorIndex !== undefined) {
+        this.style.setProperty('--vaadin-user-color', `var(--vaadin-user-color-${userColorIndex})`);
+      } else {
+        this.style.removeProperty('--vaadin-user-color');
       }
     }
 

--- a/packages/message-list/src/vaadin-message-mixin.js
+++ b/packages/message-list/src/vaadin-message-mixin.js
@@ -54,6 +54,7 @@ export const MessageMixin = (superClass) =>
 
         /**
          * A color index to be used to render the color of the avatar.
+         * Also sets `--vaadin-message-user-color` custom CSS property.
          *
          * @attr {number} user-color-index
          */
@@ -85,10 +86,7 @@ export const MessageMixin = (superClass) =>
     }
 
     static get observers() {
-      return [
-        '__avatarChanged(_avatar, userName, userAbbr, userImg, userColorIndex)',
-        '__colorIndexChanged(userColorIndex)',
-      ];
+      return ['__avatarChanged(_avatar, userName, userAbbr, userImg, userColorIndex)'];
     }
 
     /** @protected */
@@ -104,6 +102,20 @@ export const MessageMixin = (superClass) =>
       this.addController(this._avatarController);
     }
 
+    /** @protected */
+    updated(props) {
+      super.updated(props);
+
+      if (props.has('userColorIndex')) {
+        const index = this.userColorIndex;
+        if (index != null) {
+          this.style.setProperty('--vaadin-message-user-color', `var(--vaadin-user-color-${index})`);
+        } else {
+          this.style.removeProperty('--vaadin-message-user-color');
+        }
+      }
+    }
+
     /** @private */
     __avatarChanged(avatar, userName, userAbbr, userImg, userColorIndex) {
       if (avatar) {
@@ -113,15 +125,6 @@ export const MessageMixin = (superClass) =>
           img: userImg,
           colorIndex: userColorIndex,
         });
-      }
-    }
-
-    /** @private */
-    __colorIndexChanged(userColorIndex) {
-      if (userColorIndex !== undefined) {
-        this.style.setProperty('--vaadin-user-color', `var(--vaadin-user-color-${userColorIndex})`);
-      } else {
-        this.style.removeProperty('--vaadin-user-color');
       }
     }
 

--- a/packages/message-list/src/vaadin-message.d.ts
+++ b/packages/message-list/src/vaadin-message.d.ts
@@ -78,6 +78,7 @@ export type MessageEventMap = HTMLElementEventMap & {
  * `--vaadin-message-time-color`                |
  * `--vaadin-message-time-font-size`            |
  * `--vaadin-message-time-font-weight`          |
+ * `--vaadin-message-user-color`                |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/message-list/src/vaadin-message.js
+++ b/packages/message-list/src/vaadin-message.js
@@ -78,6 +78,7 @@ import { MessageMixin } from './vaadin-message-mixin.js';
  * `--vaadin-message-time-color`                |
  * `--vaadin-message-time-font-size`            |
  * `--vaadin-message-time-font-weight`          |
+ * `--vaadin-message-user-color`                |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/message-list/test/dom/__snapshots__/message.test.snap.js
+++ b/packages/message-list/test/dom/__snapshots__/message.test.snap.js
@@ -100,7 +100,7 @@ snapshots["vaadin-message avatar img"] =
 /* end snapshot vaadin-message avatar img */
 
 snapshots["vaadin-message avatar userColorIndex"] = 
-`<vaadin-message>
+`<vaadin-message style="--vaadin-message-user-color: var(--vaadin-user-color-2);">
   <vaadin-avatar
     aria-hidden="true"
     has-color-index=""

--- a/packages/message-list/test/message.test.js
+++ b/packages/message-list/test/message.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-message.js';
 
@@ -19,14 +19,26 @@ describe('message', () => {
     expect(customElements.get(tagName).is).to.equal(tagName);
   });
 
-  it('should expose the user color as a custom property', async () => {
+  it('should toggle the user color custom property on userColorIndex', async () => {
     message.userColorIndex = 2;
-    await nextRender();
-    expect(message.style.getPropertyValue('--vaadin-user-color')).to.equal('var(--vaadin-user-color-2)');
+    await nextUpdate(message);
+    expect(message.style.getPropertyValue('--vaadin-message-user-color')).to.equal('var(--vaadin-user-color-2)');
 
     message.userColorIndex = undefined;
-    await nextRender();
-    expect(message.style.getPropertyValue('--vaadin-user-color')).to.equal('');
+    await nextUpdate(message);
+    expect(message.style.getPropertyValue('--vaadin-message-user-color')).to.equal('');
+  });
+
+  it('should set the user color custom property for zero color index', async () => {
+    message.userColorIndex = 0;
+    await nextUpdate(message);
+    expect(message.style.getPropertyValue('--vaadin-message-user-color')).to.equal('var(--vaadin-user-color-0)');
+  });
+
+  it('should not set the user color custom property for null color index', async () => {
+    message.userColorIndex = null;
+    await nextUpdate(message);
+    expect(message.style.getPropertyValue('--vaadin-message-user-color')).to.equal('');
   });
 
   describe('attachments', () => {

--- a/packages/message-list/test/message.test.js
+++ b/packages/message-list/test/message.test.js
@@ -4,41 +4,50 @@ import sinon from 'sinon';
 import '../src/vaadin-message.js';
 
 describe('message', () => {
-  let message, tagName;
+  let message;
 
   beforeEach(() => {
     message = fixtureSync('<vaadin-message>Hello</vaadin-message>');
-    tagName = message.tagName.toLowerCase();
   });
 
-  it('should be defined in custom element registry', () => {
-    expect(customElements.get(tagName)).to.be.ok;
+  describe('custom element definition', () => {
+    let tagName;
+
+    beforeEach(() => {
+      tagName = message.tagName.toLowerCase();
+    });
+
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
+    });
+
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
+    });
   });
 
-  it('should have a valid static "is" getter', () => {
-    expect(customElements.get(tagName).is).to.equal(tagName);
-  });
+  describe('user color', () => {
+    it('should toggle the user color custom property on userColorIndex', async () => {
+      message.userColorIndex = 2;
+      await nextUpdate(message);
+      expect(message.style.getPropertyValue('--vaadin-message-user-color')).to.equal('var(--vaadin-user-color-2)');
 
-  it('should toggle the user color custom property on userColorIndex', async () => {
-    message.userColorIndex = 2;
-    await nextUpdate(message);
-    expect(message.style.getPropertyValue('--vaadin-message-user-color')).to.equal('var(--vaadin-user-color-2)');
+      message.userColorIndex = undefined;
+      await nextUpdate(message);
+      expect(message.style.getPropertyValue('--vaadin-message-user-color')).to.equal('');
+    });
 
-    message.userColorIndex = undefined;
-    await nextUpdate(message);
-    expect(message.style.getPropertyValue('--vaadin-message-user-color')).to.equal('');
-  });
+    it('should set the user color custom property for zero color index', async () => {
+      message.userColorIndex = 0;
+      await nextUpdate(message);
+      expect(message.style.getPropertyValue('--vaadin-message-user-color')).to.equal('var(--vaadin-user-color-0)');
+    });
 
-  it('should set the user color custom property for zero color index', async () => {
-    message.userColorIndex = 0;
-    await nextUpdate(message);
-    expect(message.style.getPropertyValue('--vaadin-message-user-color')).to.equal('var(--vaadin-user-color-0)');
-  });
-
-  it('should not set the user color custom property for null color index', async () => {
-    message.userColorIndex = null;
-    await nextUpdate(message);
-    expect(message.style.getPropertyValue('--vaadin-message-user-color')).to.equal('');
+    it('should not set the user color custom property for null color index', async () => {
+      message.userColorIndex = null;
+      await nextUpdate(message);
+      expect(message.style.getPropertyValue('--vaadin-message-user-color')).to.equal('');
+    });
   });
 
   describe('attachments', () => {

--- a/packages/message-list/test/message.test.js
+++ b/packages/message-list/test/message.test.js
@@ -19,6 +19,16 @@ describe('message', () => {
     expect(customElements.get(tagName).is).to.equal(tagName);
   });
 
+  it('should expose the user color as a custom property', async () => {
+    message.userColorIndex = 2;
+    await nextRender();
+    expect(message.style.getPropertyValue('--vaadin-user-color')).to.equal('var(--vaadin-user-color-2)');
+
+    message.userColorIndex = undefined;
+    await nextRender();
+    expect(message.style.getPropertyValue('--vaadin-user-color')).to.equal('');
+  });
+
   describe('attachments', () => {
     const imgUrl = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 


### PR DESCRIPTION
Depends on https://github.com/vaadin/web-components/pull/12504

Allow the whole message to be styled based on the active user color, not just the avatar.