### PR TITLE
docs: align field custom CSS properties tables in JSDoc

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -168,14 +168,6 @@ export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
  *
  * ### Styling
  *
- * The following custom properties are available for styling:
- *
- * Custom property                         | Description                | Default
- * ----------------------------------------|----------------------------|---------
- * `--vaadin-field-default-width`          | Default width of the field | `12em`
- * `--vaadin-combo-box-overlay-width`      | Width of the overlay       | `auto`
- * `--vaadin-combo-box-overlay-max-height` | Max height of the overlay  | `65vh`
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -208,6 +200,48 @@ export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
  * `readonly`           | Set when the element is readonly
  * `opened`             | Set when the overlay is opened
  * `loading`            | Set when loading items from the data provider
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-combo-box-overlay-max-height`          |
+ * | `--vaadin-combo-box-overlay-width`               |
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
+ * | `--vaadin-item-overlay-padding`                  |
  *
  * ### Internal components
  *

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -100,14 +100,6 @@ import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
  *
  * ### Styling
  *
- * The following custom properties are available for styling:
- *
- * Custom property                         | Description                | Default
- * ----------------------------------------|----------------------------|---------
- * `--vaadin-field-default-width`          | Default width of the field | `12em`
- * `--vaadin-combo-box-overlay-width`      | Width of the overlay       | `auto`
- * `--vaadin-combo-box-overlay-max-height` | Max height of the overlay  | `65vh`
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -140,6 +132,48 @@ import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
  * `readonly`           | Set when the element is readonly
  * `opened`             | Set when the overlay is opened
  * `loading`            | Set when loading items from the data provider
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-combo-box-overlay-max-height`          |
+ * | `--vaadin-combo-box-overlay-width`               |
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
+ * | `--vaadin-item-overlay-padding`                  |
  *
  * ### Internal components
  *

--- a/packages/date-picker/src/vaadin-date-picker.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker.d.ts
@@ -78,12 +78,6 @@ export interface DatePickerEventMap extends HTMLElementEventMap, DatePickerCusto
  *
  * ### Styling
  *
- * The following custom properties are available for styling:
- *
- * Custom property                | Description                | Default
- * -------------------------------|----------------------------|---------
- * `--vaadin-field-default-width` | Default width of the field | `12em`
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -116,6 +110,69 @@ export interface DatePickerEventMap extends HTMLElementEventMap, DatePickerCusto
  * `readonly`           | Set when the element is readonly
  * `opened`             | Set when the overlay is opened
  * `week-numbers`       | Set when week numbers are shown in the calendar
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                        |
+ * :----------------------------------------------------------|
+ * | `--vaadin-date-picker-date-border-radius`                |
+ * | `--vaadin-date-picker-date-disabled-color`               |
+ * | `--vaadin-date-picker-date-height`                       |
+ * | `--vaadin-date-picker-date-selected-background`          |
+ * | `--vaadin-date-picker-date-selected-color`               |
+ * | `--vaadin-date-picker-date-today-color`                  |
+ * | `--vaadin-date-picker-date-width`                        |
+ * | `--vaadin-date-picker-month-header-color`                |
+ * | `--vaadin-date-picker-month-header-font-size`            |
+ * | `--vaadin-date-picker-month-header-font-weight`          |
+ * | `--vaadin-date-picker-month-padding`                     |
+ * | `--vaadin-date-picker-overlay-max-height`                |
+ * | `--vaadin-date-picker-overlay-width`                     |
+ * | `--vaadin-date-picker-toolbar-padding`                   |
+ * | `--vaadin-date-picker-week-divider-color`                |
+ * | `--vaadin-date-picker-week-number-color`                 |
+ * | `--vaadin-date-picker-week-number-font-size`             |
+ * | `--vaadin-date-picker-weekday-color`                     |
+ * | `--vaadin-date-picker-weekday-font-size`                 |
+ * | `--vaadin-date-picker-weekday-font-weight`               |
+ * | `--vaadin-date-picker-year-scroller-background`          |
+ * | `--vaadin-date-picker-year-scroller-border-color`        |
+ * | `--vaadin-date-picker-year-scroller-current-year-color`  |
+ * | `--vaadin-date-picker-year-scroller-width`               |
+ * | `--vaadin-field-default-width`                           |
+ * | `--vaadin-input-field-background`                        |
+ * | `--vaadin-input-field-border-color`                      |
+ * | `--vaadin-input-field-border-radius`                     |
+ * | `--vaadin-input-field-border-width`                      |
+ * | `--vaadin-input-field-bottom-end-radius`                 |
+ * | `--vaadin-input-field-bottom-start-radius`               |
+ * | `--vaadin-input-field-button-text-color`                 |
+ * | `--vaadin-input-field-container-gap`                     |
+ * | `--vaadin-input-field-disabled-background`               |
+ * | `--vaadin-input-field-disabled-text-color`               |
+ * | `--vaadin-input-field-error-color`                       |
+ * | `--vaadin-input-field-error-font-size`                   |
+ * | `--vaadin-input-field-error-font-weight`                 |
+ * | `--vaadin-input-field-error-line-height`                 |
+ * | `--vaadin-input-field-gap`                               |
+ * | `--vaadin-input-field-helper-color`                      |
+ * | `--vaadin-input-field-helper-font-size`                  |
+ * | `--vaadin-input-field-helper-font-weight`                |
+ * | `--vaadin-input-field-helper-line-height`                |
+ * | `--vaadin-input-field-label-color`                       |
+ * | `--vaadin-input-field-label-font-size`                   |
+ * | `--vaadin-input-field-label-font-weight`                 |
+ * | `--vaadin-input-field-label-line-height`                 |
+ * | `--vaadin-input-field-padding`                           |
+ * | `--vaadin-input-field-placeholder-color`                 |
+ * | `--vaadin-input-field-required-indicator`                |
+ * | `--vaadin-input-field-required-indicator-color`          |
+ * | `--vaadin-input-field-top-end-radius`                    |
+ * | `--vaadin-input-field-top-start-radius`                  |
+ * | `--vaadin-input-field-value-color`                       |
+ * | `--vaadin-input-field-value-font-size`                   |
+ * | `--vaadin-input-field-value-font-weight`                 |
+ * | `--vaadin-input-field-value-line-height`                 |
  *
  * ### Internal components
  *

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -36,12 +36,6 @@ import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
  *
  * ### Styling
  *
