### PR TITLE
feat: add custom CSS properties for message content and avatar

### DIFF
--- a/packages/message-list/src/styles/vaadin-message-base-styles.js
+++ b/packages/message-list/src/styles/vaadin-message-base-styles.js
@@ -10,6 +10,7 @@ export const messageStyles = css`
   :host {
     display: flex;
     flex-direction: row;
+    box-sizing: border-box;
     padding: var(--vaadin-message-padding, var(--vaadin-padding-s) var(--vaadin-padding-m));
     gap: var(--vaadin-message-gap, var(--vaadin-gap-xs) var(--vaadin-gap-s));
     outline-offset: calc(var(--vaadin-focus-ring-width) * -1);
@@ -29,6 +30,9 @@ export const messageStyles = css`
     flex-direction: column;
     flex-grow: 1;
     gap: inherit;
+    background: var(--vaadin-message-content-background, transparent);
+    padding: var(--vaadin-message-content-padding, 0);
+    border-radius: var(--vaadin-message-content-border-radius, 0);
   }
 
   [part='header'] {
@@ -62,6 +66,8 @@ export const messageStyles = css`
 
   ::slotted([slot='avatar']) {
     flex: none;
+    visibility: var(--_vaadin-message-avatar-visibility, revert-layer);
+    display: var(--_vaadin-message-avatar-display, revert-layer);
   }
 
   ::slotted(vaadin-markdown) {
@@ -73,6 +79,7 @@ export const messageStyles = css`
     flex-wrap: wrap;
     gap: var(--vaadin-gap-s);
     padding-bottom: var(--vaadin-gap-xs);
+    justify-content: var(--vaadin-message-attachments-alignment, start);
   }
 
   [part~='attachment'] {

--- a/packages/message-list/src/vaadin-message.d.ts
+++ b/packages/message-list/src/vaadin-message.d.ts
@@ -65,6 +65,10 @@ export type MessageEventMap = HTMLElementEventMap & {
  * `--vaadin-message-attachment-line-height`    |
  * `--vaadin-message-attachment-padding`        |
  * `--vaadin-message-attachment-text-color`     |
+ * `--vaadin-message-attachments-alignment`     |
+ * `--vaadin-message-content-background`        |
+ * `--vaadin-message-content-border-radius`     |
+ * `--vaadin-message-content-padding`           |
  * `--vaadin-message-font-size`                 |
  * `--vaadin-message-font-weight`               |
  * `--vaadin-message-gap`                       |

--- a/packages/message-list/src/vaadin-message.js
+++ b/packages/message-list/src/vaadin-message.js
@@ -65,6 +65,10 @@ import { MessageMixin } from './vaadin-message-mixin.js';
  * `--vaadin-message-attachment-line-height`    |
  * `--vaadin-message-attachment-padding`        |
  * `--vaadin-message-attachment-text-color`     |
+ * `--vaadin-message-attachments-alignment`     |
+ * `--vaadin-message-content-background`        |
+ * `--vaadin-message-content-border-radius`     |
+ * `--vaadin-message-content-padding`           |
  * `--vaadin-message-font-size`                 |
  * `--vaadin-message-font-weight`               |
  * `--vaadin-message-gap`                       |


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/12490

- Changed `vaadin-message` to set `box-sizing: border-box` on the host
- Added content background, padding and border-radius custom properties
- Added `--vaadin-message-attachments-alignment` custom CSS property
- Added avatar properties (internal, since they are only used by message list)
- Added `revert-layer` fallback to avoid resetting the slotted element `display`

## Type of change

- Feature