### PR TITLE
refactor: hide messages via CSS until markdown component is defined

### DIFF
--- a/packages/message-list/src/vaadin-message-list-mixin.js
+++ b/packages/message-list/src/vaadin-message-list-mixin.js
@@ -165,9 +165,6 @@ export const MessageListMixin = (superClass) =>
 
     /** @private */
     _renderMessages(items) {
-      // Check if markdown component is still loading
-      const loadingMarkdown = this.markdown && !customElements.get('vaadin-markdown');
-
       render(
         html`
           ${items.map(
@@ -184,7 +181,6 @@ export const MessageListMixin = (superClass) =>
                 class="${ifDefined(item.className)}"
                 @focusin="${this._onMessageFocusIn}"
                 @attachment-click="${(e) => this.__onAttachmentClick(e, item)}"
-                style="${ifDefined(loadingMarkdown ? 'visibility: hidden' : undefined)}"
                 >${
                   this.markdown
                     ? html`<vaadin-markdown .content=${item.text} line-breaks></vaadin-markdown>`

--- a/packages/message-list/src/vaadin-message-list.js
+++ b/packages/message-list/src/vaadin-message-list.js
@@ -92,6 +92,10 @@ class MessageList extends SlotStylesMixin(MessageListMixin(ElementMixin(Themable
     const tag = this.localName;
     return [
       `
+      ${tag} vaadin-message:has(> vaadin-markdown:not(:defined)) {
+        visibility: hidden;
+      }
+
       ${tag} :where(vaadin-markdown > :is(h1, h2, h3, h4, h5, h6, p, ul, ol):first-child) {
         margin-top: 0;
       }

--- a/packages/message-list/test/message-list-markdown-import.test.js
+++ b/packages/message-list/test/message-list-markdown-import.test.js
@@ -33,7 +33,12 @@ describe('message-list-markdown dynamic import', () => {
     // Expect the markdown to not exist in DOM as such
     expect(messageList.textContent).to.not.include('**bold text**');
 
+    const message = messageList.querySelector('vaadin-message');
+    expect(getComputedStyle(message).visibility).to.equal('hidden');
+
     // Expect the markdown to be rendered as HTML eventually
     await until(() => messageList.querySelector('vaadin-message strong')?.textContent === 'bold text');
+
+    expect(getComputedStyle(message).visibility).to.equal('visible');
   });
 });


### PR DESCRIPTION
## Description

Replaced problematic inline style with `:not(:defined)` CSS selector and added a test.

## Type of change

- Refactor