### PR TITLE
fix: update InputFieldMixin to use correct override

### DIFF
--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -54,12 +54,13 @@ export const InputFieldMixin = (superclass) =>
     }
 
     /**
-     * @param {HTMLElement} input
+     * @param {HTMLElement | undefined} input
+     * @param {HTMLElement | undefined} oldInput
      * @protected
      * @override
      */
-    _inputElementChanged(input) {
-      super._inputElementChanged(input);
+    _inputElementChanged(input, oldInput) {
+      super._inputElementChanged(input, oldInput);
 
       if (input) {
         // Discard value set on the custom slotted input.


### PR DESCRIPTION
## Description

Updated `InputFieldMixin` to override `_inputElementChanged` correctly and pass `oldInput`.
Without this, `_removeInputListeners` doesn't work so this logic currently does nothing:

https://github.com/vaadin/web-components/blob/e8e1cd28545720f80ca00d3e8930fe3250932952/packages/number-field/src/vaadin-number-field-mixin.js#L180-L183

## Type of change

- Bugfix

## Note

Removing the input is generally and edge case so IMO this doesn't really need a test.