### PR TITLE
refactor: select time-picker dropdown item by value

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -108,7 +108,7 @@ export const TimePickerMixin = (superClass) =>
     static get observers() {
       return [
         '_openedOrItemsChanged(opened, _dropdownItems)',
-        '_updateScroller(opened, _dropdownItems, _focusedIndex, _theme, _comboBoxValue)',
+        '_updateScroller(opened, _dropdownItems, _focusedIndex, _theme, value)',
         '__updateAriaAttributes(_dropdownItems, opened, inputElement)',
       ];
     }
@@ -270,7 +270,7 @@ export const TimePickerMixin = (superClass) =>
     }
 
     /** @private */
-    _updateScroller(opened, items, focusedIndex, theme, comboBoxValue) {
+    _updateScroller(opened, items, focusedIndex, theme, value) {
       if (opened) {
         this._scroller.style.maxHeight =
           getComputedStyle(this).getPropertyValue(`--${this._tagNamePrefix}-overlay-max-height`) || '65vh';
@@ -283,7 +283,7 @@ export const TimePickerMixin = (superClass) =>
         opened,
         focusedIndex,
         theme,
-        selectedItem: items?.find((item) => item.value === comboBoxValue),
+        selectedItem: items?.find((item) => item.value === value),
       });
     }
 
@@ -570,7 +570,7 @@ export const TimePickerMixin = (superClass) =>
         const timeObj = validateTime(this.__addStep(time * 1000, step), step);
         time += step;
         const formatted = this.__effectiveI18n.formatTime(timeObj);
-        generatedList.push({ label: formatted, value: formatted });
+        generatedList.push({ label: formatted, value: formatISOTime(timeObj) });
       }
 
       return generatedList;

--- a/packages/time-picker/test/i18n.test.js
+++ b/packages/time-picker/test/i18n.test.js
@@ -79,6 +79,22 @@ describe('i18n', () => {
     });
   });
 
+  describe('dropdown items', () => {
+    beforeEach(() => {
+      timePicker.i18n = strictAmPmI18n;
+    });
+
+    it('should set formatted time as item label and ISO time as item value', () => {
+      expect(timePicker._dropdownItems[10].label).to.be.equal('10:00 AM');
+      expect(timePicker._dropdownItems[10].value).to.be.equal('10:00');
+    });
+
+    it('should select the item matching the value', () => {
+      timePicker.value = '10:00';
+      expect(timePicker._scroller.selectedItem).to.equal(timePicker._dropdownItems[10]);
+    });
+  });
+
   describe('reassigned', () => {
     it('should align values of dropdown and input when i18n was reassigned', () => {
       timePicker.value = '12';


### PR DESCRIPTION
## Description

Related to #888

The scroller matched the selected item by its label, which is the text `i18n.formatTime` produces:

- Changed `__generateDropdownList()` to set the ISO time as the item `value`, keeping the formatted time as the item `label`
- Changed `_updateScroller()` to find the selected item by `value` instead of `_comboBoxValue`, which removes `_comboBoxValue` from the observer
- Added tests to `i18n.test.js` for the item `label` and `value`, and for selecting the item matching the value with a custom formatter

## Type of change

- Refactor

## How to test

1. Open `dev/time-picker.html`.
2. In the browser console, run:

   ```js
   const timePicker = document.querySelector('vaadin-time-picker');
   timePicker.i18n = { formatTime: (t) => `${t.hours}h${t.minutes}`, parseTime: (s) => { const [h, m] = s.split('h'); return { hours: h, minutes: m }; } };
   timePicker.value = '10:00';
   ```

3. Open the dropdown — the item `10h0` is selected.
