### PR TITLE
feat!: make disabled buttons and menu items accessible by default

### DIFF
--- a/dev/aura/colors.html
+++ b/dev/aura/colors.html
@@ -10,11 +10,6 @@
     <link rel="stylesheet" href="./aura-control.css" />
 
     <script type="module">
-      window.Vaadin = {};
-      window.Vaadin.featureFlags = {};
-      window.Vaadin.featureFlags.accessibleDisabledButtons = true;
-    </script>
-    <script type="module">
       import './aura-scheme-control.js';
       import './aura-color-control.js';
       import './aura-number-control.js';

--- a/dev/aura/sizes.html
+++ b/dev/aura/sizes.html
@@ -9,11 +9,6 @@
     <link rel="stylesheet" href="../../packages/aura/aura.css" />
 
     <script type="module">
-      window.Vaadin = {};
-      window.Vaadin.featureFlags = {};
-      window.Vaadin.featureFlags.accessibleDisabledButtons = true;
-    </script>
-    <script type="module">
       import '@vaadin/avatar';
       import '@vaadin/badge';
       import '@vaadin/button';

--- a/dev/context-menu.html
+++ b/dev/context-menu.html
@@ -8,11 +8,6 @@
     <script type="module" src="./common.js"></script>
 
     <script type="module">
-      window.Vaadin ??= {};
-      window.Vaadin.featureFlags ??= {};
-      window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
-    </script>
-    <script type="module">
       import '@vaadin/context-menu';
       import '@vaadin/radio-group';
       import '@vaadin/tooltip';

--- a/dev/menu-bar.html
+++ b/dev/menu-bar.html
@@ -6,11 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Menu bar</title>
     <script type="module" src="./common.js"></script>
-    <script type="module">
-      window.Vaadin ??= {};
-      window.Vaadin.featureFlags ??= {};
-      window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
-    </script>
   </head>
 
   <body>

--- a/dev/playground/button.html
+++ b/dev/playground/button.html
@@ -8,11 +8,6 @@
     <script type="module" src="../common.js"></script>
 
     <script type="module">
-      window.Vaadin = {};
-      window.Vaadin.featureFlags = {};
-      window.Vaadin.featureFlags.accessibleDisabledButtons = true;
-    </script>
-    <script type="module">
       import '@vaadin/badge';
       import '@vaadin/button';
       import '@vaadin/icon';

--- a/guidelines/a11y.md
+++ b/guidelines/a11y.md
@@ -208,21 +208,17 @@ The shared building blocks:
 `tabindex="-1"` when the host becomes disabled and restores the prior
 value when re-enabled.
 
-A disabled element stays in the accessibility tree but doesn't receive
-focus or react to hover — which means screen-reader users navigating by
-Tab can't reach it, and tooltips that would explain _why_ it's disabled
-never show. Two opt-in feature flags address this by keeping disabled
-buttons and menu items focusable and hoverable while still preventing
-activation:
-
-```js
-window.Vaadin.featureFlags.accessibleDisabledButtons = true;
-window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
-```
-
-Set them before the relevant components attach to the DOM. They're
-opt-in because the default matches platform conventions for native
-`<button disabled>`.
+By default, a disabled element stays in the accessibility tree but
+doesn't receive focus or react to hover, which means screen-reader
+users navigating by Tab can't reach it, and tooltips that would explain
+_why_ it's disabled never show. Buttons and menu items address this by
+overriding `__shouldAllowFocusWhenDisabled()` (from `TabindexMixin` /
+`ItemMixin`) to stay focusable while disabled, while still preventing
+activation. The same override also makes the element hoverable: it sets
+a private CSS property (`--_vaadin-button-disabled-pointer-events` /
+`--_vaadin-item-disabled-pointer-events`) that the disabled styles read
+as `pointer-events`, falling back to `none` for components that keep
+the default.
 
 ## Screen readers
 

--- a/packages/button/src/vaadin-button.d.ts
+++ b/packages/button/src/vaadin-button.d.ts
@@ -56,19 +56,10 @@ import { ButtonMixin } from './vaadin-button-mixin.js';
  */
 declare class Button extends ButtonMixin(ElementMixin(ThemableMixin(HTMLElement))) {
   /**
-   * When disabled, the button is rendered as "dimmed".
-   *
-   * By default, disabled buttons are not focusable and don't react to hover.
-   * As a result, they are hidden from assistive technologies, and it's not
-   * possible to show a tooltip to explain why they are disabled. This can
-   * be addressed by enabling the feature flag `accessibleDisabledButtons`,
-   * which makes disabled buttons focusable and hoverable, while still
-   * preventing them from being activated:
-   *
-   * ```js
-   * // Set before any button is attached to the DOM.
-   * window.Vaadin.featureFlags.accessibleDisabledButtons = true
-   * ```
+   * When disabled, the button is rendered as "dimmed" and prevented
+   * from being activated. Disabled buttons remain focusable and
+   * hoverable, so they stay visible to assistive technologies and
+   * can show a tooltip to explain why they are disabled.
    */
   disabled: boolean;
 }

