### PR TITLE
refactor: extract message-list base styles into separate file

### DIFF
--- a/packages/message-list/src/styles/vaadin-message-list-base-styles.d.ts
+++ b/packages/message-list/src/styles/vaadin-message-list-base-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const messageListStyles: CSSResult;

--- a/packages/message-list/src/styles/vaadin-message-list-base-styles.js
+++ b/packages/message-list/src/styles/vaadin-message-list-base-styles.js
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import '@vaadin/component-base/src/styles/style-props.js';
+import { css } from 'lit';
+
+export const messageListStyles = css`
+  :host {
+    display: block;
+    overflow: auto;
+    box-sizing: border-box;
+    padding: var(--vaadin-message-list-padding, var(--vaadin-padding-xs) 0);
+    scroll-padding: var(--vaadin-message-list-padding, var(--vaadin-padding-xs) 0);
+    scroll-snap-type: y proximity;
+  }
+
+  :host([hidden]) {
+    display: none !important;
+  }
+
+  [part='list'] {
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 100%;
+    max-width: var(--vaadin-message-list-max-width, none);
+    margin-inline: auto;
+  }
+
+  [part='list']::after {
+    content: '';
+    display: block;
+    scroll-snap-align: var(--_vaadin-message-list-scroll-snap-align, none);
+  }
+`;

--- a/packages/message-list/src/vaadin-message-list.js
+++ b/packages/message-list/src/vaadin-message-list.js
@@ -4,12 +4,13 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import './vaadin-message.js';
-import { css, html, LitElement } from 'lit';
+import { html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { SlotStylesMixin } from '@vaadin/component-base/src/slot-styles-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { messageListStyles } from './styles/vaadin-message-list-base-styles.js';
 import { MessageListMixin } from './vaadin-message-list-mixin.js';
 
 /**
@@ -64,36 +65,7 @@ class MessageList extends SlotStylesMixin(MessageListMixin(ElementMixin(Themable
   }
 
   static get styles() {
-    return css`
-      :host {
-        display: block;
-        overflow: auto;
-        box-sizing: border-box;
-        padding: var(--vaadin-message-list-padding, var(--vaadin-padding-xs) 0);
-        scroll-padding: var(--vaadin-message-list-padding, var(--vaadin-padding-xs) 0);
-        scroll-snap-type: y proximity;
-      }
-
-      :host([hidden]) {
-        display: none !important;
-      }
-
-      [part='list'] {
-        display: flex;
-        flex-direction: column;
-        box-sizing: border-box;
-        width: 100%;
-        min-height: 100%;
-        max-width: var(--vaadin-message-list-max-width, none);
-        margin-inline: auto;
-      }
-
-      [part='list']::after {
-        content: '';
-        display: block;
-        scroll-snap-align: var(--_vaadin-message-list-scroll-snap-align, none);
-      }
-    `;
+    return messageListStyles;
   }
 
   /** @protected */


### PR DESCRIPTION
## Description

Originally, the `css` block in `vaadin-message-list` was very small, which is why we didn't add a separate file for it.
Let's extract it to `styles` folder for consistency with `vaadin-message` before adding more styles in #12490.

## Type of change

- Refactor