- * The following custom properties are available for styling:
- *
- * Custom property                | Description                | Default
- * -------------------------------|----------------------------|---------
- * `--vaadin-field-default-width` | Default width of the field | `12em`
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -74,6 +68,69 @@ import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
  * `readonly`           | Set when the element is readonly
  * `opened`             | Set when the overlay is opened
  * `week-numbers`       | Set when week numbers are shown in the calendar
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                        |
+ * :----------------------------------------------------------|
+ * | `--vaadin-date-picker-date-border-radius`                |
+ * | `--vaadin-date-picker-date-disabled-color`               |
+ * | `--vaadin-date-picker-date-height`                       |
+ * | `--vaadin-date-picker-date-selected-background`          |
+ * | `--vaadin-date-picker-date-selected-color`               |
+ * | `--vaadin-date-picker-date-today-color`                  |
+ * | `--vaadin-date-picker-date-width`                        |
+ * | `--vaadin-date-picker-month-header-color`                |
+ * | `--vaadin-date-picker-month-header-font-size`            |
+ * | `--vaadin-date-picker-month-header-font-weight`          |
+ * | `--vaadin-date-picker-month-padding`                     |
+ * | `--vaadin-date-picker-overlay-max-height`                |
+ * | `--vaadin-date-picker-overlay-width`                     |
+ * | `--vaadin-date-picker-toolbar-padding`                   |
+ * | `--vaadin-date-picker-week-divider-color`                |
+ * | `--vaadin-date-picker-week-number-color`                 |
+ * | `--vaadin-date-picker-week-number-font-size`             |
+ * | `--vaadin-date-picker-weekday-color`                     |
+ * | `--vaadin-date-picker-weekday-font-size`                 |
+ * | `--vaadin-date-picker-weekday-font-weight`               |
+ * | `--vaadin-date-picker-year-scroller-background`          |
+ * | `--vaadin-date-picker-year-scroller-border-color`        |
+ * | `--vaadin-date-picker-year-scroller-current-year-color`  |
+ * | `--vaadin-date-picker-year-scroller-width`               |
+ * | `--vaadin-field-default-width`                           |
+ * | `--vaadin-input-field-background`                        |
+ * | `--vaadin-input-field-border-color`                      |
+ * | `--vaadin-input-field-border-radius`                     |
+ * | `--vaadin-input-field-border-width`                      |
+ * | `--vaadin-input-field-bottom-end-radius`                 |
+ * | `--vaadin-input-field-bottom-start-radius`               |
+ * | `--vaadin-input-field-button-text-color`                 |
+ * | `--vaadin-input-field-container-gap`                     |
+ * | `--vaadin-input-field-disabled-background`               |
+ * | `--vaadin-input-field-disabled-text-color`               |
+ * | `--vaadin-input-field-error-color`                       |
+ * | `--vaadin-input-field-error-font-size`                   |
+ * | `--vaadin-input-field-error-font-weight`                 |
+ * | `--vaadin-input-field-error-line-height`                 |
+ * | `--vaadin-input-field-gap`                               |
+ * | `--vaadin-input-field-helper-color`                      |
+ * | `--vaadin-input-field-helper-font-size`                  |
+ * | `--vaadin-input-field-helper-font-weight`                |
+ * | `--vaadin-input-field-helper-line-height`                |
+ * | `--vaadin-input-field-label-color`                       |
+ * | `--vaadin-input-field-label-font-size`                   |
+ * | `--vaadin-input-field-label-font-weight`                 |
+ * | `--vaadin-input-field-label-line-height`                 |
+ * | `--vaadin-input-field-padding`                           |
+ * | `--vaadin-input-field-placeholder-color`                 |
+ * | `--vaadin-input-field-required-indicator`                |
+ * | `--vaadin-input-field-required-indicator-color`          |
+ * | `--vaadin-input-field-top-end-radius`                    |
+ * | `--vaadin-input-field-top-start-radius`                  |
+ * | `--vaadin-input-field-value-color`                       |
+ * | `--vaadin-input-field-value-font-size`                   |
+ * | `--vaadin-input-field-value-font-weight`                 |
+ * | `--vaadin-input-field-value-line-height`                 |
  *
  * ### Internal components
  *

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -133,12 +133,59 @@ export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap 
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom property                                      | Description                | Default
- * -----------------------------------------------------|----------------------------|--------
- * `--vaadin-field-default-width`                       | Default width of the field | `12em`
- * `--vaadin-multi-select-combo-box-overlay-width`      | Width of the overlay       | `auto`
- * `--vaadin-multi-select-combo-box-overlay-max-height` | Max height of the overlay  | `65vh`
- * `--vaadin-multi-select-combo-box-input-min-width`    | Min width of the input     | `4em`
+ * Custom CSS property                                     |
+ * :-------------------------------------------------------|
+ * | `--vaadin-chip-background`                            |
+ * | `--vaadin-chip-border-color`                          |
+ * | `--vaadin-chip-border-radius`                         |
+ * | `--vaadin-chip-border-width`                          |
+ * | `--vaadin-chip-font-size`                             |
+ * | `--vaadin-chip-font-weight`                           |
+ * | `--vaadin-chip-gap`                                   |
+ * | `--vaadin-chip-height`                                |
+ * | `--vaadin-chip-padding`                               |
+ * | `--vaadin-chip-remove-button-text-color`              |
+ * | `--vaadin-chip-text-color`                            |
+ * | `--vaadin-field-default-width`                        |
+ * | `--vaadin-input-field-background`                     |
+ * | `--vaadin-input-field-border-color`                   |
+ * | `--vaadin-input-field-border-radius`                  |
+ * | `--vaadin-input-field-border-width`                   |
+ * | `--vaadin-input-field-bottom-end-radius`              |
+ * | `--vaadin-input-field-bottom-start-radius`            |
+ * | `--vaadin-input-field-button-text-color`              |
+ * | `--vaadin-input-field-container-gap`                  |
+ * | `--vaadin-input-field-disabled-background`            |
+ * | `--vaadin-input-field-disabled-text-color`            |
+ * | `--vaadin-input-field-error-color`                    |
+ * | `--vaadin-input-field-error-font-size`                |
+ * | `--vaadin-input-field-error-font-weight`              |
+ * | `--vaadin-input-field-error-line-height`              |
+ * | `--vaadin-input-field-gap`                            |
+ * | `--vaadin-input-field-helper-color`                   |
+ * | `--vaadin-input-field-helper-font-size`               |
+ * | `--vaadin-input-field-helper-font-weight`             |
+ * | `--vaadin-input-field-helper-line-height`             |
+ * | `--vaadin-input-field-label-color`                    |
+ * | `--vaadin-input-field-label-font-size`                |
+ * | `--vaadin-input-field-label-font-weight`              |
+ * | `--vaadin-input-field-label-line-height`              |
+ * | `--vaadin-input-field-padding`                        |
+ * | `--vaadin-input-field-placeholder-color`              |
+ * | `--vaadin-input-field-required-indicator`             |
+ * | `--vaadin-input-field-required-indicator-color`       |
+ * | `--vaadin-input-field-top-end-radius`                 |
+ * | `--vaadin-input-field-top-start-radius`               |
+ * | `--vaadin-input-field-value-color`                    |
+ * | `--vaadin-input-field-value-font-size`                |
+ * | `--vaadin-input-field-value-font-weight`              |
+ * | `--vaadin-input-field-value-line-height`              |
+ * | `--vaadin-item-overlay-padding`                       |
+ * | `--vaadin-multi-select-combo-box-chip-min-width`      |
+ * | `--vaadin-multi-select-combo-box-chips-gap`           |
+ * | `--vaadin-multi-select-combo-box-input-min-width`     |
+ * | `--vaadin-multi-select-combo-box-overlay-max-height`  |
+ * | `--vaadin-multi-select-combo-box-overlay-width`       |
  *
  * ### Internal components
  *

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -71,12 +71,59 @@ import { MultiSelectComboBoxMixin } from './vaadin-multi-select-combo-box-mixin.
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom property                                      | Description                | Default
- * -----------------------------------------------------|----------------------------|--------
- * `--vaadin-field-default-width`                       | Default width of the field | `12em`
- * `--vaadin-multi-select-combo-box-overlay-width`      | Width of the overlay       | `auto`
- * `--vaadin-multi-select-combo-box-overlay-max-height` | Max height of the overlay  | `65vh`
- * `--vaadin-multi-select-combo-box-input-min-width`    | Min width of the input     | `4em`
+ * Custom CSS property                                     |
+ * :-------------------------------------------------------|
+ * | `--vaadin-chip-background`                            |
+ * | `--vaadin-chip-border-color`                          |
+ * | `--vaadin-chip-border-radius`                         |
+ * | `--vaadin-chip-border-width`                          |
+ * | `--vaadin-chip-font-size`                             |
+ * | `--vaadin-chip-font-weight`                           |
+ * | `--vaadin-chip-gap`                                   |
+ * | `--vaadin-chip-height`                                |
+ * | `--vaadin-chip-padding`                               |
+ * | `--vaadin-chip-remove-button-text-color`              |
+ * | `--vaadin-chip-text-color`                            |
+ * | `--vaadin-field-default-width`                        |
+ * | `--vaadin-input-field-background`                     |
+ * | `--vaadin-input-field-border-color`                   |
+ * | `--vaadin-input-field-border-radius`                  |
+ * | `--vaadin-input-field-border-width`                   |
+ * | `--vaadin-input-field-bottom-end-radius`              |
+ * | `--vaadin-input-field-bottom-start-radius`            |
+ * | `--vaadin-input-field-button-text-color`              |
+ * | `--vaadin-input-field-container-gap`                  |
+ * | `--vaadin-input-field-disabled-background`            |
+ * | `--vaadin-input-field-disabled-text-color`            |
+ * | `--vaadin-input-field-error-color`                    |
+ * | `--vaadin-input-field-error-font-size`                |
+ * | `--vaadin-input-field-error-font-weight`              |
+ * | `--vaadin-input-field-error-line-height`              |
+ * | `--vaadin-input-field-gap`                            |
+ * | `--vaadin-input-field-helper-color`                   |
+ * | `--vaadin-input-field-helper-font-size`               |
+ * | `--vaadin-input-field-helper-font-weight`             |
+ * | `--vaadin-input-field-helper-line-height`             |
+ * | `--vaadin-input-field-label-color`                    |
+ * | `--vaadin-input-field-label-font-size`                |
+ * | `--vaadin-input-field-label-font-weight`              |
+ * | `--vaadin-input-field-label-line-height`              |
+ * | `--vaadin-input-field-padding`                        |
+ * | `--vaadin-input-field-placeholder-color`              |
+ * | `--vaadin-input-field-required-indicator`             |
+ * | `--vaadin-input-field-required-indicator-color`       |
+ * | `--vaadin-input-field-top-end-radius`                 |
+ * | `--vaadin-input-field-top-start-radius`               |
+ * | `--vaadin-input-field-value-color`                    |
+ * | `--vaadin-input-field-value-font-size`                |
+ * | `--vaadin-input-field-value-font-weight`              |
+ * | `--vaadin-input-field-value-line-height`              |
+ * | `--vaadin-item-overlay-padding`                       |
+ * | `--vaadin-multi-select-combo-box-chip-min-width`      |
+ * | `--vaadin-multi-select-combo-box-chips-gap`           |
+ * | `--vaadin-multi-select-combo-box-input-min-width`     |
+ * | `--vaadin-multi-select-combo-box-overlay-max-height`  |
+ * | `--vaadin-multi-select-combo-box-overlay-width`       |
  *
  * ### Internal components
  *

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -144,13 +144,6 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  *
  * ### Styling
  *
