### PR TITLE
refactor: use updated() for message-list items and markdown observers

### DIFF
--- a/packages/message-list/src/vaadin-message-list-mixin.js
+++ b/packages/message-list/src/vaadin-message-list-mixin.js
@@ -42,7 +42,6 @@ export const MessageListMixin = (superClass) =>
         items: {
           type: Array,
           value: () => [],
-          observer: '_itemsChanged',
           sync: true,
         },
 
@@ -51,7 +50,6 @@ export const MessageListMixin = (superClass) =>
          */
         markdown: {
           type: Boolean,
-          observer: '__markdownChanged',
           reflectToAttribute: true,
         },
 
@@ -80,6 +78,19 @@ export const MessageListMixin = (superClass) =>
       // Make screen readers announce new messages
       this.setAttribute('aria-relevant', 'additions');
       this.setAttribute('role', 'region');
+    }
+
+    /** @protected */
+    updated(props) {
+      super.updated(props);
+
+      if (props.has('items')) {
+        this._itemsChanged(this.items, props.get('items'));
+      }
+
+      if (props.has('markdown')) {
+        this.__markdownChanged(this.markdown);
+      }
     }
 
     /**


### PR DESCRIPTION
## Description

Extracted from #12509

- Replaced the `items` and `markdown` property observers with an explicit `updated(props)` hook, so that the order they run in is part of the source
  - Observers are dispatched from `PolylitMixin`'s `updated()` in the order the properties were assigned, so assigning `markdown` before `items` rendered the messages before `_itemsChanged` measured the scroll position
- Handled `items` first, which keeps the existing order for the case where `items` is assigned before `markdown`

## Type of change

- Refactor

> [!NOTE]
> Not strictly behavior neutral. When `markdown` and `items` are assigned in the same task
> with `markdown` first, the scroll to the last message was skipped entirely and now happens.
> Assigning `items` first behaves exactly as before. There is no observable difference on
> `dev/messages-ai-chat.html`, where the `markdown` attribute is applied one update cycle
> earlier than `items`.
