### PR TITLE
feat: add shared deepMerge helper to component-base (CP: 25.1)

### DIFF
--- a/packages/charts/src/helpers.js
+++ b/packages/charts/src/helpers.js
@@ -9,6 +9,11 @@
  * license.
  */
 
+/**
+ * @deprecated Import `deepMerge` from `@vaadin/component-base/src/object-utils.js` instead.
+ */
+export { deepMerge } from '@vaadin/component-base/src/object-utils.js';
+
 export function inflateFunctions(config) {
   if (Array.isArray(config)) {
     config.forEach(inflateFunctions);
@@ -36,26 +41,6 @@ export function inflateFunctions(config) {
       inflateFunctions(targetProperty);
     }
   });
-}
-
-export function deepMerge(target, source) {
-  const isObject = (item) => item && typeof item === 'object' && !Array.isArray(item);
-
-  if (isObject(source) && isObject(target)) {
-    Object.keys(source).forEach((key) => {
-      if (isObject(source[key])) {
-        if (!target[key]) {
-          Object.assign(target, { [key]: {} });
-        }
-
-        deepMerge(target[key], source[key]);
-      } else {
-        Object.assign(target, { [key]: source[key] });
-      }
-    });
-  }
-
-  return target;
 }
 
 export function prepareExport(chart) {

--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -32,10 +32,11 @@ import KeyboardNavigation from 'highcharts/es-modules/Accessibility/KeyboardNavi
 import HTMLUtilities from 'highcharts/es-modules/Accessibility/Utils/HTMLUtilities.js';
 import Pointer from 'highcharts/es-modules/Core/Pointer.js';
 import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
+import { deepMerge } from '@vaadin/component-base/src/object-utils.js';
 import { get } from '@vaadin/component-base/src/path-utils.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
-import { cleanupExport, deepMerge, inflateFunctions, prepareExport } from './helpers.js';
+import { cleanupExport, inflateFunctions, prepareExport } from './helpers.js';
 
 ['exportChart', 'exportChartLocal', 'getSVG'].forEach((methodName) => {
   /* eslint-disable @typescript-eslint/no-invalid-this, prefer-arrow-callback */

--- a/packages/charts/src/vaadin-chart-series-mixin.js
+++ b/packages/charts/src/vaadin-chart-series-mixin.js
@@ -8,7 +8,7 @@
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
-import { deepMerge } from './helpers.js';
+import { deepMerge } from '@vaadin/component-base/src/object-utils.js';
 
 /**
  * @polymerMixin

--- a/packages/charts/test/chart-element.test.js
+++ b/packages/charts/test/chart-element.test.js
@@ -242,6 +242,18 @@ describe('vaadin-chart', () => {
       expect(title).to.be.ok;
       expect(title.textContent).to.be.empty;
     });
+
+    describe('ignored keys', () => {
+      afterEach(() => {
+        delete Object.prototype.injected;
+      });
+
+      it('should not copy the __proto__ key of a JSON configuration', async () => {
+        chart.updateConfiguration(JSON.parse('{"__proto__": {"injected": "yes"}}'));
+        await nextFrame();
+        expect({}.injected).to.be.undefined;
+      });
+    });
   });
 
   describe('series', () => {

--- a/packages/component-base/src/i18n-mixin.js
+++ b/packages/component-base/src/i18n-mixin.js
@@ -3,34 +3,7 @@
  * Copyright (c) 2025 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-
-function deepMerge(target, ...sources) {
-  const isArray = (item) => Array.isArray(item);
-  const isObject = (item) => item && typeof item === 'object' && !isArray(item);
-  const merge = (target, source) => {
-    if (isObject(source) && isObject(target)) {
-      Object.keys(source).forEach((key) => {
-        const sourceValue = source[key];
-        if (isObject(sourceValue)) {
-          if (!target[key]) {
-            target[key] = {};
-          }
-          merge(target[key], sourceValue);
-        } else if (isArray(sourceValue)) {
-          target[key] = [...sourceValue];
-        } else if (sourceValue !== undefined && sourceValue !== null) {
-          target[key] = sourceValue;
-        }
-      });
-    }
-  };
-
-  sources.forEach((source) => {
-    merge(target, source);
-  });
-
-  return target;
-}
+import { deepMergePartials } from './object-utils.js';
 
 /**
  * A mixin that allows to set partial I18N properties.
@@ -58,7 +31,7 @@ export const I18nMixin = (defaultI18n, superClass) =>
     constructor() {
       super();
 
-      this.i18n = deepMerge({}, defaultI18n);
+      this.i18n = deepMergePartials({}, defaultI18n);
     }
 
     /**
@@ -80,6 +53,6 @@ export const I18nMixin = (defaultI18n, superClass) =>
         return;
       }
       this.__customI18n = value;
-      this.__effectiveI18n = deepMerge({}, defaultI18n, this.__customI18n);
+      this.__effectiveI18n = deepMergePartials({}, defaultI18n, this.__customI18n);
     }
   };

--- a/packages/component-base/src/object-utils.d.ts
+++ b/packages/component-base/src/object-utils.d.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * Recursively copies own properties of `source` into `target` and returns
+ * `target`. Plain objects are merged, other values are assigned as they are.
+ * An object is plain when it inherits from `Object.prototype` or from nothing,
+ * so values such as a `Date` or a class instance are assigned, not merged.
+ *
+ * Merges a single source. Use `deepMergePartials()` to merge several objects,
+ * or to merge objects that only provide some of the properties.
+ *
+ * Both arguments are expected to be plain objects. When either of them is not,
+ * `target` is returned without changes. A property of the target that is not a
+ * plain object is replaced with the merged object, unlike the arguments.
+ *
+ * Keys that would modify `Object.prototype`, such as `__proto__`, are ignored.
+ */
+export function deepMerge<T extends object>(target: T, source: object): T;
+
+/**
+ * Recursively merges partial objects into `target` in order and returns
+ * `target`, so that a later source overrides an earlier one.
+ *
+ * Values that are `null` or `undefined` are skipped, so a source that only
+ * provides some of the properties does not remove the others. For the same
+ * reason, a property that the target already has is not replaced with an
+ * object when the source has one for the same key. Arrays are copied one level
+ * deep, so that the result does not share an array with any of the sources.
+ *
+ * Sources that are not plain objects are ignored. When `target` is not a plain
+ * object, it is returned without changes.
+ *
+ * Keys that would modify `Object.prototype`, such as `__proto__`, are ignored.
+ */
+export function deepMergePartials<T extends object>(target: T, ...sources: object[]): T;

--- a/packages/component-base/src/object-utils.js
+++ b/packages/component-base/src/object-utils.js
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * Keys that are not copied while merging, as assigning them would modify
+ * `Object.prototype` instead of the merge target, and so affect every
+ * object in the application.
+ */
+const IGNORED_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+const isPlainObject = (value) => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+};
+
+/**
+ * Merges `source` into `target`. With `partial`, the source is treated as an
+ * object that may provide only some of the properties: nullish values are
+ * skipped and arrays are copied instead of shared.
+ */
+function merge(target, source, partial) {
+  if (!isPlainObject(target) || !isPlainObject(source)) {
+    return target;
+  }
+
+  Object.keys(source).forEach((key) => {
+    if (IGNORED_KEYS.includes(key)) {
+      return;
+    }
+
+    const value = source[key];
+
+    if (isPlainObject(value)) {
+      // Only merge into an own plain object, so that the merge can never
+      // continue into an object inherited from the prototype chain.
+      if (!Object.hasOwn(target, key) || !isPlainObject(target[key])) {
+        // With `partial`, a value that the target already has is kept, so that
+        // a source property of an unexpected type does not remove a default.
+        if (partial && Object.hasOwn(target, key) && target[key]) {
+          return;
+        }
+
+        target[key] = {};
+      }
+
+      merge(target[key], value, partial);
+    } else if (partial && Array.isArray(value)) {
+      target[key] = [...value];
+    } else if (!partial || (value !== undefined && value !== null)) {
+      target[key] = value;
+    }
+  });
+
+  return target;
+}
+
+/**
+ * Recursively copies own properties of `source` into `target` and returns
+ * `target`. Plain objects are merged, other values are assigned as they are.
+ * An object is plain when it inherits from `Object.prototype` or from nothing,
+ * so values such as a `Date` or a class instance are assigned, not merged.
+ *
+ * Merges a single source. Use `deepMergePartials()` to merge several objects,
+ * or to merge objects that only provide some of the properties.
+ *
+ * Both arguments are expected to be plain objects. When either of them is not,
+ * `target` is returned without changes. A property of the target that is not a
+ * plain object is replaced with the merged object, unlike the arguments.
+ *
+ * Keys that would modify `Object.prototype`, such as `__proto__`, are ignored.
+ *
+ * @param {object} target the object to merge into, modified in place
+ * @param {object} source the object to copy the properties from
+ * @return {object} the `target` object
+ */
+export function deepMerge(target, source) {
+  return merge(target, source, false);
+}
+
+/**
+ * Recursively merges partial objects into `target` in order and returns
+ * `target`, so that a later source overrides an earlier one.
+ *
+ * Values that are `null` or `undefined` are skipped, so a source that only
+ * provides some of the properties does not remove the others. For the same
+ * reason, a property that the target already has is not replaced with an
+ * object when the source has one for the same key. Arrays are copied one level
+ * deep, so that the result does not share an array with any of the sources.
+ *
+ * Sources that are not plain objects are ignored. When `target` is not a plain
+ * object, it is returned without changes.
+ *
+ * Keys that would modify `Object.prototype`, such as `__proto__`, are ignored.
+ *
+ * @param {object} target the object to merge into, modified in place
+ * @param {...object} sources the objects to copy the properties from
+ * @return {object} the `target` object
+ */
+export function deepMergePartials(target, ...sources) {
+  sources.forEach((source) => merge(target, source, true));
+
+  return target;
+}

--- a/packages/component-base/test/i18n-mixin.test.js
+++ b/packages/component-base/test/i18n-mixin.test.js
@@ -69,6 +69,17 @@ describe('I18nMixin', () => {
     expect(element.__effectiveI18n).to.deep.equal(DEFAULT_I18N);
   });
 
+  describe('ignored keys', () => {
+    afterEach(() => {
+      delete Object.prototype.injected;
+    });
+
+    it('should not copy the __proto__ key of custom i18n', () => {
+      element.i18n = JSON.parse('{"__proto__": {"injected": "yes"}}');
+      expect({}.injected).to.be.undefined;
+    });
+  });
+
   it('should not refresh i18n when setting property to same reference', () => {
     const customI18n = { foo: 'Custom Foo' };
     element.i18n = customI18n;

--- a/packages/component-base/test/object-utils.test.js
+++ b/packages/component-base/test/object-utils.test.js
@@ -1,0 +1,203 @@
+import { expect } from '@vaadin/chai-plugins';
+import { deepMerge, deepMergePartials } from '../src/object-utils.js';
+
+describe('object-utils', () => {
+  describe('deepMerge', () => {
+    it('should copy properties from source to target', () => {
+      const target = { foo: 'foo' };
+      expect(deepMerge(target, { bar: 'bar' })).to.equal(target);
+      expect(target).to.eql({ foo: 'foo', bar: 'bar' });
+    });
+
+    it('should override existing properties of target', () => {
+      expect(deepMerge({ foo: 'foo' }, { foo: 'bar' })).to.eql({ foo: 'bar' });
+    });
+
+    it('should merge nested objects', () => {
+      const target = { foo: { bar: 'bar' } };
+      expect(deepMerge(target, { foo: { baz: 'baz' } })).to.eql({ foo: { bar: 'bar', baz: 'baz' } });
+    });
+
+    it('should not modify the source object', () => {
+      const source = { foo: { bar: 'bar' } };
+      deepMerge({ foo: { baz: 'baz' } }, source);
+      expect(source).to.eql({ foo: { bar: 'bar' } });
+    });
+
+    it('should replace a non-object target property with an object', () => {
+      expect(deepMerge({ foo: 'foo' }, { foo: { bar: 'bar' } })).to.eql({ foo: { bar: 'bar' } });
+    });
+
+    it('should assign nullish values', () => {
+      expect(deepMerge({ foo: 'foo', bar: 'bar' }, { foo: null, bar: undefined })).to.eql({
+        foo: null,
+        bar: undefined,
+      });
+    });
+
+    it('should assign the array itself', () => {
+      const array = ['foo'];
+      expect(deepMerge({}, { foo: array }).foo).to.equal(array);
+    });
+
+    it('should replace an array target property with an object', () => {
+      expect(deepMerge({ foo: ['foo'] }, { foo: { bar: 'bar' } })).to.eql({ foo: { bar: 'bar' } });
+    });
+
+    it('should assign a value that is an object but not a plain object', () => {
+      const source = { date: new Date(0), map: new Map(), instance: new (class Foo {})() };
+      const merged = deepMerge({}, source);
+      expect(merged.date).to.equal(source.date);
+      expect(merged.map).to.equal(source.map);
+      expect(merged.instance).to.equal(source.instance);
+    });
+
+    it('should merge an object without a prototype', () => {
+      const source = Object.create(null);
+      source.foo = 'foo';
+      expect(deepMerge({}, { nested: source })).to.eql({ nested: { foo: 'foo' } });
+    });
+
+    it('should return the target when the source is not an object', () => {
+      const target = { foo: 'foo' };
+      expect(deepMerge(target, 'bar')).to.equal(target);
+      expect(target).to.eql({ foo: 'foo' });
+    });
+
+    it('should return the target when the source is null', () => {
+      const target = { foo: 'foo' };
+      expect(deepMerge(target, null)).to.equal(target);
+      expect(target).to.eql({ foo: 'foo' });
+    });
+
+    it('should return the target when the source is an array', () => {
+      const target = { foo: 'foo' };
+      expect(deepMerge(target, ['bar'])).to.equal(target);
+      expect(target).to.eql({ foo: 'foo' });
+    });
+
+    it('should return the target when the target is not a plain object', () => {
+      expect(deepMerge('foo', { bar: 'bar' })).to.equal('foo');
+    });
+
+    describe('ignored keys', () => {
+      afterEach(() => {
+        delete Object.prototype.injected;
+      });
+
+      it('should not copy the __proto__ key', () => {
+        const target = deepMerge({}, JSON.parse('{"__proto__": {"injected": "yes"}}'));
+        expect({}.injected).to.be.undefined;
+        expect(Object.getPrototypeOf(target)).to.equal(Object.prototype);
+      });
+
+      it('should not copy a nested __proto__ key', () => {
+        deepMerge({}, JSON.parse('{"foo": {"__proto__": {"injected": "yes"}}}'));
+        expect({}.injected).to.be.undefined;
+      });
+
+      it('should not copy the prototype key', () => {
+        deepMerge({}, JSON.parse('{"prototype": {"injected": "yes"}}'));
+        expect({}.injected).to.be.undefined;
+      });
+
+      it('should not copy the constructor key', () => {
+        deepMerge({}, JSON.parse('{"constructor": {"prototype": {"injected": "yes"}}}'));
+        expect({}.injected).to.be.undefined;
+      });
+
+      it('should not merge into an object inherited from the prototype chain', () => {
+        // eslint-disable-next-line no-extend-native
+        Object.prototype.injected = { foo: 'foo' };
+        const target = deepMerge({}, { injected: { bar: 'bar' } });
+        expect(Object.prototype.injected).to.eql({ foo: 'foo' });
+        expect(target.injected).to.eql({ bar: 'bar' });
+      });
+    });
+  });
+
+  describe('deepMergePartials', () => {
+    it('should merge multiple sources into the target', () => {
+      expect(deepMergePartials({ foo: 'foo' }, { bar: 'bar' }, { baz: 'baz' })).to.eql({
+        foo: 'foo',
+        bar: 'bar',
+        baz: 'baz',
+      });
+    });
+
+    it('should override an earlier source with a later one', () => {
+      expect(deepMergePartials({}, { foo: 'foo' }, { foo: 'bar' })).to.eql({ foo: 'bar' });
+    });
+
+    it('should return the target', () => {
+      const target = { foo: 'foo' };
+      expect(deepMergePartials(target, { bar: 'bar' })).to.equal(target);
+    });
+
+    it('should skip nullish values', () => {
+      const source = { foo: null, bar: undefined, baz: { qux: null } };
+      const target = { foo: 'foo', bar: 'bar', baz: { qux: 'qux' } };
+      expect(deepMergePartials(target, source)).to.eql({
+        foo: 'foo',
+        bar: 'bar',
+        baz: { qux: 'qux' },
+      });
+    });
+
+    it('should assign a copy of an array', () => {
+      const array = ['foo'];
+      const merged = deepMergePartials({}, { foo: array });
+      expect(merged.foo).to.not.equal(array);
+      expect(merged.foo).to.eql(array);
+    });
+
+    it('should not share nested objects with the sources', () => {
+      const source = { foo: { bar: 'bar' } };
+      const merged = deepMergePartials({}, source);
+      expect(merged.foo).to.not.equal(source.foo);
+      expect(merged.foo).to.eql(source.foo);
+    });
+
+    it('should keep a target property that is not a plain object', () => {
+      const target = { weekdays: ['Sunday'], date: new Date(0), text: 'text' };
+      const merged = deepMergePartials(target, {
+        weekdays: { 0: 'Sunnuntai' },
+        date: { foo: 'foo' },
+        text: { foo: 'foo' },
+      });
+      expect(merged.weekdays).to.eql(['Sunday']);
+      expect(merged.date).to.eql(new Date(0));
+      expect(merged.text).to.equal('text');
+    });
+
+    it('should merge an object that the target does not have', () => {
+      expect(deepMergePartials({ foo: 'foo' }, { bar: { baz: 'baz' } })).to.eql({ foo: 'foo', bar: { baz: 'baz' } });
+    });
+
+    it('should replace a falsy target property with the merged object', () => {
+      expect(deepMergePartials({ foo: 0 }, { foo: { bar: 'bar' } })).to.eql({ foo: { bar: 'bar' } });
+    });
+
+    it('should assign a value that is an object but not a plain object', () => {
+      const source = { date: new Date(0) };
+      expect(deepMergePartials({}, source).date).to.equal(source.date);
+    });
+
+    it('should ignore a source that is not a plain object', () => {
+      const target = { foo: 'foo' };
+      expect(deepMergePartials(target, undefined, 'bar', ['baz'])).to.equal(target);
+      expect(target).to.eql({ foo: 'foo' });
+    });
+
+    describe('ignored keys', () => {
+      afterEach(() => {
+        delete Object.prototype.injected;
+      });
+
+      it('should not copy the __proto__ key with an array value', () => {
+        deepMergePartials({}, JSON.parse('{"__proto__": {"injected": ["yes"]}}'));
+        expect({}.injected).to.be.undefined;
+      });
+    });
+  });
+});

--- a/packages/component-base/test/typings/object-utils/object-utils.types.ts
+++ b/packages/component-base/test/typings/object-utils/object-utils.types.ts
@@ -1,0 +1,13 @@
+import { deepMerge, deepMergePartials } from '../../../src/object-utils.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+interface TestObject {
+  foo: string;
+  bar?: { baz: string };
+}
+
+const target: TestObject = { foo: 'foo' };
+
+assertType<TestObject>(deepMerge(target, { bar: { baz: 'baz' } }));
+assertType<TestObject>(deepMergePartials(target, { bar: { baz: 'baz' } }, { foo: 'foo' }));


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #12483 to branch 25.1.

---

> Two packages carried their own private deep merge implementation: one in
> `packages/charts/src/helpers.js` and one in `I18nMixin`. They were near
> duplicates, but not quite. The charts version assigned nullish values and
> shared arrays with the source, while the `I18nMixin` version skipped nullish
> values and copied arrays, so that an `i18n` object providing only some of the
> properties does not remove the others. Neither had tests of its own.
>
> This adds one documented helper in `component-base` and removes both copies.
>
> `packages/component-base/src/object-utils.js` exports two functions:
>
> - `deepMerge(target, source)` merges a single source and assigns values as they
>   are. Used by the chart mixins.
> - `deepMergePartials(target, ...sources)` merges several sources in order,
>   skips nullish values and copies arrays. Used by `I18nMixin`, which keeps its
>   current behaviour.
>
> Both ignore `__proto__`, `constructor` and `prototype` keys in the source, and
> never continue a merge into an object reached through the prototype chain, so
> that merging an object provided by an application can not modify
> `Object.prototype`.
>
> `deepMerge` changes behaviour in two ways:
>
> - When a property of the target is not a plain object and the source has an
>   object for the same key, the target property is now replaced with the merged
>   object. Previously the source subtree was dropped. With an invalid chart
>   configuration this can replace an array from the base config with an object,
>   where the array used to survive.
> - Only an object that inherits from `Object.prototype` or from nothing is
>   merged. A value such as a `Date`, a `Map` or a class instance is now assigned
>   as it is, where both previous implementations replaced it with an empty
>   object.
>
> `deepMergePartials()` keeps the behaviour of the `I18nMixin` implementation it
> replaces: a property that the target already has is not replaced with an
> object, so that a custom `i18n` value of an unexpected type does not remove a
> default.
>
> `deepMerge` stays exported from `packages/charts/src/helpers.js` as a
> deprecated re-export, so deep imports keep working.
>
> ---
>
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)
>
