### PR TITLE
fix: hide button container from accessibility tree (CP: 24.10)

### DIFF
--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -83,7 +83,7 @@ class Button extends ButtonMixin(ElementMixin(ThemableMixin(ControllerMixin(Poly
 
   static get template() {
     return html`
-      <div class="vaadin-button-container">
+      <div class="vaadin-button-container" role="presentation">
         <span part="prefix" aria-hidden="true">
           <slot name="prefix"></slot>
         </span>

--- a/packages/button/test/dom/__snapshots__/button.test.snap.js
+++ b/packages/button/test/dom/__snapshots__/button.test.snap.js
@@ -78,7 +78,10 @@ snapshots["vaadin-button host active"] =
 /* end snapshot vaadin-button host active */
 
 snapshots["vaadin-button shadow default"] = 
-`<div class="vaadin-button-container">
+`<div
+  class="vaadin-button-container"
+  role="presentation"
+>
   <span
     aria-hidden="true"
     part="prefix"

--- a/packages/dashboard/src/vaadin-dashboard-button.js
+++ b/packages/dashboard/src/vaadin-dashboard-button.js
@@ -29,7 +29,7 @@ class DashboardButton extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixi
   /** @protected */
   render() {
     return html`
-      <div class="vaadin-button-container">
+      <div class="vaadin-button-container" role="presentation">
         <span part="prefix" aria-hidden="true">
           <slot name="prefix"></slot>
         </span>

--- a/packages/select/src/vaadin-select-value-button.js
+++ b/packages/select/src/vaadin-select-value-button.js
@@ -27,7 +27,7 @@ class SelectValueButton extends ButtonMixin(ThemableMixin(PolymerElement)) {
 
   static get template() {
     return html`
-      <div class="vaadin-button-container">
+      <div class="vaadin-button-container" role="presentation">
         <span part="label">
           <slot></slot>
         </span>


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #12525 to branch 24.10.

Note that the bug reproduces on this branch, so steps 1-3 of "How to test" are enough to see the fix here — step 4 of the original description is not needed.

---

> ## Description
>
> Fixes https://github.com/vaadin/web-components/issues/12450
>
> In NVDA browse mode, the key is not sent to the page: NVDA finds the innermost accessible
> node at the virtual cursor and invokes its default action. When `.vaadin-button-container`
> is exposed in the accessibility tree, it sits between the button and the text that gives the
> button its name, so the action resolves to a generic node that has none, and nothing
> happens. Children of `role="button"` are already presentational per ARIA, so a browser may
> drop the container on its own — 25.3 does, 24.10 does not — but that is not something to
> rely on. Setting the role explicitly keeps the container out of the tree in every browser
> and version. `aria-hidden` is not an option here, as it would also remove the accessible
> name.
>
> - Added `role="presentation"` to `.vaadin-button-container` in `vaadin-button`,
>   `vaadin-select-value-button`, `vaadin-upload-button`, `vaadin-message-input-button` and
>   `vaadin-dashboard-button`
>   - `vaadin-menu-bar-button` extends `Button`, so it inherits the change
> - Updated DOM snapshots for `button`, `upload` and `dashboard`
>
> ## Type of change
>
> - Bugfix
>
> ## How to test
>
> Requires a screen reader. Steps are for NVDA + Chrome on Windows; the same applies to JAWS,
> and to VoiceOver + Safari with <kbd>VO</kbd>+<kbd>Space</kbd> in place of <kbd>Enter</kbd>.
>
> The bug does not reproduce on this branch's base version, so the check here is that nothing
> regressed. Step 4 is where the fix itself can be seen.
>
> 1. Run `yarn start` and open `dev/button.html`
> 2. Start NVDA and make sure it is in browse mode (<kbd>NVDA</kbd>+<kbd>Space</kbd>)
> 3. Move the virtual cursor to a button with a text label and press <kbd>Enter</kbd>, then
>    <kbd>Space</kbd> — the button activates, and the announced name is the button's text,
>    unchanged from before this PR
> 4. To see the fix on an affected version: check out the `24.10` branch, add
>    `role="presentation"` to the `.vaadin-button-container` element in
>    `packages/button/src/vaadin-button.js`, then repeat steps 1–3 there. Buttons with a text
>    label do not activate without the attribute and do activate with it
>
> > [!NOTE]
> > Verified on 24.10 with NVDA 2026.1.1 + Chrome 151 and + Firefox. Buttons whose accessible
> > name comes from slotted content — plain text, text wrapped in an element, and text with an
> > icon or text prefix/suffix — go from not activating to activating, with the same announced
> > name before and after. Buttons named by `aria-label` with `aria-hidden` content, and
> > icon-only buttons, were never affected either way.
>