- * The following custom properties are available for styling:
- *
- * Custom property                  | Description                 | Default
- * ---------------------------------|-----------------------------|--------
- * `--vaadin-field-default-width`   | Default width of the field  | `12em`
- * `--vaadin-select-overlay-width`  | Width of the overlay        |
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -181,6 +174,47 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  * `readonly`           | Set when the element is readonly
  * `opened`             | Set when the overlay is opened
  * `phone`              | Set when the overlay is shown in phone mode
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
+ * | `--vaadin-item-overlay-padding`                  |
+ * | `--vaadin-select-overlay-width`                  |
  *
  * ### Internal components
  *

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -95,13 +95,6 @@ import { SelectBaseMixin } from './vaadin-select-base-mixin.js';
  *
  * ### Styling
  *
- * The following custom properties are available for styling:
- *
- * Custom property                  | Description                 | Default
- * ---------------------------------|-----------------------------|--------
- * `--vaadin-field-default-width`   | Default width of the field  | `12em`
- * `--vaadin-select-overlay-width`  | Width of the overlay        |
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -132,6 +125,47 @@ import { SelectBaseMixin } from './vaadin-select-base-mixin.js';
  * `readonly`           | Set when the element is readonly
  * `opened`             | Set when the overlay is opened
  * `phone`              | Set when the overlay is shown in phone mode
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
+ * | `--vaadin-item-overlay-padding`                  |
+ * | `--vaadin-select-overlay-width`                  |
  *
  * ### Internal components
  *

