### PR TITLE
fix: use soft line breaks in message-list markdown mode

### DIFF
--- a/packages/message-list/src/vaadin-message-list-mixin.js
+++ b/packages/message-list/src/vaadin-message-list-mixin.js
@@ -186,7 +186,9 @@ export const MessageListMixin = (superClass) =>
                 @attachment-click="${(e) => this.__onAttachmentClick(e, item)}"
                 style="${ifDefined(loadingMarkdown ? 'visibility: hidden' : undefined)}"
                 >${
-                  this.markdown ? html`<vaadin-markdown .content=${item.text}></vaadin-markdown>` : item.text
+                  this.markdown
+                    ? html`<vaadin-markdown .content=${item.text} line-breaks></vaadin-markdown>`
+                    : item.text
                 }<vaadin-avatar slot="avatar"></vaadin-avatar
               ></vaadin-message>
             `,

--- a/packages/message-list/test/message-list-markdown.test.js
+++ b/packages/message-list/test/message-list-markdown.test.js
@@ -45,6 +45,19 @@ describe('message-list-markdown', () => {
     expect(messageList.querySelector('vaadin-message strong')).to.exist;
   });
 
+  it('should render single line breaks as <br> (soft line breaks)', async () => {
+    messageList.items = [{ text: 'First line\nSecond line', time: '10:00 AM', userName: 'MU' }];
+    await nextUpdate(messageList);
+    await nextFrame();
+    const markdown = messageList.querySelector('vaadin-message vaadin-markdown');
+    expect(markdown.querySelector('br')).to.exist;
+  });
+
+  it('should enable line breaks on the markdown element', () => {
+    const markdown = messageList.querySelector('vaadin-message vaadin-markdown');
+    expect(markdown.lineBreaks).to.be.true;
+  });
+
   it('should toggle markdown attribute', async () => {
     expect(messageList.hasAttribute('markdown')).to.be.true;
     messageList.markdown = false;


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/12497

- Rendered `<vaadin-markdown>` with the `line-breaks` attribute in `vaadin-message-list` so single line breaks inside a paragraph become `<br>` instead of being dropped
- Makes Markdown mode consistent with plain-text mode and with how chat/message UIs render messages
- Added tests verifying soft line breaks render as `<br>` and that `lineBreaks` is enabled

## Type of change

- Bugfix

## How to test

1. Open `dev/messages.html`
2. Add the `markdown` attribute to `<vaadin-message-list>` and add a message containing a single line break inside a paragraph
3. The line break should be preserved and rendered on a new line

Generated with [Claude Code](https://claude.ai/code)