### PR TITLE
fix: scroll to bottom after markdown content is rendered

### DIFF
--- a/packages/message-list/src/vaadin-message-list-mixin.js
+++ b/packages/message-list/src/vaadin-message-list-mixin.js
@@ -160,18 +160,13 @@ export const MessageListMixin = (superClass) =>
       }
     }
 
-    /** @private */
-    get __isMarkdownLoading() {
-      return !!this.markdown && !customElements.get('vaadin-markdown');
-    }
-
     /**
      * Scrolls to the last message, unless the markdown component is still loading,
      * in which case the final height of the messages is not yet known.
      * @private
      */
     __flushScrollToLastMessage() {
-      if (!this.__scrollToLastMessagePending || this.__isMarkdownLoading) {
+      if (!this.__scrollToLastMessagePending || (this.markdown && !customElements.get('vaadin-markdown'))) {
         return;
       }
 

--- a/packages/message-list/src/vaadin-message-list-mixin.js
+++ b/packages/message-list/src/vaadin-message-list-mixin.js
@@ -153,20 +153,30 @@ export const MessageListMixin = (superClass) =>
           this.__enableScrollSnapping();
         }
 
-        requestAnimationFrame(() => {
-          if (items.length > oldItems.length && closeToBottom) {
-            this._scrollToLastMessage();
-
-            const loadingMarkdown = this.markdown && !customElements.get('vaadin-markdown');
-
-            if (loadingMarkdown) {
-              customElements.whenDefined('vaadin-markdown').then(() => {
-                this._scrollToLastMessage();
-              });
-            }
-          }
-        });
+        if (items.length > oldItems.length && closeToBottom) {
+          this.__scrollToLastMessagePending = true;
+          this.__flushScrollToLastMessage();
+        }
       }
+    }
+
+    /** @private */
+    get __isMarkdownLoading() {
+      return !!this.markdown && !customElements.get('vaadin-markdown');
+    }
+
+    /**
+     * Scrolls to the last message, unless the markdown component is still loading,
+     * in which case the final height of the messages is not yet known.
+     * @private
+     */
+    __flushScrollToLastMessage() {
+      if (!this.__scrollToLastMessagePending || this.__isMarkdownLoading) {
+        return;
+      }
+
+      this.__scrollToLastMessagePending = false;
+      requestAnimationFrame(() => this._scrollToLastMessage());
     }
 
     /** @private */
@@ -176,8 +186,8 @@ export const MessageListMixin = (superClass) =>
         import('@vaadin/markdown/src/vaadin-markdown.js')
           // Wait until the component is defined
           .then(() => customElements.whenDefined('vaadin-markdown'))
-          // Render the messages again
-          .then(() => this._renderMessages(this.items));
+          // The messages grow once the markdown content is rendered
+          .then(() => this.__flushScrollToLastMessage());
       }
       this._renderMessages(this.items);
     }
@@ -200,9 +210,11 @@ export const MessageListMixin = (superClass) =>
                 class="${ifDefined(item.className)}"
                 @focusin="${this._onMessageFocusIn}"
                 @attachment-click="${(e) => this.__onAttachmentClick(e, item)}"
