### PR TITLE
chore: update CLAUDE.md to mention single package per group

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,8 +77,8 @@ yarn start:aura       # Start with Aura theme specifically
 ```bash
 yarn test                                            # Run tests for changed packages only
 yarn test --all                                      # Run tests for all packages
-yarn test --group combo-box                          # Run tests for specific component
-yarn test --group combo-box --glob="data-provider*"  # Run specific tests for specific component
+yarn test --group combo-box                          # Run tests for single package
+yarn test --group combo-box --glob="data-provider*"  # Run specific tests for single package
 yarn test:firefox                                    # Run tests in Firefox
 yarn test:webkit                                     # Run tests in WebKit
 ```


### PR DESCRIPTION
## Description

Claude occasionally gets confused about `--group` WTR flag and tries to confirm whether it can run several groups at once or not. Updated `CLAUDE.md` to mention "single package" - same wording that we use in `DEVELOPMENT.md`.

Example from recent conversation:

```
⏺ The critic's B2 is the decisive claim. Verifying it and its --group claim against source.

  Searched for 2 patterns (ctrl+o to expand)

⏺ All verified — B2 is real (I traced it independently), --group is single-value (wtr-utils.js:43),
```

## Type of change

- Internal change