--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -72,14 +72,6 @@ export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCusto
  *
  * ### Styling
  *
- * The following custom properties are available for styling:
- *
- * Custom property                          | Description                | Default
- * -----------------------------------------|----------------------------|---------
- * `--vaadin-field-default-width`           | Default width of the field | `12em`
- * `--vaadin-time-picker-overlay-width`     | Width of the overlay       | `auto`
- * `--vaadin-time-picker-overlay-max-height`| Max height of the overlay  | `65vh`
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -110,6 +102,48 @@ export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCusto
  * `focus-ring`         | Set when the element is keyboard focused
  * `readonly`           | Set when the element is readonly
  * `opened`             | Set when the overlay is opened
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
+ * | `--vaadin-item-overlay-padding`                  |
+ * | `--vaadin-time-picker-overlay-max-height`        |
+ * | `--vaadin-time-picker-overlay-width`             |
  *
  * ### Internal components
  *

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -32,14 +32,6 @@ import { TimePickerMixin } from './vaadin-time-picker-mixin.js';
  *
  * ### Styling
  *
- * The following custom properties are available for styling:
- *
- * Custom property                          | Description                | Default
- * -----------------------------------------|----------------------------|---------
- * `--vaadin-field-default-width`           | Default width of the field | `12em`
- * `--vaadin-time-picker-overlay-width`     | Width of the overlay       | `auto`
- * `--vaadin-time-picker-overlay-max-height`| Max height of the overlay  | `65vh`
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -70,6 +62,48 @@ import { TimePickerMixin } from './vaadin-time-picker-mixin.js';
  * `focus-ring`         | Set when the element is keyboard focused
  * `readonly`           | Set when the element is readonly
  * `opened`             | Set when the overlay is opened
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
+ * | `--vaadin-item-overlay-padding`                  |
+ * | `--vaadin-time-picker-overlay-max-height`        |
+ * | `--vaadin-time-picker-overlay-width`             |
  *
  * ### Internal components
  *


### PR DESCRIPTION
## Description

Added tables with all base styles custom CSS properties to the field components missing them:

- `vaadin-combo-box`
- `vaadin-date-picker`
- `vaadin-multi-select-combo-box`
- `vaadin-select`
- `vaadin-time-picker`

## Type of change

- Docs