--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -76,19 +76,10 @@ class Button extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInj
   static get properties() {
     return {
       /**
-       * When disabled, the button is rendered as "dimmed".
-       *
-       * By default, disabled buttons are not focusable and don't react to hover.
-       * As a result, they are hidden from assistive technologies, and it's not
-       * possible to show a tooltip to explain why they are disabled. This can
-       * be addressed by enabling the feature flag `accessibleDisabledButtons`,
-       * which makes disabled buttons focusable and hoverable, while still
-       * preventing them from being activated:
-       *
-       * ```js
-       * // Set before any button is attached to the DOM.
-       * window.Vaadin.featureFlags.accessibleDisabledButtons = true
-       * ```
+       * When disabled, the button is rendered as "dimmed" and prevented
+       * from being activated. Disabled buttons remain focusable and
+       * hoverable, so they stay visible to assistive technologies and
+       * can show a tooltip to explain why they are disabled.
        */
       disabled: {
         type: Boolean,
@@ -129,7 +120,7 @@ class Button extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInj
 
   /** @override */
   __shouldAllowFocusWhenDisabled() {
-    return window.Vaadin.featureFlags.accessibleDisabledButtons;
+    return true;
   }
 }
 

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -136,58 +136,6 @@ describe('vaadin-button', () => {
       await resetMouse();
     });
 
-    it('should prevent programmatic focus when disabled', () => {
-      lastGlobalFocusable.focus();
-      button.focus();
-      expect(document.activeElement).to.equal(lastGlobalFocusable);
-    });
-
-    it('should prevent pointer focus when disabled', async () => {
-      await sendMouseToElement({ type: 'click', element: button });
-      expect(document.activeElement).to.equal(document.body);
-    });
-
-    it('should prevent keyboard focus when disabled', async () => {
-      await sendKeys({ press: 'Tab' });
-      expect(document.activeElement).to.equal(lastGlobalFocusable);
-    });
-
-    ['mousedown', 'mouseup', 'click', 'dblclick', 'keypress', 'keydown', 'keyup'].forEach((eventType) => {
-      it(`should suppress ${eventType} events when disabled`, () => {
-        const spy = sinon.spy();
-        button.addEventListener(eventType, spy, true);
-        fire(button, eventType);
-        expect(spy.called).to.be.false;
-      });
-    });
-  });
-
-  describe('disabled and accessible', () => {
-    let lastGlobalFocusable: HTMLInputElement;
-
-    before(() => {
-      window.Vaadin.featureFlags ??= {};
-      window.Vaadin.featureFlags.accessibleDisabledButtons = true;
-    });
-
-    after(() => {
-      window.Vaadin.featureFlags!.accessibleDisabledButtons = false;
-    });
-
-    beforeEach(async () => {
-      [button, lastGlobalFocusable] = fixtureSync(
-        `<div>
-          <vaadin-button disabled>Press me</vaadin-button>
-          <input id="last-global-focusable" />
-        </div>`,
-      ).children as unknown as [Button, HTMLInputElement];
-      await nextRender();
-    });
-
-    afterEach(async () => {
-      await resetMouse();
-    });
-
     it('should allow programmatic focus when disabled', () => {
       button.focus();
       expect(document.activeElement).to.equal(button);
@@ -204,6 +152,15 @@ describe('vaadin-button', () => {
 
       await sendKeys({ press: 'Tab' });
       expect(document.activeElement).to.equal(lastGlobalFocusable);
+    });
+
+    ['mousedown', 'mouseup', 'click', 'dblclick', 'keypress', 'keydown', 'keyup'].forEach((eventType) => {
+      it(`should suppress ${eventType} events when disabled`, () => {
+        const spy = sinon.spy();
+        button.addEventListener(eventType, spy, true);
+        fire(button, eventType);
+        expect(spy.called).to.be.false;
+      });
     });
   });
 });

--- a/packages/button/test/dom/__snapshots__/button.test.snap.js
+++ b/packages/button/test/dom/__snapshots__/button.test.snap.js
@@ -4,6 +4,7 @@ export const snapshots = {};
 snapshots["vaadin-button host default"] = 
 `<vaadin-button
   role="button"
+  style="--_vaadin-button-disabled-pointer-events: auto;"
   tabindex="0"
 >
   Confirm
@@ -16,7 +17,8 @@ snapshots["vaadin-button host disabled"] =
   aria-disabled="true"
   disabled=""
   role="button"
-  tabindex="-1"
+  style="--_vaadin-button-disabled-pointer-events: auto;"
+  tabindex="1"
 >
   Confirm
 </vaadin-button>
@@ -26,6 +28,7 @@ snapshots["vaadin-button host disabled"] =
 snapshots["vaadin-button host tabIndex"] = 
 `<vaadin-button
   role="button"
+  style="--_vaadin-button-disabled-pointer-events: auto;"
   tabindex="1"
 >
   Confirm
@@ -36,6 +39,7 @@ snapshots["vaadin-button host tabIndex"] =
 snapshots["vaadin-button host tabindex"] = 
 `<vaadin-button
   role="button"
+  style="--_vaadin-button-disabled-pointer-events: auto;"
   tabindex="1"
 >
   Confirm
@@ -47,6 +51,7 @@ snapshots["vaadin-button host focused"] =
 `<vaadin-button
   focused=""
   role="button"
+  style="--_vaadin-button-disabled-pointer-events: auto;"
   tabindex="0"
 >
   Confirm
@@ -59,6 +64,7 @@ snapshots["vaadin-button host focus-ring"] =
   focus-ring=""
   focused=""
   role="button"
+  style="--_vaadin-button-disabled-pointer-events: auto;"
   tabindex="0"
 >
   Confirm
