### PR TITLE
docs: add missing rich-text-editor custom CSS properties to JSDoc

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.d.ts
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.d.ts
@@ -94,22 +94,29 @@ export interface RichTextEditorEventMap extends HTMLElementEventMap, RichTextEdi
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property            |
- * :-------------------------------|
- * `--vaadin-rich-text-editor-background` |
- * `--vaadin-rich-text-editor-content-color` |
- * `--vaadin-rich-text-editor-content-font-size` |
- * `--vaadin-rich-text-editor-content-line-height` |
- * `--vaadin-rich-text-editor-content-padding` |
- * `--vaadin-rich-text-editor-toolbar-background` |
- * `--vaadin-rich-text-editor-toolbar-gap` |
- * `--vaadin-rich-text-editor-toolbar-padding` |
- * `--vaadin-rich-text-editor-toolbar-button-background` |
- * `--vaadin-rich-text-editor-toolbar-button-border-width` |
- * `--vaadin-rich-text-editor-toolbar-button-border-color` |
- * `--vaadin-rich-text-editor-toolbar-button-border-radius` |
- * `--vaadin-rich-text-editor-toolbar-button-text-color` |
- * `--vaadin-rich-text-editor-toolbar-button-padding` |
+ * Custom CSS property                                                |
+ * :------------------------------------------------------------------|
+ * | `--vaadin-rich-text-editor-background`                           |
+ * | `--vaadin-rich-text-editor-content-color`                        |
+ * | `--vaadin-rich-text-editor-content-font-size`                    |
+ * | `--vaadin-rich-text-editor-content-line-height`                  |
+ * | `--vaadin-rich-text-editor-content-padding`                      |
+ * | `--vaadin-rich-text-editor-overlay-color-option-border-color`    |
+ * | `--vaadin-rich-text-editor-overlay-color-option-border-radius`   |
+ * | `--vaadin-rich-text-editor-overlay-color-option-border-width`    |
+ * | `--vaadin-rich-text-editor-overlay-color-option-height`          |
+ * | `--vaadin-rich-text-editor-overlay-color-option-width`           |
+ * | `--vaadin-rich-text-editor-overlay-gap`                          |
+ * | `--vaadin-rich-text-editor-overlay-padding`                      |
+ * | `--vaadin-rich-text-editor-toolbar-background`                   |
+ * | `--vaadin-rich-text-editor-toolbar-button-background`            |
+ * | `--vaadin-rich-text-editor-toolbar-button-border-color`          |
+ * | `--vaadin-rich-text-editor-toolbar-button-border-radius`         |
+ * | `--vaadin-rich-text-editor-toolbar-button-border-width`          |
+ * | `--vaadin-rich-text-editor-toolbar-button-padding`               |
+ * | `--vaadin-rich-text-editor-toolbar-button-text-color`            |
+ * | `--vaadin-rich-text-editor-toolbar-gap`                          |
+ * | `--vaadin-rich-text-editor-toolbar-padding`                      |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -92,22 +92,29 @@ import { RichTextEditorMixin } from './vaadin-rich-text-editor-mixin.js';
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property            |
- * :-------------------------------|
- * `--vaadin-rich-text-editor-background` |
- * `--vaadin-rich-text-editor-content-color` |
- * `--vaadin-rich-text-editor-content-font-size` |
- * `--vaadin-rich-text-editor-content-line-height` |
- * `--vaadin-rich-text-editor-content-padding` |
- * `--vaadin-rich-text-editor-toolbar-background` |
- * `--vaadin-rich-text-editor-toolbar-gap` |
- * `--vaadin-rich-text-editor-toolbar-padding` |
- * `--vaadin-rich-text-editor-toolbar-button-background` |
- * `--vaadin-rich-text-editor-toolbar-button-border-width` |
- * `--vaadin-rich-text-editor-toolbar-button-border-color` |
- * `--vaadin-rich-text-editor-toolbar-button-border-radius` |
- * `--vaadin-rich-text-editor-toolbar-button-text-color` |
- * `--vaadin-rich-text-editor-toolbar-button-padding` |
+ * Custom CSS property                                                |
+ * :------------------------------------------------------------------|
+ * | `--vaadin-rich-text-editor-background`                           |
+ * | `--vaadin-rich-text-editor-content-color`                        |
+ * | `--vaadin-rich-text-editor-content-font-size`                    |
+ * | `--vaadin-rich-text-editor-content-line-height`                  |
+ * | `--vaadin-rich-text-editor-content-padding`                      |
+ * | `--vaadin-rich-text-editor-overlay-color-option-border-color`    |
+ * | `--vaadin-rich-text-editor-overlay-color-option-border-radius`   |
+ * | `--vaadin-rich-text-editor-overlay-color-option-border-width`    |
+ * | `--vaadin-rich-text-editor-overlay-color-option-height`          |
+ * | `--vaadin-rich-text-editor-overlay-color-option-width`           |
+ * | `--vaadin-rich-text-editor-overlay-gap`                          |
+ * | `--vaadin-rich-text-editor-overlay-padding`                      |
+ * | `--vaadin-rich-text-editor-toolbar-background`                   |
+ * | `--vaadin-rich-text-editor-toolbar-button-background`            |
+ * | `--vaadin-rich-text-editor-toolbar-button-border-color`          |
+ * | `--vaadin-rich-text-editor-toolbar-button-border-radius`         |
+ * | `--vaadin-rich-text-editor-toolbar-button-border-width`          |
+ * | `--vaadin-rich-text-editor-toolbar-button-padding`               |
+ * | `--vaadin-rich-text-editor-toolbar-button-text-color`            |
+ * | `--vaadin-rich-text-editor-toolbar-gap`                          |
+ * | `--vaadin-rich-text-editor-toolbar-padding`                      |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *


### PR DESCRIPTION
## Description

Added missing popup overlay custom CSS properties to RTE, fixed table formatting.

## Type of change

- Documentation