-                >${this.markdown
-                  ? html`<vaadin-markdown .content=${item.text} line-breaks></vaadin-markdown>`
-                  : item.text}<vaadin-avatar slot="avatar"></vaadin-avatar
+                >${
+                  this.markdown
+                    ? html`<vaadin-markdown .content=${item.text} line-breaks></vaadin-markdown>`
+                    : item.text
+                }<vaadin-avatar slot="avatar"></vaadin-avatar
               ></vaadin-message>
             `,
           )}

--- a/packages/message-list/src/vaadin-message-list-mixin.js
+++ b/packages/message-list/src/vaadin-message-list-mixin.js
@@ -156,6 +156,14 @@ export const MessageListMixin = (superClass) =>
         requestAnimationFrame(() => {
           if (items.length > oldItems.length && closeToBottom) {
             this._scrollToLastMessage();
+
+            const loadingMarkdown = this.markdown && !customElements.get('vaadin-markdown');
+
+            if (loadingMarkdown) {
+              customElements.whenDefined('vaadin-markdown').then(() => {
+                this._scrollToLastMessage();
+              });
+            }
           }
         });
       }
@@ -192,11 +200,9 @@ export const MessageListMixin = (superClass) =>
                 class="${ifDefined(item.className)}"
                 @focusin="${this._onMessageFocusIn}"
                 @attachment-click="${(e) => this.__onAttachmentClick(e, item)}"
-                >${
-                  this.markdown
-                    ? html`<vaadin-markdown .content=${item.text} line-breaks></vaadin-markdown>`
-                    : item.text
-                }<vaadin-avatar slot="avatar"></vaadin-avatar
+                >${this.markdown
+                  ? html`<vaadin-markdown .content=${item.text} line-breaks></vaadin-markdown>`
+                  : item.text}<vaadin-avatar slot="avatar"></vaadin-avatar
               ></vaadin-message>
             `,
           )}

--- a/packages/message-list/test/message-list-markdown-import.test.js
+++ b/packages/message-list/test/message-list-markdown-import.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../src/vaadin-message-list.js';
 
 async function until(predicate) {
@@ -13,20 +13,18 @@ async function until(predicate) {
 
 describe('message-list-markdown dynamic import', () => {
   let messageList;
-  const messages = [
-    {
-      text: 'This is a **bold text** in Markdown',
-      time: '10:00 AM',
-      userName: 'Markdown User',
-      userAbbr: 'MU',
-    },
-  ];
+  const messages = Array.from({ length: 20 }, (_, i) => ({
+    text: `Message ${i} with **bold text** in Markdown`,
+    time: '10:00 AM',
+    userName: 'Markdown User',
+    userAbbr: 'MU',
+  }));
 
   beforeEach(() => {
-    messageList = fixtureSync('<vaadin-message-list></vaadin-message-list>');
+    messageList = fixtureSync('<vaadin-message-list style="height: 200px"></vaadin-message-list>');
   });
 
-  it('should not render incorrect content during import', async () => {
+  it('should render the markdown and scroll to the last message after the import', async () => {
     messageList.markdown = true;
     messageList.items = messages;
 
@@ -37,8 +35,10 @@ describe('message-list-markdown dynamic import', () => {
     expect(getComputedStyle(message).visibility).to.equal('hidden');
 
     // Expect the markdown to be rendered as HTML eventually
-    await until(() => messageList.querySelector('vaadin-message strong')?.textContent === 'bold text');
+    await until(() => messageList.querySelectorAll('vaadin-message strong').length === messages.length);
+    await nextFrame();
 
     expect(getComputedStyle(message).visibility).to.equal('visible');
+    expect(messageList.scrollTop).to.be.closeTo(messageList.scrollHeight - messageList.clientHeight, 1);
   });
 });


### PR DESCRIPTION
## Description

Depends on #12513

If the markdown component hasn't finished loading, the content of messages is still rendered in plain text (or empty), making them shorter than the final render. The first scroll to the bottom therefore lands short of the real end of the list once the markdown content is fully rendered.

- Deferred the scroll to the last message until the markdown component is defined, instead of scrolling once against message heights that are not final yet
  - The existing `whenDefined` chain in `__markdownChanged` releases it, so no second `whenDefined` is needed
- Dropped the re-render after the import, since Lit re-applies the `content` set on the not yet upgraded `<vaadin-markdown>` and the markdown renders on upgrade
- Extended the dynamic import test to 20 messages in a fixed-height list, asserting that the list ends up scrolled to the last message

## Type of change

- Bugfix

## How to test

1. Open `dev/messages-ai-chat.html` in a window short enough that the two initial messages do not fit (around 420px tall)
2. Reload the page
3. The message list is scrolled down to the assistant's reply — before this fix it stayed at the top