@@ -70,6 +76,7 @@ snapshots["vaadin-button host active"] =
 `<vaadin-button
   active=""
   role="button"
+  style="--_vaadin-button-disabled-pointer-events: auto;"
   tabindex="0"
 >
   Confirm

--- a/packages/context-menu/src/vaadin-context-menu-item.js
+++ b/packages/context-menu/src/vaadin-context-menu-item.js
@@ -79,7 +79,7 @@ class ContextMenuItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(Lumo
 
   /** @override */
   __shouldAllowFocusWhenDisabled() {
-    return window.Vaadin.featureFlags.accessibleDisabledMenuItems;
+    return true;
   }
 }
 

--- a/packages/context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu.d.ts
@@ -114,19 +114,10 @@ export interface ContextMenuEventMap<TItem extends ContextMenuItemData = Context
  *
  * #### Disabled menu items
  *
- * When disabled, menu items are rendered as "dimmed".
- *
- * By default, disabled items are not focusable and don't react to hover.
- * As a result, they are hidden from assistive technologies, and it's not
- * possible to show a tooltip to explain why they are disabled. This can
- * be addressed by enabling the feature flag `accessibleDisabledMenuItems`,
- * which makes disabled items focusable and hoverable, while still
- * preventing them from being activated:
- *
- * ```js
- * // Set before any context menu is attached to the DOM.
- * window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
- * ```
+ * When disabled, menu items are rendered as "dimmed" and prevented
+ * from being activated. Disabled items remain focusable and hoverable,
+ * so they stay visible to assistive technologies and can show a
+ * tooltip to explain why they are disabled.
  *
  * #### Item tooltips
  *

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -56,19 +56,10 @@ import { ContextMenuMixin } from './vaadin-context-menu-mixin.js';
  *
  * #### Disabled menu items
  *
- * When disabled, menu items are rendered as "dimmed".
- *
- * By default, disabled items are not focusable and don't react to hover.
- * As a result, they are hidden from assistive technologies, and it's not
- * possible to show a tooltip to explain why they are disabled. This can
- * be addressed by enabling the feature flag `accessibleDisabledMenuItems`,
- * which makes disabled items focusable and hoverable, while still
- * preventing them from being activated:
- *
- * ```js
- * // Set before any context menu is attached to the DOM.
- * window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
- * ```
+ * When disabled, menu items are rendered as "dimmed" and prevented
+ * from being activated. Disabled items remain focusable and hoverable,
+ * so they stay visible to assistive technologies and can show a
+ * tooltip to explain why they are disabled.
  *
  * #### Item tooltips
  *

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -419,8 +419,8 @@ export const ItemsMixin = (superClass) =>
         }
       }
 
-      // Only reachable with `accessibleDisabledMenuItems` enabled (disabled
-      // items otherwise have `pointer-events: none` and never receive mouseover).
+      // Disabled items are hoverable but never open a sub-menu, so close
+      // an expanded sibling sub-menu when the pointer moves onto one.
       if (item?.disabled) {
         subMenu.close();
       }

--- a/packages/context-menu/test/accessible-disabled-menu-items.test.js
+++ b/packages/context-menu/test/accessible-disabled-menu-items.test.js
@@ -9,15 +9,6 @@ import { activateItem, getMenuItems, getSubMenu, openMenu } from './helpers.js';
 describe('accessible disabled menu items', () => {
   let rootMenu, subMenu, target, items;
 
-  before(() => {
-    window.Vaadin.featureFlags ??= {};
-    window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
-  });
-
-  after(() => {
-    window.Vaadin.featureFlags.accessibleDisabledMenuItems = false;
-  });
-
   beforeEach(async () => {
     // Firefox: when a previous test ends with focus on an overlay item
     // that then gets removed during fixture teardown, element.focus()
@@ -115,38 +106,5 @@ describe('accessible disabled menu items', () => {
 
   it('should set --_vaadin-item-disabled-pointer-events on disabled item', () => {
     expect(items[1].style.getPropertyValue('--_vaadin-item-disabled-pointer-events')).to.equal('auto');
-  });
-});
-
-describe('accessible disabled menu items (feature flag disabled)', () => {
-  let rootMenu, target, items;
-
-  beforeEach(async () => {
-    const wrapper = fixtureSync(`
-      <div>
-        <input id="first-global-focusable" />
-        <vaadin-context-menu>
-          <button id="target"></button>
-        </vaadin-context-menu>
-      </div>
-    `);
-    rootMenu = wrapper.querySelector('vaadin-context-menu');
-    rootMenu.openOn = isTouch ? 'click' : 'mouseover';
-    target = rootMenu.firstElementChild;
-    rootMenu.items = [{ text: 'Item 0' }, { text: 'Item 1', disabled: true }, { text: 'Item 2' }];
-    await nextRender();
-    await openMenu(target);
-    items = getMenuItems(rootMenu);
-  });
-
-  it('should not allow programmatic focus on disabled item', () => {
-    items[1].focus();
-    expect(document.activeElement).to.not.equal(items[1]);
-  });
-
-  it('should skip disabled items in arrow key navigation', async () => {
-    items[0].focus();
-    await sendKeys({ press: 'ArrowDown' });
-    expect(document.activeElement).to.equal(items[2]);
   });
 });

--- a/packages/context-menu/test/items-interactions.test.js
+++ b/packages/context-menu/test/items-interactions.test.js
@@ -324,7 +324,7 @@ describe('items interactions', () => {
       expect(items[0].hasAttribute('focus-ring')).to.be.true;
     });
 
-    it('should focus first non-disabled item after re-opening when using components', async () => {
+    it('should focus first item after re-opening even if it is disabled when using components', async () => {
       rootMenu.items[3].children[0].disabled = true;
 
       const rootItem = getMenuItems(rootMenu)[3];
@@ -346,7 +346,7 @@ describe('items interactions', () => {
 
       // Re-open sub-menu and check focus
       await openMenu(rootItem);
-      expect(items[1].hasAttribute('focus-ring')).to.be.true;
+      expect(items[0].hasAttribute('focus-ring')).to.be.true;
     });
   });
 

--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -23,6 +23,7 @@ snapshots["vaadin-crud host default"] =
     <vaadin-button
       role="button"
       slot="cancel-button"
+      style="--_vaadin-button-disabled-pointer-events: auto;"
       tabindex="0"
       theme="tertiary"
     >
@@ -32,6 +33,7 @@ snapshots["vaadin-crud host default"] =
       hidden=""
       role="button"
       slot="reject-button"
+      style="--_vaadin-button-disabled-pointer-events: auto;"
       tabindex="0"
       theme="error tertiary"
     >
@@ -40,6 +42,7 @@ snapshots["vaadin-crud host default"] =
     <vaadin-button
       role="button"
       slot="confirm-button"
+      style="--_vaadin-button-disabled-pointer-events: auto;"
       tabindex="0"
       theme="primary"
     >
@@ -66,6 +69,7 @@ snapshots["vaadin-crud host default"] =
     <vaadin-button
       role="button"
       slot="cancel-button"
+      style="--_vaadin-button-disabled-pointer-events: auto;"
       tabindex="0"
       theme="tertiary"
     >
@@ -75,6 +79,7 @@ snapshots["vaadin-crud host default"] =
       hidden=""
       role="button"
       slot="reject-button"
+      style="--_vaadin-button-disabled-pointer-events: auto;"
       tabindex="0"
       theme="error tertiary"
     >
@@ -83,6 +88,7 @@ snapshots["vaadin-crud host default"] =
     <vaadin-button
       role="button"
       slot="confirm-button"
+      style="--_vaadin-button-disabled-pointer-events: auto;"
       tabindex="0"
       theme="primary error"
     >
@@ -213,6 +219,7 @@ snapshots["vaadin-crud host default"] =
       <vaadin-crud-edit
         aria-label="Edit"
         role="button"
+        style="--_vaadin-button-disabled-pointer-events: auto;"
         tabindex="0"
       >
       </vaadin-crud-edit>
@@ -221,6 +228,7 @@ snapshots["vaadin-crud host default"] =
   <vaadin-button
     role="button"
     slot="new-button"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
   >
     New item
@@ -235,7 +243,8 @@ snapshots["vaadin-crud host default"] =
     disabled=""
     role="button"
     slot="save-button"
-    tabindex="-1"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
+    tabindex="0"
     theme="primary"
   >
     Save
@@ -243,6 +252,7 @@ snapshots["vaadin-crud host default"] =
   <vaadin-button
     role="button"
     slot="cancel-button"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="tertiary"
   >
@@ -252,6 +262,7 @@ snapshots["vaadin-crud host default"] =
     hidden=""
     role="button"
     slot="delete-button"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="tertiary error"
   >

--- a/packages/login/test/dom/__snapshots__/login-form.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-form.test.snap.js
@@ -94,6 +94,7 @@ snapshots["vaadin-login-form host default"] =
   <vaadin-button
     role="button"
     slot="submit"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="primary submit"
   >
@@ -102,6 +103,7 @@ snapshots["vaadin-login-form host default"] =
   <vaadin-button
     role="button"
     slot="forgot-password"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="tertiary small"
   >
@@ -214,6 +216,7 @@ snapshots["vaadin-login-form host required"] =
   <vaadin-button
     role="button"
     slot="submit"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="primary submit"
   >
@@ -222,6 +225,7 @@ snapshots["vaadin-login-form host required"] =
   <vaadin-button
     role="button"
     slot="forgot-password"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="tertiary small"
   >
@@ -324,6 +328,7 @@ snapshots["vaadin-login-form host i18n"] =
   <vaadin-button
     role="button"
     slot="submit"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="primary submit"
   >
@@ -332,6 +337,7 @@ snapshots["vaadin-login-form host i18n"] =
   <vaadin-button
     role="button"
     slot="forgot-password"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="tertiary small"
   >
@@ -434,6 +440,7 @@ snapshots["vaadin-login-form host i18n-partial"] =
   <vaadin-button
     role="button"
     slot="submit"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="primary submit"
   >
@@ -442,6 +449,7 @@ snapshots["vaadin-login-form host i18n-partial"] =
   <vaadin-button
     role="button"
     slot="forgot-password"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="tertiary small"
   >
@@ -554,6 +562,7 @@ snapshots["vaadin-login-form host i18n-required"] =
   <vaadin-button
     role="button"
     slot="submit"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="primary submit"
   >
@@ -562,6 +571,7 @@ snapshots["vaadin-login-form host i18n-required"] =
   <vaadin-button
     role="button"
     slot="forgot-password"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="tertiary small"
   >
@@ -664,6 +674,7 @@ snapshots["vaadin-login-form host noForgotPassword"] =
   <vaadin-button
     role="button"
     slot="submit"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="primary submit"
   >
@@ -673,6 +684,7 @@ snapshots["vaadin-login-form host noForgotPassword"] =
     hidden=""
     role="button"
     slot="forgot-password"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="tertiary small"
   >

--- a/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
@@ -101,6 +101,7 @@ snapshots["vaadin-login-overlay host default"] =
   <vaadin-button
     role="button"
     slot="submit"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="primary submit"
   >
@@ -109,6 +110,7 @@ snapshots["vaadin-login-overlay host default"] =
   <vaadin-button
     role="button"
     slot="forgot-password"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="tertiary small"
   >
@@ -226,6 +228,7 @@ snapshots["vaadin-login-overlay host i18n"] =
   <vaadin-button
     role="button"
     slot="submit"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="primary submit"
   >
@@ -234,6 +237,7 @@ snapshots["vaadin-login-overlay host i18n"] =
   <vaadin-button
     role="button"
     slot="forgot-password"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="tertiary small"
   >
@@ -351,6 +355,7 @@ snapshots["vaadin-login-overlay host i18n-partial"] =
   <vaadin-button
     role="button"
     slot="submit"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="primary submit"
   >
@@ -359,6 +364,7 @@ snapshots["vaadin-login-overlay host i18n-partial"] =
   <vaadin-button
     role="button"
     slot="forgot-password"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
     theme="tertiary small"
   >

--- a/packages/menu-bar/src/vaadin-menu-bar-item.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-item.js
@@ -50,7 +50,7 @@ class MenuBarItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInje
 
   /** @override */
   __shouldAllowFocusWhenDisabled() {
-    return window.Vaadin.featureFlags.accessibleDisabledMenuItems;
+    return true;
   }
 }
 

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.d.ts
@@ -123,23 +123,10 @@ export declare class MenuBarMixinClass<TItem extends MenuBarItem = MenuBarItem> 
    *
    * #### Disabled items
    *
-   * When disabled, menu bar items are rendered as "dimmed".
-   *
-   * By default, disabled items are not focusable and don't react to hover.
-   * As a result, they are hidden from assistive technologies, and it's not
-   * possible to show a tooltip to explain why they are disabled. This can be
-   * addressed by enabling several feature flags, which makes disabled items
-   * focusable and hoverable, while still preventing them from being activated:
-   *
-   * ```js
-   * // Allow focus and hover interactions with disabled menu bar root items (buttons)
-   * window.Vaadin.featureFlags.accessibleDisabledButtons = true;
-   *
-   * // Allow focus and hover interactions with disabled menu bar sub-menu items
-   * window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
-   * ```
-   *
-   * Both flags must be set before any menu bar is attached to the DOM.
+   * When disabled, menu bar items are rendered as "dimmed" and prevented
+   * from being activated. Disabled items remain focusable and hoverable,
+   * so they stay visible to assistive technologies and can show a
+   * tooltip to explain why they are disabled.
    *
    * #### Item tooltips
    *

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -128,23 +128,10 @@ export const MenuBarMixin = (superClass) =>
          *
          * #### Disabled items
          *
-         * When disabled, menu bar items are rendered as "dimmed".
-         *
-         * By default, disabled items are not focusable and don't react to hover.
-         * As a result, they are hidden from assistive technologies, and it's not
-         * possible to show a tooltip to explain why they are disabled. This can be
-         * addressed by enabling several feature flags, which makes disabled items
-         * focusable and hoverable, while still preventing them from being activated:
-         *
-         * ```js
-         * // Allow focus and hover interactions with disabled menu bar root items (buttons)
-         * window.Vaadin.featureFlags.accessibleDisabledButtons = true;
-         *
-         * // Allow focus and hover interactions with disabled menu bar sub-menu items
-         * window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
-         * ```
-         *
-         * Both flags must be set before any menu bar is attached to the DOM.
+         * When disabled, menu bar items are rendered as "dimmed" and prevented
+         * from being activated. Disabled items remain focusable and hoverable,
+         * so they stay visible to assistive technologies and can show a
+         * tooltip to explain why they are disabled.
          *
          * #### Item tooltips
          *

--- a/packages/menu-bar/test/accessible-disabled-buttons.test.js
+++ b/packages/menu-bar/test/accessible-disabled-buttons.test.js
@@ -6,15 +6,6 @@ import '../src/vaadin-menu-bar.js';
 describe('accessible disabled buttons', () => {
   let menuBar, buttons;
 
-  before(() => {
-    window.Vaadin.featureFlags ??= {};
-    window.Vaadin.featureFlags.accessibleDisabledButtons = true;
-  });
-
-  after(() => {
-    window.Vaadin.featureFlags.accessibleDisabledButtons = false;
-  });
-
   beforeEach(async () => {
     menuBar = fixtureSync('<vaadin-menu-bar></vaadin-menu-bar>');
     menuBar.items = [

--- a/packages/menu-bar/test/accessible-disabled-menu-items.test.js
+++ b/packages/menu-bar/test/accessible-disabled-menu-items.test.js
@@ -7,15 +7,6 @@ import '../src/vaadin-menu-bar.js';
 describe('accessible disabled menu items', () => {
   let menuBar, buttons, subMenu;
 
-  before(() => {
-    window.Vaadin.featureFlags ??= {};
-    window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
-  });
-
-  after(() => {
-    window.Vaadin.featureFlags.accessibleDisabledMenuItems = false;
-  });
-
   beforeEach(async () => {
     menuBar = fixtureSync('<vaadin-menu-bar></vaadin-menu-bar>');
     menuBar.items = [

--- a/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
+++ b/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
@@ -17,6 +17,7 @@ snapshots["menu-bar basic"] =
     class="home"
     first-visible=""
     role="menuitem"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
   >
     Home
@@ -25,6 +26,7 @@ snapshots["menu-bar basic"] =
     aria-expanded="false"
     aria-haspopup="true"
     role="menuitem"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
   >
     Reports
@@ -33,7 +35,8 @@ snapshots["menu-bar basic"] =
     aria-disabled="true"
     disabled=""
     role="menuitem"
-    tabindex="-1"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
+    tabindex="0"
   >
     Dashboard
   </vaadin-menu-bar-button>
@@ -41,9 +44,13 @@ snapshots["menu-bar basic"] =
     class="help"
     last-visible=""
     role="menuitem"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
   >
-    <vaadin-menu-bar-item aria-selected="false">
+    <vaadin-menu-bar-item
+      aria-selected="false"
+      style="--_vaadin-item-disabled-pointer-events: auto;"
+    >
       <strong>
         Help
       </strong>
@@ -56,6 +63,7 @@ snapshots["menu-bar basic"] =
     hidden=""
     role="menuitem"
     slot="overflow"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
   >
     <div aria-hidden="true">
@@ -90,6 +98,7 @@ snapshots["menu-bar opened"] =
           aria-haspopup="false"
           aria-selected="false"
           role="menuitem"
+          style="--_vaadin-item-disabled-pointer-events: auto;"
           tabindex="0"
         >
           View Reports
@@ -99,6 +108,7 @@ snapshots["menu-bar opened"] =
           aria-selected="false"
           class="generate reports"
           role="menuitem"
+          style="--_vaadin-item-disabled-pointer-events: auto;"
           tabindex="-1"
         >
           Generate Report
@@ -115,6 +125,7 @@ snapshots["menu-bar opened"] =
     class="home"
     first-visible=""
     role="menuitem"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
   >
     Home
@@ -125,6 +136,7 @@ snapshots["menu-bar opened"] =
     aria-haspopup="true"
     expanded=""
     role="menuitem"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
   >
     Reports
@@ -133,7 +145,8 @@ snapshots["menu-bar opened"] =
     aria-disabled="true"
     disabled=""
     role="menuitem"
-    tabindex="-1"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
+    tabindex="0"
   >
     Dashboard
   </vaadin-menu-bar-button>
@@ -141,9 +154,13 @@ snapshots["menu-bar opened"] =
     class="help"
     last-visible=""
     role="menuitem"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
   >
-    <vaadin-menu-bar-item aria-selected="false">
+    <vaadin-menu-bar-item
+      aria-selected="false"
+      style="--_vaadin-item-disabled-pointer-events: auto;"
+    >
       <strong>
         Help
       </strong>
@@ -156,6 +173,7 @@ snapshots["menu-bar opened"] =
     hidden=""
     role="menuitem"
     slot="overflow"
+    style="--_vaadin-button-disabled-pointer-events: auto;"
     tabindex="0"
   >
     <div aria-hidden="true">

--- a/packages/menu-bar/test/keyboard-navigation.test.js
+++ b/packages/menu-bar/test/keyboard-navigation.test.js
@@ -56,14 +56,14 @@ describe('keyboard navigation', () => {
           expect(buttons[0].hasAttribute('focused')).to.be.true;
         });
 
-        it('should move focus to second button if first is disabled on Home keydown', async () => {
+        it('should move focus to first button on Home keydown even if it is disabled', async () => {
           menu.items[0].disabled = true;
           updateItemsAndButtons();
           buttons[3].focus();
-          const spy = sinon.spy(buttons[1], 'focus');
+          const spy = sinon.spy(buttons[0], 'focus');
           await sendKeys({ press: 'Home' });
           expect(spy.calledOnce).to.be.true;
-          expect(buttons[1].hasAttribute('focused')).to.be.true;
+          expect(buttons[0].hasAttribute('focused')).to.be.true;
         });
 
         it('should move focus to last button on End keydown', async () => {
@@ -74,14 +74,14 @@ describe('keyboard navigation', () => {
           expect(buttons[3].hasAttribute('focused')).to.be.true;
         });
 
-        it('should move focus to the closest enabled button if last is disabled on End keydown', async () => {
+        it('should move focus to last button on End keydown even if it is disabled', async () => {
           menu.items[3].disabled = true;
           updateItemsAndButtons();
           buttons[0].focus();
-          const spy = sinon.spy(buttons[1], 'focus');
+          const spy = sinon.spy(buttons[3], 'focus');
           await sendKeys({ press: 'End' });
           expect(spy.calledOnce).to.be.true;
-          expect(buttons[1].hasAttribute('focused')).to.be.true;
+          expect(buttons[3].hasAttribute('focused')).to.be.true;
         });
 
         it('should move focus to first button on Arrow Right, if last button has focus', async () => {
@@ -233,10 +233,10 @@ describe('keyboard navigation', () => {
         expect(buttons[0].hasAttribute('focused')).to.be.true;
       });
 
-      it('should move focus to fourth button if third is disabled on Tab keydown', async () => {
+      it('should move focus to third button on Tab keydown even if it is disabled', async () => {
         buttons[1].focus();
         await sendKeys({ press: 'Tab' });
-        expect(buttons[3].hasAttribute('focused')).to.be.true;
+        expect(buttons[2].hasAttribute('focused')).to.be.true;
       });
 
       it('should move focus out of the menu bar on last button Tab keydown', async () => {
@@ -492,7 +492,7 @@ describe('keyboard navigation', () => {
         expect(document.activeElement).to.equal(firstGlobalFocusable);
       });
 
-      it('should move focus out of the menu bar on last available submenu item Tab', async () => {
+      it('should move focus to next disabled button on submenu item Tab', async () => {
         menu.items[3].disabled = true;
         updateItemsAndButtons();
 
@@ -502,15 +502,15 @@ describe('keyboard navigation', () => {
         expect(subMenu.opened).to.be.true;
         expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
-        // Tab outside the menu bar (since next button is disabled)
+        // Tab moves focus to the next button even though it is disabled
         await sendKeys({ press: 'Tab' });
         await nextRender();
 
         expect(subMenu.opened).to.be.false;
-        expect(document.activeElement).to.equal(lastGlobalFocusable);
+        expect(document.activeElement).to.equal(buttons[3]);
       });
 
-      it('should move focus out of the menu bar on first available submenu item Tab', async () => {
+      it('should move focus to previous disabled button on submenu item Shift Tab', async () => {
         menu.items[0].disabled = true;
         menu.items[1].disabled = true;
         updateItemsAndButtons();
@@ -521,12 +521,12 @@ describe('keyboard navigation', () => {
         expect(subMenu.opened).to.be.true;
         expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
-        // Tab outside the menu bar (since previous buttons are disabled)
+        // Shift + Tab moves focus to the previous button even though it is disabled
         await sendKeys({ press: 'Shift+Tab' });
         await nextRender();
 
         expect(subMenu.opened).to.be.false;
-        expect(document.activeElement).to.equal(firstGlobalFocusable);
+        expect(document.activeElement).to.equal(buttons[1]);
       });
     });
   });

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -78,14 +78,10 @@ describe('root menu layout', () => {
     });
   });
 
-  it('should set tabindex to 0 when the button is not disabled in tab navigation', () => {
+  it('should set tabindex to 0 on all buttons in tab navigation', () => {
     menu.tabNavigation = true;
     buttons.forEach((btn) => {
-      if (btn.disabled) {
-        expect(btn.getAttribute('tabindex')).to.equal('-1');
-      } else {
-        expect(btn.getAttribute('tabindex')).to.equal('0');
-      }
+      expect(btn.getAttribute('tabindex')).to.equal('0');
     });
   });
 

--- a/packages/menu-bar/test/sub-menu.test.js
+++ b/packages/menu-bar/test/sub-menu.test.js
@@ -201,21 +201,21 @@ describe('sub-menu', () => {
     expect(items[0].hasAttribute('focus-ring')).to.be.true;
   });
 
-  it('should focus first non-disabled item after re-opening when using components', async () => {
+  it('should focus first item after re-opening even if it is disabled when using components', async () => {
     menu.items[2].children[0].disabled = true;
 
     arrowDown(buttons[2]);
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
 
     const items = subMenuOverlay._contentRoot.querySelectorAll('vaadin-menu-bar-item');
-    expect(items[1].hasAttribute('focus-ring')).to.be.true;
+    expect(items[0].hasAttribute('focus-ring')).to.be.true;
 
     // Close and re-open
-    esc(items[1]);
+    esc(items[0]);
     arrowDown(buttons[2]);
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
 
-    expect(items[1].hasAttribute('focus-ring')).to.be.true;
+    expect(items[0].hasAttribute('focus-ring')).to.be.true;
   });
 
   it('should close sub-menu on first item arrow up', async () => {

--- a/packages/rich-text-editor/test/dom/__snapshots__/rich-text-editor.test.snap.js
+++ b/packages/rich-text-editor/test/dom/__snapshots__/rich-text-editor.test.snap.js
@@ -39,6 +39,7 @@ snapshots["vaadin-rich-text-editor host"] =
     <vaadin-button
       role="button"
       slot="cancel-button"
+      style="--_vaadin-button-disabled-pointer-events: auto;"
       tabindex="0"
       theme="tertiary"
     >
@@ -48,6 +49,7 @@ snapshots["vaadin-rich-text-editor host"] =
       hidden=""
       role="button"
       slot="reject-button"
+      style="--_vaadin-button-disabled-pointer-events: auto;"
       tabindex="0"
       theme="error"
     >
@@ -56,6 +58,7 @@ snapshots["vaadin-rich-text-editor host"] =
     <vaadin-button
       role="button"
       slot="confirm-button"
+      style="--_vaadin-button-disabled-pointer-events: auto;"
       tabindex="0"
       theme="primary"
     >

--- a/packages/upload/src/vaadin-upload-button.js
+++ b/packages/upload/src/vaadin-upload-button.js
@@ -274,7 +274,7 @@ class UploadButton extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(L
 
   /** @override */
   __shouldAllowFocusWhenDisabled() {
-    return window.Vaadin.featureFlags.accessibleDisabledButtons;
+    return true;
   }
 }
 

--- a/packages/upload/test/dom/__snapshots__/vaadin-upload-button.test.snap.js
+++ b/packages/upload/test/dom/__snapshots__/vaadin-upload-button.test.snap.js
@@ -4,6 +4,7 @@ export const snapshots = {};
 snapshots["vaadin-upload-button host default"] = 
 `<vaadin-upload-button
   role="button"
