### PR TITLE
fix: reset combo-box item renderer state when clearing content

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-item-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-item-mixin.js
@@ -125,10 +125,10 @@ export const ComboBoxItemMixin = (superClass) =>
         // When clearing the rendered content, this part needs to be manually disposed of.
         // Otherwise, using a Lit-based renderer on the same node will throw an exception or render nothing afterward.
         delete this._$litPart$;
+        this._oldRenderer = renderer;
       }
 
       if (renderer) {
-        this._oldRenderer = renderer;
         this.requestContentUpdate();
       }
     }

--- a/packages/combo-box/test/items.test.js
+++ b/packages/combo-box/test/items.test.js
@@ -2,6 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-combo-box.js';
+import { html, render } from 'lit';
 import { getAllItems, getFirstItem, setInputValue } from './helpers.js';
 
 describe('items', () => {
@@ -118,6 +119,19 @@ describe('items', () => {
       comboBox.renderer = null;
 
       expect(getFirstItem(comboBox).textContent).to.equal('foo');
+    });
+
+    it('should not keep the item label when restoring the renderer', () => {
+      const renderer = (root, _owner, { item }) => render(html`<span>${item}</span>`, root);
+      comboBox.renderer = renderer;
+      comboBox.opened = true;
+
+      comboBox.renderer = null;
+      expect(getFirstItem(comboBox).textContent).to.equal('foo');
+
+      comboBox.renderer = renderer;
+      expect(getFirstItem(comboBox).textContent).to.equal('foo');
+      expect(getFirstItem(comboBox).querySelectorAll('span')).to.have.lengthOf(1);
     });
 
     it('should clear the old content after assigning a new renderer', () => {


### PR DESCRIPTION
## Description

`ComboBoxItemMixin` tracks the previously used renderer in `_oldRenderer` to decide when the
item content needs to be cleared. That field was only updated when a renderer was set, so
after the renderer was removed it still pointed at the old function. Setting the same
renderer again then looked like "no change", the clearing branch was skipped, and the
renderer appended its content next to the default label that had been rendered in between.

- Moved the `_oldRenderer` assignment into the branch that clears the item content, so it is also updated when the renderer is removed
- Fixed the item label being rendered twice when a renderer is set, removed, and set again
- Added a test in `packages/combo-box/test/items.test.js` covering the renderer set → remove → set sequence

## Type of change

- Bugfix