### PR TITLE
feat: make message-list a flex container, add max-width custom property

### DIFF
--- a/packages/message-list/src/vaadin-message-list.d.ts
+++ b/packages/message-list/src/vaadin-message-list.d.ts
@@ -47,6 +47,13 @@ export type MessageListEventMap = HTMLElementEventMap & {
  * ----------|----------------
  * `list`    | The container wrapping messages.
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                |
+ * :--------------------------------- |
+ * `--vaadin-message-list-max-width`  |
+ * `--vaadin-message-list-padding`    |
+ *
  * See the [`<vaadin-message>`](#/elements/vaadin-message) documentation for the available
  * state attributes and stylable shadow parts of message elements.
  *

--- a/packages/message-list/src/vaadin-message-list.js
+++ b/packages/message-list/src/vaadin-message-list.js
@@ -61,6 +61,7 @@ class MessageList extends SlotStylesMixin(MessageListMixin(ElementMixin(Themable
       :host {
         display: block;
         overflow: auto;
+        box-sizing: border-box;
         padding: var(--vaadin-message-list-padding, var(--vaadin-padding-xs) 0);
         scroll-padding: var(--vaadin-message-list-padding, var(--vaadin-padding-xs) 0);
         scroll-snap-type: y proximity;
@@ -68,6 +69,13 @@ class MessageList extends SlotStylesMixin(MessageListMixin(ElementMixin(Themable
 
       :host([hidden]) {
         display: none !important;
+      }
+
+      [part='list'] {
+        display: flex;
+        flex-direction: column;
+        box-sizing: border-box;
+        min-height: 100%;
       }
 
       [part='list']::after {

--- a/packages/message-list/src/vaadin-message-list.js
+++ b/packages/message-list/src/vaadin-message-list.js
@@ -40,6 +40,13 @@ import { MessageListMixin } from './vaadin-message-list-mixin.js';
  * ----------|----------------
  * `list`    | The container wrapping messages.
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                |
+ * :--------------------------------- |
+ * `--vaadin-message-list-max-width`  |
+ * `--vaadin-message-list-padding`    |
+ *
  * See the [`<vaadin-message>`](#/elements/vaadin-message) documentation for the available
  * state attributes and stylable shadow parts of message elements.
  *
@@ -75,7 +82,10 @@ class MessageList extends SlotStylesMixin(MessageListMixin(ElementMixin(Themable
         display: flex;
         flex-direction: column;
         box-sizing: border-box;
+        width: 100%;
         min-height: 100%;
+        max-width: var(--vaadin-message-list-max-width, none);
+        margin-inline: auto;
       }
 
       [part='list']::after {

--- a/packages/message-list/test/message-list.test.js
+++ b/packages/message-list/test/message-list.test.js
@@ -85,6 +85,28 @@ describe('message-list', () => {
     expect(messageList.items).to.be.empty;
   });
 
+  describe('max width', () => {
+    let list;
+
+    beforeEach(async () => {
+      messageList.items = messages;
+      messageList.style.width = '500px';
+      messageList.style.setProperty('--vaadin-message-list-max-width', '200px');
+      list = messageList.shadowRoot.querySelector('[part="list"]');
+      await nextRender();
+    });
+
+    it('should limit the width of the list content', () => {
+      expect(list.getBoundingClientRect().width).to.equal(200);
+    });
+
+    it('should center the list content horizontally', () => {
+      const listRect = list.getBoundingClientRect();
+      const listRootRect = messageList.getBoundingClientRect();
+      expect(listRect.left - listRootRect.left).to.equal(listRootRect.right - listRect.right);
+    });
+  });
+
   describe('items property', () => {
     beforeEach(async () => {
       messageList.items = messages;


### PR DESCRIPTION
## Description

Extracted from #12490

- Changed `[part='list']` into a column flex container, so that individual messages can be aligned and sized
  - Existing visual tests pass unchanged in base, Lumo and Aura themes
- Added `--vaadin-message-list-max-width` for restricting the width of the messages and centering them in the scrolling viewport
- Added `box-sizing: border-box` to the host and the list container, so that padding does not add to width
- Added the missing custom CSS properties table to the JSDoc, which also documents the existing `--vaadin-message-list-padding`
- Added a test for the width restriction

## Type of change

- Feature

## How to test

1. Open `dev/messages.html`
2. Select the `<vaadin-message-list>` element in devtools and set `--vaadin-message-list-max-width: 300px` on it
3. The messages become narrower and are centered horizontally in the list
4. Remove the property — the messages span the full width again