+  style="--_vaadin-button-disabled-pointer-events: auto;"
   tabindex="0"
 >
   Upload
@@ -16,7 +17,8 @@ snapshots["vaadin-upload-button host disabled"] =
   aria-disabled="true"
   disabled=""
   role="button"
-  tabindex="-1"
+  style="--_vaadin-button-disabled-pointer-events: auto;"
+  tabindex="0"
 >
   Upload
 </vaadin-upload-button>
@@ -27,6 +29,7 @@ snapshots["vaadin-upload-button host max-files-reached"] =
 `<vaadin-upload-button
   max-files-reached=""
   role="button"
+  style="--_vaadin-button-disabled-pointer-events: auto;"
   tabindex="0"
 >
   Upload
@@ -38,6 +41,7 @@ snapshots["vaadin-upload-button host focused"] =
 `<vaadin-upload-button
   focused=""
   role="button"
+  style="--_vaadin-button-disabled-pointer-events: auto;"
   tabindex="0"
 >
   Upload
@@ -50,6 +54,7 @@ snapshots["vaadin-upload-button host focus-ring"] =
   focus-ring=""
   focused=""
   role="button"
+  style="--_vaadin-button-disabled-pointer-events: auto;"
   tabindex="0"
 >
   Upload
@@ -61,6 +66,7 @@ snapshots["vaadin-upload-button host active"] =
 `<vaadin-upload-button
   active=""
   role="button"
+  style="--_vaadin-button-disabled-pointer-events: auto;"
   tabindex="0"
 >
   Upload

--- a/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
+++ b/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
@@ -70,7 +70,7 @@ snapshots["vaadin-upload host max files"] =
     disabled=""
     role="button"
     slot="add-button"
-    tabindex="-1"
+    tabindex="0"
   >
     Upload File...
   </vaadin-button>
@@ -134,7 +134,7 @@ snapshots["vaadin-upload host disabled"] =
     disabled=""
     role="button"
     slot="add-button"
-    tabindex="-1"
+    tabindex="0"
   >
     Upload Files...
   </vaadin-button>

--- a/packages/upload/test/upload-button.test.ts
+++ b/packages/upload/test/upload-button.test.ts
@@ -36,8 +36,8 @@ describe('vaadin-upload-button', () => {
       expect(button.hasAttribute('disabled')).to.be.true;
     });
 
-    it('should have tabindex="-1" when no manager is set', () => {
-      expect(button.getAttribute('tabindex')).to.equal('-1');
+    it('should remain focusable when no manager is set', () => {
+      expect(button.getAttribute('tabindex')).to.equal('0');
     });
 
     it('should be enabled when manager is set', async () => {
@@ -468,26 +468,13 @@ describe('vaadin-upload-button', () => {
         expect(spy.called).to.be.false;
       });
 
-      it('should not be focusable when disabled due to maxFilesReached', async () => {
+      it('should remain focusable when disabled due to maxFilesReached', async () => {
         uploadManager.maxFiles = 1;
         button.manager = uploadManager;
         await nextFrame();
         expect(button.getAttribute('tabindex')).to.equal('0');
 
         uploadManager.addFiles([createFile(100, 'text/plain')]);
-        await nextFrame();
-        expect(button.getAttribute('tabindex')).to.equal('-1');
-      });
-
-      it('should restore tabindex when maxFilesReached becomes false', async () => {
-        uploadManager.maxFiles = 1;
-        button.manager = uploadManager;
-
-        uploadManager.addFiles([createFile(100, 'text/plain')]);
-        await nextFrame();
-        expect(button.getAttribute('tabindex')).to.equal('-1');
-
-        uploadManager.removeFile(uploadManager.files[0]);
         await nextFrame();
         expect(button.getAttribute('tabindex')).to.equal('0');
       });
@@ -582,24 +569,12 @@ describe('vaadin-upload-button', () => {
         expect(spy.called).to.be.false;
       });
 
-      it('should not be focusable when manager is disabled', async () => {
+      it('should remain focusable when manager is disabled', async () => {
         button.manager = uploadManager;
         await nextFrame();
         expect(button.getAttribute('tabindex')).to.equal('0');
 
         uploadManager.disabled = true;
-        await nextFrame();
-        expect(button.getAttribute('tabindex')).to.equal('-1');
-      });
-
-      it('should restore tabindex when manager is re-enabled', async () => {
-        button.manager = uploadManager;
-
-        uploadManager.disabled = true;
-        await nextFrame();
-        expect(button.getAttribute('tabindex')).to.equal('-1');
-
-        uploadManager.disabled = false;
         await nextFrame();
         expect(button.getAttribute('tabindex')).to.equal('0');
       });

--- a/test/integration/component-tooltip.test.js
+++ b/test/integration/component-tooltip.test.js
@@ -272,15 +272,6 @@ before(() => {
 describe('accessible disabled button', () => {
   let button, tooltip;
 
-  before(() => {
-    window.Vaadin.featureFlags ??= {};
-    window.Vaadin.featureFlags.accessibleDisabledButtons = true;
-  });
-
-  after(() => {
-    window.Vaadin.featureFlags.accessibleDisabledButtons = false;
-  });
-
   beforeEach(() => {
     button = fixtureSync(
       `<div>

