### PR TITLE
docs: add grid custom CSS properties tables to JSDoc

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro.d.ts
@@ -60,6 +60,34 @@ export interface GridProEventMap<TItem>
  * - `<vaadin-grid-pro-edit-text-field>` - has the same API as [`<vaadin-text-field>`](#/elements/vaadin-text-field).
  * - `<vaadin-grid-pro-edit-select>` - has the same API as [`<vaadin-select>`](#/elements/vaadin-select).
  *
+ * ### Styling
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                    |
+ * :------------------------------------------------------|
+ * | `--vaadin-grid-background`                           |
+ * | `--vaadin-grid-border-color`                         |
+ * | `--vaadin-grid-border-radius`                        |
+ * | `--vaadin-grid-border-width`                         |
+ * | `--vaadin-grid-cell-background-color`                |
+ * | `--vaadin-grid-cell-padding`                         |
+ * | `--vaadin-grid-cell-text-overflow`                   |
+ * | `--vaadin-grid-column-border-width`                  |
+ * | `--vaadin-grid-column-resize-handle-color`           |
+ * | `--vaadin-grid-header-font-size`                     |
+ * | `--vaadin-grid-header-font-weight`                   |
+ * | `--vaadin-grid-header-text-color`                    |
+ * | `--vaadin-grid-pro-editable-cell-background-color`   |
+ * | `--vaadin-grid-row-background-color`                 |
+ * | `--vaadin-grid-row-border-width`                     |
+ * | `--vaadin-grid-row-highlight-background-color`       |
+ * | `--vaadin-grid-row-hover-background-color`           |
+ * | `--vaadin-grid-row-odd-background-color`             |
+ * | `--vaadin-grid-row-selected-background-color`        |
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ *
  * @fires {CustomEvent} active-item-changed - Fired when the `activeItem` property changes.
  * @fires {CustomEvent} cell-activate - Fired when the cell is activated with click or keyboard.
  * @fires {CustomEvent} cell-edit-started - Fired when the user starts editing a grid cell.

--- a/packages/grid-pro/src/vaadin-grid-pro.js
+++ b/packages/grid-pro/src/vaadin-grid-pro.js
@@ -32,6 +32,34 @@ import { InlineEditingMixin } from './vaadin-grid-pro-inline-editing-mixin.js';
  * - `<vaadin-grid-pro-edit-text-field>` - has the same API as [`<vaadin-text-field>`](#/elements/vaadin-text-field).
  * - `<vaadin-grid-pro-edit-select>` - has the same API as [`<vaadin-select>`](#/elements/vaadin-select).
  *
+ * ### Styling
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                    |
+ * :------------------------------------------------------|
+ * | `--vaadin-grid-background`                           |
+ * | `--vaadin-grid-border-color`                         |
+ * | `--vaadin-grid-border-radius`                        |
+ * | `--vaadin-grid-border-width`                         |
+ * | `--vaadin-grid-cell-background-color`                |
+ * | `--vaadin-grid-cell-padding`                         |
+ * | `--vaadin-grid-cell-text-overflow`                   |
+ * | `--vaadin-grid-column-border-width`                  |
+ * | `--vaadin-grid-column-resize-handle-color`           |
+ * | `--vaadin-grid-header-font-size`                     |
+ * | `--vaadin-grid-header-font-weight`                   |
+ * | `--vaadin-grid-header-text-color`                    |
+ * | `--vaadin-grid-pro-editable-cell-background-color`   |
+ * | `--vaadin-grid-row-background-color`                 |
+ * | `--vaadin-grid-row-border-width`                     |
+ * | `--vaadin-grid-row-highlight-background-color`       |
+ * | `--vaadin-grid-row-hover-background-color`           |
+ * | `--vaadin-grid-row-odd-background-color`             |
+ * | `--vaadin-grid-row-selected-background-color`        |
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ *
  * @fires {CustomEvent} active-item-changed - Fired when the `activeItem` property changes.
  * @fires {CustomEvent} cell-activate - Fired when the cell is activated with click or keyboard.
  * @fires {CustomEvent} cell-edit-started - Fired when the user starts editing a grid cell.

--- a/packages/grid/src/vaadin-grid-tree-toggle.d.ts
+++ b/packages/grid/src/vaadin-grid-tree-toggle.d.ts
@@ -51,9 +51,11 @@ export * from './vaadin-grid-tree-toggle-mixin.js';
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property | Description | Default
- * ---|---|---
- * `--vaadin-grid-tree-toggle-level-offset` | Visual offset step for each tree sublevel | `1em`
+ * Custom CSS property                          |
+ * :--------------------------------------------|
+ * | `--vaadin-grid-tree-toggle-level-offset`   |
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} expanded-changed - Fired when the `expanded` property changes.
  */

--- a/packages/grid/src/vaadin-grid-tree-toggle.js
+++ b/packages/grid/src/vaadin-grid-tree-toggle.js
@@ -53,9 +53,11 @@ import { GridTreeToggleMixin } from './vaadin-grid-tree-toggle-mixin.js';
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property | Description | Default
- * ---|---|---
- * `--vaadin-grid-tree-toggle-level-offset` | Visual offset step for each tree sublevel | `1em`
+ * Custom CSS property                          |
+ * :--------------------------------------------|
+ * | `--vaadin-grid-tree-toggle-level-offset`   |
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} expanded-changed - Fired when the `expanded` property changes.
  *

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -276,6 +276,29 @@ export interface GridI18n {
  * `drag-disabled`        | Set to a row that isn't available for dragging                                                    | row
  * `drop-disabled`        | Set to a row that can't be dropped on top of                                                      | row
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-grid-background`                       |
+ * | `--vaadin-grid-border-color`                     |
+ * | `--vaadin-grid-border-radius`                    |
+ * | `--vaadin-grid-border-width`                     |
+ * | `--vaadin-grid-cell-background-color`            |
+ * | `--vaadin-grid-cell-padding`                     |
+ * | `--vaadin-grid-cell-text-overflow`               |
+ * | `--vaadin-grid-column-border-width`              |
+ * | `--vaadin-grid-column-resize-handle-color`       |
+ * | `--vaadin-grid-header-font-size`                 |
+ * | `--vaadin-grid-header-font-weight`               |
+ * | `--vaadin-grid-header-text-color`                |
+ * | `--vaadin-grid-row-background-color`             |
+ * | `--vaadin-grid-row-border-width`                 |
+ * | `--vaadin-grid-row-highlight-background-color`   |
+ * | `--vaadin-grid-row-hover-background-color`       |
+ * | `--vaadin-grid-row-odd-background-color`         |
+ * | `--vaadin-grid-row-selected-background-color`    |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} active-item-changed - Fired when the `activeItem` property changes.

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -257,6 +257,29 @@ const DEFAULT_I18N = {
  * `drag-disabled`       | Set to a row that isn't available for dragging                                                    | row
  * `drop-disabled`       | Set to a row that can't be dropped on top of                                                      | row
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-grid-background`                       |
+ * | `--vaadin-grid-border-color`                     |
+ * | `--vaadin-grid-border-radius`                    |
+ * | `--vaadin-grid-border-width`                     |
+ * | `--vaadin-grid-cell-background-color`            |
+ * | `--vaadin-grid-cell-padding`                     |
+ * | `--vaadin-grid-cell-text-overflow`               |
+ * | `--vaadin-grid-column-border-width`              |
+ * | `--vaadin-grid-column-resize-handle-color`       |
+ * | `--vaadin-grid-header-font-size`                 |
+ * | `--vaadin-grid-header-font-weight`               |
+ * | `--vaadin-grid-header-text-color`                |
+ * | `--vaadin-grid-row-background-color`             |
+ * | `--vaadin-grid-row-border-width`                 |
+ * | `--vaadin-grid-row-highlight-background-color`   |
+ * | `--vaadin-grid-row-hover-background-color`       |
+ * | `--vaadin-grid-row-odd-background-color`         |
+ * | `--vaadin-grid-row-selected-background-color`    |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} active-item-changed - Fired when the `activeItem` property changes.


### PR DESCRIPTION
## Description

Added custom CSS properties tables to JSDoc for `vaadin-grid` and `vaadin-grid-pro`.

## Type of change

- Documentation