--- a/test/integration/context-menu-tooltip.test.js
+++ b/test/integration/context-menu-tooltip.test.js
@@ -204,15 +204,6 @@ describe('context-menu with tooltip', () => {
   });
 
   describe('disabled item', () => {
-    before(() => {
-      window.Vaadin.featureFlags ??= {};
-      window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
-    });
-
-    after(() => {
-      window.Vaadin.featureFlags.accessibleDisabledMenuItems = false;
-    });
-
     it('should show tooltip for disabled item on hover', async () => {
       await sendMouseToElement({ type: 'click', element: target });
       await nextRender();

--- a/test/integration/menu-bar-tooltip.test.js
+++ b/test/integration/menu-bar-tooltip.test.js
@@ -350,15 +350,6 @@ describe('menu-bar with tooltip', () => {
   });
 
   describe('accessible disabled button', () => {
-    before(() => {
-      window.Vaadin.featureFlags ??= {};
-      window.Vaadin.featureFlags.accessibleDisabledButtons = true;
-    });
-
-    after(() => {
-      window.Vaadin.featureFlags.accessibleDisabledButtons = false;
-    });
-
     beforeEach(async () => {
       menuBar = fixtureSync(
         `<div>
@@ -563,15 +554,6 @@ describe('menu-bar with tooltip', () => {
     });
 
     describe('disabled sub-menu item', () => {
-      before(() => {
-        window.Vaadin.featureFlags ??= {};
-        window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
-      });
-
-      after(() => {
-        window.Vaadin.featureFlags.accessibleDisabledMenuItems = false;
-      });
-
       it('should show tooltip for disabled sub-menu item on hover', async () => {
         await sendMouseToElement({ type: 'click', element: buttons[0] });
         await nextRender();


### PR DESCRIPTION
## Description

- Removed the `accessibleDisabledButtons` and `accessibleDisabledMenuItems` feature flags
- Disabled buttons and menu items are now always focusable and hoverable, while still prevented from being activated
- Affects `vaadin-button`, `vaadin-menu-bar`, `vaadin-context-menu` and `vaadin-upload-button`; other components keep the old disabled behavior
- Updated API docs, tests and dev pages accordingly

Part of https://github.com/vaadin/web-components/issues/12512

## Type of change

- Feature

## How to test

1. Open `dev/menu-bar.html`
2. Open the "Share" sub-menu and hover the disabled "By email" item
3. The item should show a tooltip, and clicking or pressing <kbd>Enter</kbd> should not select it
