### PR TITLE
docs: add missing custom CSS properties to JSDoc styling tables

### DIFF
--- a/packages/avatar/src/vaadin-avatar.d.ts
+++ b/packages/avatar/src/vaadin-avatar.d.ts
@@ -36,7 +36,6 @@ export { AvatarI18n } from './vaadin-avatar-mixin.js';
  * | `--vaadin-avatar-font-weight`    |
  * | `--vaadin-avatar-size`           |
  * | `--vaadin-avatar-text-color`     |
- * | `--vaadin-avatar-user-color`     |
  *
  * The following state attributes are available for styling:
  *

--- a/packages/avatar/src/vaadin-avatar.d.ts
+++ b/packages/avatar/src/vaadin-avatar.d.ts
@@ -27,15 +27,16 @@ export { AvatarI18n } from './vaadin-avatar-mixin.js';
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property            | Description
- * -------------------------------|-------------
- * `--vaadin-avatar-background`   | Background color of the avatar
- * `--vaadin-avatar-border-color` | Border color of the avatar
- * `--vaadin-avatar-border-width` | Border width of the avatar
- * `--vaadin-avatar-font-size`    | Font size of the avatar
- * `--vaadin-avatar-font-weight`  | Font weight of the avatar
- * `--vaadin-avatar-size`         | Size of the avatar
- * `--vaadin-avatar-text-color`   | Text color of the avatar
+ * Custom CSS property                |
+ * :----------------------------------|
+ * | `--vaadin-avatar-background`     |
+ * | `--vaadin-avatar-border-color`   |
+ * | `--vaadin-avatar-border-width`   |
+ * | `--vaadin-avatar-font-size`      |
+ * | `--vaadin-avatar-font-weight`    |
+ * | `--vaadin-avatar-size`           |
+ * | `--vaadin-avatar-text-color`     |
+ * | `--vaadin-avatar-user-color`     |
  *
  * The following state attributes are available for styling:
  *

--- a/packages/avatar/src/vaadin-avatar.js
+++ b/packages/avatar/src/vaadin-avatar.js
@@ -42,7 +42,6 @@ import { AvatarMixin } from './vaadin-avatar-mixin.js';
  * | `--vaadin-avatar-font-weight`    |
  * | `--vaadin-avatar-size`           |
  * | `--vaadin-avatar-text-color`     |
- * | `--vaadin-avatar-user-color`     |
  *
  * The following state attributes are available for styling:
  *

--- a/packages/avatar/src/vaadin-avatar.js
+++ b/packages/avatar/src/vaadin-avatar.js
@@ -33,15 +33,16 @@ import { AvatarMixin } from './vaadin-avatar-mixin.js';
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property            | Description
- * -------------------------------|-------------
- * `--vaadin-avatar-background`   | Background color of the avatar
- * `--vaadin-avatar-border-color` | Border color of the avatar
- * `--vaadin-avatar-border-width` | Border width of the avatar
- * `--vaadin-avatar-font-size`    | Font size of the avatar
- * `--vaadin-avatar-font-weight`  | Font weight of the avatar
- * `--vaadin-avatar-size`         | Size of the avatar
- * `--vaadin-avatar-text-color`   | Text color of the avatar
+ * Custom CSS property                |
+ * :----------------------------------|
+ * | `--vaadin-avatar-background`     |
+ * | `--vaadin-avatar-border-color`   |
+ * | `--vaadin-avatar-border-width`   |
+ * | `--vaadin-avatar-font-size`      |
+ * | `--vaadin-avatar-font-weight`    |
+ * | `--vaadin-avatar-size`           |
+ * | `--vaadin-avatar-text-color`     |
+ * | `--vaadin-avatar-user-color`     |
  *
  * The following state attributes are available for styling:
  *

--- a/packages/button/src/vaadin-button.d.ts
+++ b/packages/button/src/vaadin-button.d.ts
@@ -42,6 +42,7 @@ import { ButtonMixin } from './vaadin-button-mixin.js';
  * | `--vaadin-button-border-color`   |
  * | `--vaadin-button-border-radius`  |
  * | `--vaadin-button-border-width`   |
+ * | `--vaadin-button-font-family`    |
  * | `--vaadin-button-font-size`      |
  * | `--vaadin-button-font-weight`    |
  * | `--vaadin-button-gap`            |

--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -48,6 +48,7 @@ import { ButtonMixin } from './vaadin-button-mixin.js';
  * | `--vaadin-button-border-color`   |
  * | `--vaadin-button-border-radius`  |
  * | `--vaadin-button-border-width`   |
+ * | `--vaadin-button-font-family`    |
  * | `--vaadin-button-font-size`      |
  * | `--vaadin-button-font-weight`    |
  * | `--vaadin-button-gap`            |

--- a/packages/card/src/vaadin-card.d.ts
+++ b/packages/card/src/vaadin-card.d.ts
@@ -46,6 +46,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * | `--vaadin-card-shadow`               |
  * | `--vaadin-card-subtitle-color`       |
  * | `--vaadin-card-subtitle-font-size`   |
+ * | `--vaadin-card-subtitle-font-weight` |
  * | `--vaadin-card-subtitle-line-height` |
  * | `--vaadin-card-title-color`          |
  * | `--vaadin-card-title-font-size`      |

--- a/packages/card/src/vaadin-card.js
+++ b/packages/card/src/vaadin-card.js
@@ -53,6 +53,7 @@ import { TitleController } from './title-controller.js';
  * | `--vaadin-card-shadow`               |
  * | `--vaadin-card-subtitle-color`       |
  * | `--vaadin-card-subtitle-font-size`   |
+ * | `--vaadin-card-subtitle-font-weight` |
  * | `--vaadin-card-subtitle-line-height` |
  * | `--vaadin-card-title-color`          |
  * | `--vaadin-card-title-font-size`      |

--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -162,6 +162,7 @@ export type DialogEventMap = DialogCustomEventMap & HTMLElementEventMap;
  * |`--vaadin-dialog-title-font-size`           |
  * |`--vaadin-dialog-title-font-weight`         |
  * |`--vaadin-dialog-title-line-height`         |
+ * |`--vaadin-dialog-toolbar-gap`               |
  * |`--vaadin-overlay-backdrop-background`      |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -105,6 +105,7 @@ export { DialogOverlay } from './vaadin-dialog-overlay.js';
  * |`--vaadin-dialog-title-font-size`           |
  * |`--vaadin-dialog-title-font-weight`         |
  * |`--vaadin-dialog-title-line-height`         |
+ * |`--vaadin-dialog-toolbar-gap`               |
  * |`--vaadin-overlay-backdrop-background`      |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.

--- a/packages/icon/src/vaadin-icon.d.ts
+++ b/packages/icon/src/vaadin-icon.d.ts
@@ -50,11 +50,12 @@ import { IconMixin } from './vaadin-icon-mixin.js';
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property          | Description
- * -----------------------------|-------------
- * `--vaadin-icon-size`         | Size (width and height) of the icon
- * `--vaadin-icon-stroke-width` | Stroke width of the SVG icon
- * `--vaadin-icon-visual-size`  | Visual size of the icon
+ * Custom CSS property            |
+ * :------------------------------|
+ * | `--vaadin-icon-color`        |
+ * | `--vaadin-icon-size`         |
+ * | `--vaadin-icon-stroke-width` |
+ * | `--vaadin-icon-visual-size`  |
  *
  * The following state attributes are available for styling:
  *

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -58,11 +58,12 @@ import { ensureSvgLiteral } from './vaadin-icon-svg.js';
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property          | Description
- * -----------------------------|-------------
- * `--vaadin-icon-size`         | Size (width and height) of the icon
- * `--vaadin-icon-stroke-width` | Stroke width of the SVG icon
- * `--vaadin-icon-visual-size`  | Visual size of the icon
+ * Custom CSS property            |
+ * :------------------------------|
+ * | `--vaadin-icon-color`        |
+ * | `--vaadin-icon-size`         |
+ * | `--vaadin-icon-stroke-width` |
+ * | `--vaadin-icon-visual-size`  |
  *
  * The following state attributes are available for styling:
  *

--- a/packages/login/src/vaadin-login-overlay.d.ts
+++ b/packages/login/src/vaadin-login-overlay.d.ts
@@ -97,6 +97,7 @@ export interface LoginOverlayEventMap extends HTMLElementEventMap, LoginOverlayC
  * | `--vaadin-login-overlay-description-font-size`   |
  * | `--vaadin-login-overlay-description-font-weight` |
  * | `--vaadin-login-overlay-description-line-height` |
+ * | `--vaadin-login-overlay-shadow`                  |
  * | `--vaadin-login-overlay-text-color`              |
  * | `--vaadin-login-overlay-title-color`             |
  * | `--vaadin-login-overlay-title-font-size`         |

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -59,6 +59,7 @@ import { LoginOverlayMixin } from './vaadin-login-overlay-mixin.js';
  * | `--vaadin-login-overlay-description-font-size`   |
  * | `--vaadin-login-overlay-description-font-weight` |
  * | `--vaadin-login-overlay-description-line-height` |
+ * | `--vaadin-login-overlay-shadow`                  |
  * | `--vaadin-login-overlay-text-color`              |
  * | `--vaadin-login-overlay-title-color`             |
  * | `--vaadin-login-overlay-title-font-size`         |

--- a/packages/menu-bar/src/vaadin-menu-bar.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar.d.ts
@@ -54,6 +54,12 @@ export interface MenuBarEventMap<TItem extends MenuBarItem = MenuBarItem>
  * `disabled`          | Set when the menu bar is disabled
  * `has-single-button` | Set when there is only one button visible
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property         |
+ * :---------------------------|
+ * | `--vaadin-menu-bar-gap`   |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * ### Internal components

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -46,6 +46,12 @@ import { MenuBarMixin } from './vaadin-menu-bar-mixin.js';
  * `disabled`          | Set when the menu bar is disabled
  * `has-single-button` | Set when there is only one button visible
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property         |
+ * :---------------------------|
+ * | `--vaadin-menu-bar-gap`   |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * ### Internal components

--- a/packages/slider/src/vaadin-range-slider.d.ts
+++ b/packages/slider/src/vaadin-range-slider.d.ts
@@ -94,49 +94,51 @@ export interface RangeSliderEventMap extends HTMLElementEventMap, RangeSliderCus
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property                          |
- * :--------------------------------------------|
- * `--vaadin-field-default-width`               |
- * `--vaadin-input-field-error-color`           |
- * `--vaadin-input-field-error-font-size`       |
- * `--vaadin-input-field-error-font-weight`     |
- * `--vaadin-input-field-helper-color`          |
- * `--vaadin-input-field-helper-font-size`      |
- * `--vaadin-input-field-helper-font-weight`    |
- * `--vaadin-input-field-label-color`           |
- * `--vaadin-input-field-label-font-size`       |
- * `--vaadin-input-field-label-font-weight`     |
- * `--vaadin-input-field-required-indicator`    |
- * `--vaadin-slider-bubble-arrow-size`          |
- * `--vaadin-slider-bubble-background`          |
- * `--vaadin-slider-bubble-border-color`        |
- * `--vaadin-slider-bubble-border-radius`       |
- * `--vaadin-slider-bubble-border-width`        |
- * `--vaadin-slider-bubble-offset`              |
- * `--vaadin-slider-bubble-padding`             |
- * `--vaadin-slider-bubble-shadow`              |
- * `--vaadin-slider-bubble-text-color`          |
- * `--vaadin-slider-bubble-font-size`           |
- * `--vaadin-slider-bubble-font-weight`         |
- * `--vaadin-slider-bubble-line-height`         |
- * `--vaadin-slider-fill-background`            |
- * `--vaadin-slider-fill-border-color`          |
- * `--vaadin-slider-fill-border-width`          |
- * `--vaadin-slider-marks-color`                |
- * `--vaadin-slider-marks-font-size`            |
- * `--vaadin-slider-marks-font-weight`          |
- * `--vaadin-slider-thumb-border-color`         |
- * `--vaadin-slider-thumb-border-radius`        |
- * `--vaadin-slider-thumb-border-width`         |
- * `--vaadin-slider-thumb-cursor`               |
- * `--vaadin-slider-thumb-cursor-active`        |
- * `--vaadin-slider-thumb-height`               |
- * `--vaadin-slider-thumb-width`                |
- * `--vaadin-slider-track-background`           |
- * `--vaadin-slider-track-border-color`         |
- * `--vaadin-slider-track-border-radius`        |
- * `--vaadin-slider-track-border-width`         |
- * `--vaadin-slider-track-height`               |
+ * Custom CSS property                              |
+ * :------------------------------------------------|
+ * | `--vaadin-field-default-width`                 |
+ * | `--vaadin-input-field-error-color`             |
+ * | `--vaadin-input-field-error-font-size`         |
+ * | `--vaadin-input-field-error-font-weight`       |
+ * | `--vaadin-input-field-helper-color`            |
+ * | `--vaadin-input-field-helper-font-size`        |
+ * | `--vaadin-input-field-helper-font-weight`      |
+ * | `--vaadin-input-field-label-color`             |
+ * | `--vaadin-input-field-label-font-size`         |
+ * | `--vaadin-input-field-label-font-weight`       |
+ * | `--vaadin-input-field-required-indicator`      |
+ * | `--vaadin-slider-bubble-arrow-border-radius`   |
+ * | `--vaadin-slider-bubble-arrow-size`            |
+ * | `--vaadin-slider-bubble-background`            |
+ * | `--vaadin-slider-bubble-border-color`          |
+ * | `--vaadin-slider-bubble-border-radius`         |
+ * | `--vaadin-slider-bubble-border-width`          |
+ * | `--vaadin-slider-bubble-font-size`             |
+ * | `--vaadin-slider-bubble-font-weight`           |
+ * | `--vaadin-slider-bubble-line-height`           |
+ * | `--vaadin-slider-bubble-offset`                |
+ * | `--vaadin-slider-bubble-padding`               |
+ * | `--vaadin-slider-bubble-shadow`                |
+ * | `--vaadin-slider-bubble-text-color`            |
+ * | `--vaadin-slider-fill-background`              |
+ * | `--vaadin-slider-fill-border-color`            |
+ * | `--vaadin-slider-fill-border-width`            |
+ * | `--vaadin-slider-marks-color`                  |
+ * | `--vaadin-slider-marks-font-size`              |
+ * | `--vaadin-slider-marks-font-weight`            |
+ * | `--vaadin-slider-thumb-background`             |
+ * | `--vaadin-slider-thumb-border-color`           |
+ * | `--vaadin-slider-thumb-border-radius`          |
+ * | `--vaadin-slider-thumb-border-width`           |
+ * | `--vaadin-slider-thumb-cursor`                 |
+ * | `--vaadin-slider-thumb-cursor-active`          |
+ * | `--vaadin-slider-thumb-height`                 |
+ * | `--vaadin-slider-thumb-width`                  |
+ * | `--vaadin-slider-track-background`             |
+ * | `--vaadin-slider-track-border-color`           |
+ * | `--vaadin-slider-track-border-radius`          |
+ * | `--vaadin-slider-track-border-width`           |
+ * | `--vaadin-slider-track-height`                 |
  *
  * In order to style the slider bubble, use `<vaadin-slider-bubble>` shadow DOM parts:
  *

--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -63,49 +63,51 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property                          |
- * :--------------------------------------------|
- * `--vaadin-field-default-width`               |
- * `--vaadin-input-field-error-color`           |
- * `--vaadin-input-field-error-font-size`       |
- * `--vaadin-input-field-error-font-weight`     |
- * `--vaadin-input-field-helper-color`          |
- * `--vaadin-input-field-helper-font-size`      |
- * `--vaadin-input-field-helper-font-weight`    |
- * `--vaadin-input-field-label-color`           |
- * `--vaadin-input-field-label-font-size`       |
- * `--vaadin-input-field-label-font-weight`     |
- * `--vaadin-input-field-required-indicator`    |
- * `--vaadin-slider-bubble-arrow-size`          |
- * `--vaadin-slider-bubble-background`          |
- * `--vaadin-slider-bubble-border-color`        |
- * `--vaadin-slider-bubble-border-radius`       |
- * `--vaadin-slider-bubble-border-width`        |
- * `--vaadin-slider-bubble-offset`              |
- * `--vaadin-slider-bubble-padding`             |
- * `--vaadin-slider-bubble-shadow`              |
- * `--vaadin-slider-bubble-text-color`          |
- * `--vaadin-slider-bubble-font-size`           |
- * `--vaadin-slider-bubble-font-weight`         |
- * `--vaadin-slider-bubble-line-height`         |
- * `--vaadin-slider-fill-background`            |
- * `--vaadin-slider-fill-border-color`          |
- * `--vaadin-slider-fill-border-width`          |
- * `--vaadin-slider-marks-color`                |
- * `--vaadin-slider-marks-font-size`            |
- * `--vaadin-slider-marks-font-weight`          |
- * `--vaadin-slider-thumb-border-color`         |
- * `--vaadin-slider-thumb-border-radius`        |
- * `--vaadin-slider-thumb-border-width`         |
- * `--vaadin-slider-thumb-cursor`               |
- * `--vaadin-slider-thumb-cursor-active`        |
- * `--vaadin-slider-thumb-height`               |
- * `--vaadin-slider-thumb-width`                |
- * `--vaadin-slider-track-background`           |
- * `--vaadin-slider-track-border-color`         |
- * `--vaadin-slider-track-border-radius`        |
- * `--vaadin-slider-track-border-width`         |
- * `--vaadin-slider-track-height`               |
+ * Custom CSS property                              |
+ * :------------------------------------------------|
+ * | `--vaadin-field-default-width`                 |
+ * | `--vaadin-input-field-error-color`             |
+ * | `--vaadin-input-field-error-font-size`         |
+ * | `--vaadin-input-field-error-font-weight`       |
+ * | `--vaadin-input-field-helper-color`            |
+ * | `--vaadin-input-field-helper-font-size`        |
+ * | `--vaadin-input-field-helper-font-weight`      |
+ * | `--vaadin-input-field-label-color`             |
+ * | `--vaadin-input-field-label-font-size`         |
+ * | `--vaadin-input-field-label-font-weight`       |
+ * | `--vaadin-input-field-required-indicator`      |
+ * | `--vaadin-slider-bubble-arrow-border-radius`   |
+ * | `--vaadin-slider-bubble-arrow-size`            |
+ * | `--vaadin-slider-bubble-background`            |
+ * | `--vaadin-slider-bubble-border-color`          |
+ * | `--vaadin-slider-bubble-border-radius`         |
+ * | `--vaadin-slider-bubble-border-width`          |
+ * | `--vaadin-slider-bubble-font-size`             |
+ * | `--vaadin-slider-bubble-font-weight`           |
+ * | `--vaadin-slider-bubble-line-height`           |
+ * | `--vaadin-slider-bubble-offset`                |
+ * | `--vaadin-slider-bubble-padding`               |
+ * | `--vaadin-slider-bubble-shadow`                |
+ * | `--vaadin-slider-bubble-text-color`            |
+ * | `--vaadin-slider-fill-background`              |
+ * | `--vaadin-slider-fill-border-color`            |
+ * | `--vaadin-slider-fill-border-width`            |
+ * | `--vaadin-slider-marks-color`                  |
+ * | `--vaadin-slider-marks-font-size`              |
+ * | `--vaadin-slider-marks-font-weight`            |
+ * | `--vaadin-slider-thumb-background`             |
+ * | `--vaadin-slider-thumb-border-color`           |
+ * | `--vaadin-slider-thumb-border-radius`          |
+ * | `--vaadin-slider-thumb-border-width`           |
+ * | `--vaadin-slider-thumb-cursor`                 |
+ * | `--vaadin-slider-thumb-cursor-active`          |
+ * | `--vaadin-slider-thumb-height`                 |
+ * | `--vaadin-slider-thumb-width`                  |
+ * | `--vaadin-slider-track-background`             |
+ * | `--vaadin-slider-track-border-color`           |
+ * | `--vaadin-slider-track-border-radius`          |
+ * | `--vaadin-slider-track-border-width`           |
+ * | `--vaadin-slider-track-height`                 |
  *
  * In order to style the slider bubble, use `<vaadin-slider-bubble>` shadow DOM parts:
  *

--- a/packages/slider/src/vaadin-slider.d.ts
+++ b/packages/slider/src/vaadin-slider.d.ts
@@ -89,49 +89,51 @@ export interface SliderEventMap extends HTMLElementEventMap, SliderCustomEventMa
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property                          |
- * :--------------------------------------------|
- * `--vaadin-field-default-width`               |
- * `--vaadin-input-field-error-color`           |
- * `--vaadin-input-field-error-font-size`       |
- * `--vaadin-input-field-error-font-weight`     |
- * `--vaadin-input-field-helper-color`          |
- * `--vaadin-input-field-helper-font-size`      |
- * `--vaadin-input-field-helper-font-weight`    |
- * `--vaadin-input-field-label-color`           |
- * `--vaadin-input-field-label-font-size`       |
- * `--vaadin-input-field-label-font-weight`     |
- * `--vaadin-input-field-required-indicator`    |
- * `--vaadin-slider-bubble-arrow-size`          |
- * `--vaadin-slider-bubble-background`          |
- * `--vaadin-slider-bubble-border-color`        |
- * `--vaadin-slider-bubble-border-radius`       |
- * `--vaadin-slider-bubble-border-width`        |
- * `--vaadin-slider-bubble-offset`              |
- * `--vaadin-slider-bubble-padding`             |
- * `--vaadin-slider-bubble-shadow`              |
- * `--vaadin-slider-bubble-text-color`          |
- * `--vaadin-slider-bubble-font-size`           |
- * `--vaadin-slider-bubble-font-weight`         |
- * `--vaadin-slider-bubble-line-height`         |
- * `--vaadin-slider-fill-background`            |
- * `--vaadin-slider-fill-border-color`          |
- * `--vaadin-slider-fill-border-width`          |
- * `--vaadin-slider-marks-color`                |
- * `--vaadin-slider-marks-font-size`            |
- * `--vaadin-slider-marks-font-weight`          |
- * `--vaadin-slider-thumb-border-color`         |
- * `--vaadin-slider-thumb-border-radius`        |
- * `--vaadin-slider-thumb-border-width`         |
- * `--vaadin-slider-thumb-cursor`               |
- * `--vaadin-slider-thumb-cursor-active`        |
- * `--vaadin-slider-thumb-height`               |
- * `--vaadin-slider-thumb-width`                |
- * `--vaadin-slider-track-background`           |
- * `--vaadin-slider-track-border-color`         |
- * `--vaadin-slider-track-border-radius`        |
- * `--vaadin-slider-track-border-width`         |
- * `--vaadin-slider-track-height`               |
+ * Custom CSS property                              |
+ * :------------------------------------------------|
+ * | `--vaadin-field-default-width`                 |
+ * | `--vaadin-input-field-error-color`             |
+ * | `--vaadin-input-field-error-font-size`         |
+ * | `--vaadin-input-field-error-font-weight`       |
+ * | `--vaadin-input-field-helper-color`            |
+ * | `--vaadin-input-field-helper-font-size`        |
+ * | `--vaadin-input-field-helper-font-weight`      |
+ * | `--vaadin-input-field-label-color`             |
+ * | `--vaadin-input-field-label-font-size`         |
+ * | `--vaadin-input-field-label-font-weight`       |
+ * | `--vaadin-input-field-required-indicator`      |
+ * | `--vaadin-slider-bubble-arrow-border-radius`   |
+ * | `--vaadin-slider-bubble-arrow-size`            |
+ * | `--vaadin-slider-bubble-background`            |
+ * | `--vaadin-slider-bubble-border-color`          |
+ * | `--vaadin-slider-bubble-border-radius`         |
+ * | `--vaadin-slider-bubble-border-width`          |
+ * | `--vaadin-slider-bubble-font-size`             |
+ * | `--vaadin-slider-bubble-font-weight`           |
+ * | `--vaadin-slider-bubble-line-height`           |
+ * | `--vaadin-slider-bubble-offset`                |
+ * | `--vaadin-slider-bubble-padding`               |
+ * | `--vaadin-slider-bubble-shadow`                |
+ * | `--vaadin-slider-bubble-text-color`            |
+ * | `--vaadin-slider-fill-background`              |
+ * | `--vaadin-slider-fill-border-color`            |
+ * | `--vaadin-slider-fill-border-width`            |
+ * | `--vaadin-slider-marks-color`                  |
+ * | `--vaadin-slider-marks-font-size`              |
+ * | `--vaadin-slider-marks-font-weight`            |
+ * | `--vaadin-slider-thumb-background`             |
+ * | `--vaadin-slider-thumb-border-color`           |
+ * | `--vaadin-slider-thumb-border-radius`          |
+ * | `--vaadin-slider-thumb-border-width`           |
+ * | `--vaadin-slider-thumb-cursor`                 |
+ * | `--vaadin-slider-thumb-cursor-active`          |
+ * | `--vaadin-slider-thumb-height`                 |
+ * | `--vaadin-slider-thumb-width`                  |
+ * | `--vaadin-slider-track-background`             |
+ * | `--vaadin-slider-track-border-color`           |
+ * | `--vaadin-slider-track-border-radius`          |
+ * | `--vaadin-slider-track-border-width`           |
+ * | `--vaadin-slider-track-height`                 |
  *
  * In order to style the slider bubble, use `<vaadin-slider-bubble>` shadow DOM parts:
  *

--- a/packages/slider/src/vaadin-slider.js
+++ b/packages/slider/src/vaadin-slider.js
@@ -58,49 +58,51 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property                          |
- * :--------------------------------------------|
- * `--vaadin-field-default-width`               |
- * `--vaadin-input-field-error-color`           |
- * `--vaadin-input-field-error-font-size`       |
- * `--vaadin-input-field-error-font-weight`     |
- * `--vaadin-input-field-helper-color`          |
- * `--vaadin-input-field-helper-font-size`      |
- * `--vaadin-input-field-helper-font-weight`    |
- * `--vaadin-input-field-label-color`           |
- * `--vaadin-input-field-label-font-size`       |
- * `--vaadin-input-field-label-font-weight`     |
- * `--vaadin-input-field-required-indicator`    |
- * `--vaadin-slider-bubble-arrow-size`          |
- * `--vaadin-slider-bubble-background`          |
- * `--vaadin-slider-bubble-border-color`        |
- * `--vaadin-slider-bubble-border-radius`       |
- * `--vaadin-slider-bubble-border-width`        |
- * `--vaadin-slider-bubble-offset`              |
- * `--vaadin-slider-bubble-padding`             |
- * `--vaadin-slider-bubble-shadow`              |
- * `--vaadin-slider-bubble-text-color`          |
- * `--vaadin-slider-bubble-font-size`           |
- * `--vaadin-slider-bubble-font-weight`         |
- * `--vaadin-slider-bubble-line-height`         |
- * `--vaadin-slider-fill-background`            |
- * `--vaadin-slider-fill-border-color`          |
- * `--vaadin-slider-fill-border-width`          |
- * `--vaadin-slider-marks-color`                |
- * `--vaadin-slider-marks-font-size`            |
- * `--vaadin-slider-marks-font-weight`          |
- * `--vaadin-slider-thumb-border-color`         |
- * `--vaadin-slider-thumb-border-radius`        |
- * `--vaadin-slider-thumb-border-width`         |
- * `--vaadin-slider-thumb-cursor`               |
- * `--vaadin-slider-thumb-cursor-active`        |
- * `--vaadin-slider-thumb-height`               |
- * `--vaadin-slider-thumb-width`                |
- * `--vaadin-slider-track-background`           |
- * `--vaadin-slider-track-border-color`         |
- * `--vaadin-slider-track-border-radius`        |
- * `--vaadin-slider-track-border-width`         |
- * `--vaadin-slider-track-height`               |
+ * Custom CSS property                              |
+ * :------------------------------------------------|
+ * | `--vaadin-field-default-width`                 |
+ * | `--vaadin-input-field-error-color`             |
+ * | `--vaadin-input-field-error-font-size`         |
+ * | `--vaadin-input-field-error-font-weight`       |
+ * | `--vaadin-input-field-helper-color`            |
+ * | `--vaadin-input-field-helper-font-size`        |
+ * | `--vaadin-input-field-helper-font-weight`      |
+ * | `--vaadin-input-field-label-color`             |
+ * | `--vaadin-input-field-label-font-size`         |
+ * | `--vaadin-input-field-label-font-weight`       |
+ * | `--vaadin-input-field-required-indicator`      |
+ * | `--vaadin-slider-bubble-arrow-border-radius`   |
+ * | `--vaadin-slider-bubble-arrow-size`            |
+ * | `--vaadin-slider-bubble-background`            |
+ * | `--vaadin-slider-bubble-border-color`          |
+ * | `--vaadin-slider-bubble-border-radius`         |
+ * | `--vaadin-slider-bubble-border-width`          |
+ * | `--vaadin-slider-bubble-font-size`             |
+ * | `--vaadin-slider-bubble-font-weight`           |
+ * | `--vaadin-slider-bubble-line-height`           |
+ * | `--vaadin-slider-bubble-offset`                |
+ * | `--vaadin-slider-bubble-padding`               |
+ * | `--vaadin-slider-bubble-shadow`                |
+ * | `--vaadin-slider-bubble-text-color`            |
+ * | `--vaadin-slider-fill-background`              |
+ * | `--vaadin-slider-fill-border-color`            |
+ * | `--vaadin-slider-fill-border-width`            |
+ * | `--vaadin-slider-marks-color`                  |
+ * | `--vaadin-slider-marks-font-size`              |
+ * | `--vaadin-slider-marks-font-weight`            |
+ * | `--vaadin-slider-thumb-background`             |
+ * | `--vaadin-slider-thumb-border-color`           |
+ * | `--vaadin-slider-thumb-border-radius`          |
+ * | `--vaadin-slider-thumb-border-width`           |
+ * | `--vaadin-slider-thumb-cursor`                 |
+ * | `--vaadin-slider-thumb-cursor-active`          |
+ * | `--vaadin-slider-thumb-height`                 |
+ * | `--vaadin-slider-thumb-width`                  |
+ * | `--vaadin-slider-track-background`             |
+ * | `--vaadin-slider-track-border-color`           |
+ * | `--vaadin-slider-track-border-radius`          |
+ * | `--vaadin-slider-track-border-width`           |
+ * | `--vaadin-slider-track-height`                 |
  *
  * In order to style the slider bubble, use `<vaadin-slider-bubble>` shadow DOM parts:
  *

--- a/packages/split-layout/src/vaadin-split-layout.d.ts
+++ b/packages/split-layout/src/vaadin-split-layout.d.ts
@@ -165,6 +165,7 @@ export interface SplitLayoutEventMap extends HTMLElementEventMap, SplitLayoutCus
  *
  * Custom CSS property                            |
  * :----------------------------------------------|
+ * | `--vaadin-split-layout-handle-background`    |
  * | `--vaadin-split-layout-handle-size`          |
  * | `--vaadin-split-layout-handle-target-size`   |
  * | `--vaadin-split-layout-splitter-background`  |

--- a/packages/split-layout/src/vaadin-split-layout.js
+++ b/packages/split-layout/src/vaadin-split-layout.js
@@ -165,6 +165,7 @@ const DEFAULT_I18N = {
  *
  * Custom CSS property                            |
  * :----------------------------------------------|
+ * | `--vaadin-split-layout-handle-background`    |
  * | `--vaadin-split-layout-handle-size`          |
  * | `--vaadin-split-layout-handle-target-size`   |
  * | `--vaadin-split-layout-splitter-background`  |

--- a/packages/tabs/src/vaadin-tab.d.ts
+++ b/packages/tabs/src/vaadin-tab.d.ts
@@ -32,10 +32,12 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * :------------------------------|
  * | `--vaadin-tab-background`    |
  * | `--vaadin-tab-border-color`  |
+ * | `--vaadin-tab-border-radius` |
  * | `--vaadin-tab-border-width`  |
  * | `--vaadin-tab-font-size`     |
  * | `--vaadin-tab-font-weight`   |
  * | `--vaadin-tab-gap`           |
+ * | `--vaadin-tab-line-height`   |
  * | `--vaadin-tab-padding`       |
  * | `--vaadin-tab-text-color`    |
  *

--- a/packages/tabs/src/vaadin-tab.js
+++ b/packages/tabs/src/vaadin-tab.js
@@ -38,10 +38,12 @@ import { tabStyles } from './styles/vaadin-tab-base-styles.js';
  * :------------------------------|
  * | `--vaadin-tab-background`    |
  * | `--vaadin-tab-border-color`  |
+ * | `--vaadin-tab-border-radius` |
  * | `--vaadin-tab-border-width`  |
  * | `--vaadin-tab-font-size`     |
  * | `--vaadin-tab-font-weight`   |
  * | `--vaadin-tab-gap`           |
+ * | `--vaadin-tab-line-height`   |
  * | `--vaadin-tab-padding`       |
  * | `--vaadin-tab-text-color`    |
  *

--- a/packages/upload/src/vaadin-upload.d.ts
+++ b/packages/upload/src/vaadin-upload.d.ts
@@ -156,44 +156,45 @@ export interface UploadEventMap extends HTMLElementEventMap, UploadCustomEventMa
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property                          |
- * :--------------------------------------------|
- * `--vaadin-upload-background`                 |
- * `--vaadin-upload-border-color`               |
- * `--vaadin-upload-border-radius`              |
- * `--vaadin-upload-border-width`               |
- * `--vaadin-upload-gap`                        |
- * `--vaadin-upload-padding`                    |
- * `--vaadin-upload-drop-label-color`           |
- * `--vaadin-upload-drop-label-font-size`       |
- * `--vaadin-upload-drop-label-font-weight`     |
- * `--vaadin-upload-drop-label-gap`             |
- * `--vaadin-upload-drop-label-line-height`     |
- * `--vaadin-upload-file-list-divider-color`    |
- * `--vaadin-upload-file-list-divider-width`    |
- * `--vaadin-upload-file-border-radius`         |
- * `--vaadin-upload-file-button-background`     |
- * `--vaadin-upload-file-button-border-color`   |
- * `--vaadin-upload-file-button-border-radius`  |
- * `--vaadin-upload-file-button-border-width`   |
- * `--vaadin-upload-file-button-text-color`     |
- * `--vaadin-upload-file-button-padding`        |
- * `--vaadin-upload-file-done-color`            |
- * `--vaadin-upload-file-error-color`           |
- * `--vaadin-upload-file-error-font-size`       |
- * `--vaadin-upload-file-error-font-weight`     |
- * `--vaadin-upload-file-error-line-height`     |
- * `--vaadin-upload-file-gap`                   |
- * `--vaadin-upload-file-name-color`            |
- * `--vaadin-upload-file-name-font-size`        |
- * `--vaadin-upload-file-name-font-weight`      |
- * `--vaadin-upload-file-name-line-height`      |
- * `--vaadin-upload-file-padding`               |
- * `--vaadin-upload-file-status-color`          |
- * `--vaadin-upload-file-status-font-size`      |
- * `--vaadin-upload-file-status-font-weight`    |
- * `--vaadin-upload-file-status-line-height`    |
- * `--vaadin-upload-file-warning-color`         |
+ * Custom CSS property                             |
+ * :-----------------------------------------------|
+ * | `--vaadin-upload-background`                  |
+ * | `--vaadin-upload-border-color`                |
+ * | `--vaadin-upload-border-radius`               |
+ * | `--vaadin-upload-border-width`                |
+ * | `--vaadin-upload-drop-label-color`            |
+ * | `--vaadin-upload-drop-label-font-size`        |
+ * | `--vaadin-upload-drop-label-font-weight`      |
+ * | `--vaadin-upload-drop-label-gap`              |
+ * | `--vaadin-upload-drop-label-line-height`      |
+ * | `--vaadin-upload-file-border-radius`          |
+ * | `--vaadin-upload-file-button-background`      |
+ * | `--vaadin-upload-file-button-border-color`    |
+ * | `--vaadin-upload-file-button-border-radius`   |
+ * | `--vaadin-upload-file-button-border-width`    |
+ * | `--vaadin-upload-file-button-padding`         |
+ * | `--vaadin-upload-file-button-text-color`      |
+ * | `--vaadin-upload-file-done-color`             |
+ * | `--vaadin-upload-file-error-color`            |
+ * | `--vaadin-upload-file-error-font-size`        |
+ * | `--vaadin-upload-file-error-font-weight`      |
+ * | `--vaadin-upload-file-error-line-height`      |
+ * | `--vaadin-upload-file-gap`                    |
+ * | `--vaadin-upload-file-list-divider-color`     |
+ * | `--vaadin-upload-file-list-divider-width`     |
+ * | `--vaadin-upload-file-name-color`             |
+ * | `--vaadin-upload-file-name-font-size`         |
+ * | `--vaadin-upload-file-name-font-weight`       |
+ * | `--vaadin-upload-file-name-line-height`       |
+ * | `--vaadin-upload-file-padding`                |
+ * | `--vaadin-upload-file-status-color`           |
+ * | `--vaadin-upload-file-status-font-size`       |
+ * | `--vaadin-upload-file-status-font-weight`     |
+ * | `--vaadin-upload-file-status-line-height`     |
+ * | `--vaadin-upload-file-warning-color`          |
+ * | `--vaadin-upload-gap`                         |
+ * | `--vaadin-upload-icon-color`                  |
+ * | `--vaadin-upload-padding`                     |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -47,44 +47,45 @@ import { UploadMixin } from './vaadin-upload-mixin.js';
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property                          |
- * :--------------------------------------------|
- * `--vaadin-upload-background`                 |
- * `--vaadin-upload-border-color`               |
- * `--vaadin-upload-border-radius`              |
- * `--vaadin-upload-border-width`               |
- * `--vaadin-upload-gap`                        |
- * `--vaadin-upload-padding`                    |
- * `--vaadin-upload-drop-label-color`           |
- * `--vaadin-upload-drop-label-font-size`       |
- * `--vaadin-upload-drop-label-font-weight`     |
- * `--vaadin-upload-drop-label-gap`             |
- * `--vaadin-upload-drop-label-line-height`     |
- * `--vaadin-upload-file-list-divider-color`    |
- * `--vaadin-upload-file-list-divider-width`    |
- * `--vaadin-upload-file-border-radius`         |
- * `--vaadin-upload-file-button-background`     |
- * `--vaadin-upload-file-button-border-color`   |
- * `--vaadin-upload-file-button-border-radius`  |
- * `--vaadin-upload-file-button-border-width`   |
- * `--vaadin-upload-file-button-text-color`     |
- * `--vaadin-upload-file-button-padding`        |
- * `--vaadin-upload-file-done-color`            |
- * `--vaadin-upload-file-error-color`           |
- * `--vaadin-upload-file-error-font-size`       |
- * `--vaadin-upload-file-error-font-weight`     |
- * `--vaadin-upload-file-error-line-height`     |
- * `--vaadin-upload-file-gap`                   |
- * `--vaadin-upload-file-name-color`            |
- * `--vaadin-upload-file-name-font-size`        |
- * `--vaadin-upload-file-name-font-weight`      |
- * `--vaadin-upload-file-name-line-height`      |
- * `--vaadin-upload-file-padding`               |
- * `--vaadin-upload-file-status-color`          |
- * `--vaadin-upload-file-status-font-size`      |
- * `--vaadin-upload-file-status-font-weight`    |
- * `--vaadin-upload-file-status-line-height`    |
- * `--vaadin-upload-file-warning-color`         |
+ * Custom CSS property                             |
+ * :-----------------------------------------------|
+ * | `--vaadin-upload-background`                  |
+ * | `--vaadin-upload-border-color`                |
+ * | `--vaadin-upload-border-radius`               |
+ * | `--vaadin-upload-border-width`                |
+ * | `--vaadin-upload-drop-label-color`            |
+ * | `--vaadin-upload-drop-label-font-size`        |
+ * | `--vaadin-upload-drop-label-font-weight`      |
+ * | `--vaadin-upload-drop-label-gap`              |
+ * | `--vaadin-upload-drop-label-line-height`      |
+ * | `--vaadin-upload-file-border-radius`          |
+ * | `--vaadin-upload-file-button-background`      |
+ * | `--vaadin-upload-file-button-border-color`    |
+ * | `--vaadin-upload-file-button-border-radius`   |
+ * | `--vaadin-upload-file-button-border-width`    |
+ * | `--vaadin-upload-file-button-padding`         |
+ * | `--vaadin-upload-file-button-text-color`      |
+ * | `--vaadin-upload-file-done-color`             |
+ * | `--vaadin-upload-file-error-color`            |
+ * | `--vaadin-upload-file-error-font-size`        |
+ * | `--vaadin-upload-file-error-font-weight`      |
+ * | `--vaadin-upload-file-error-line-height`      |
+ * | `--vaadin-upload-file-gap`                    |
+ * | `--vaadin-upload-file-list-divider-color`     |
+ * | `--vaadin-upload-file-list-divider-width`     |
+ * | `--vaadin-upload-file-name-color`             |
+ * | `--vaadin-upload-file-name-font-size`         |
+ * | `--vaadin-upload-file-name-font-weight`       |
+ * | `--vaadin-upload-file-name-line-height`       |
+ * | `--vaadin-upload-file-padding`                |
+ * | `--vaadin-upload-file-status-color`           |
+ * | `--vaadin-upload-file-status-font-size`       |
+ * | `--vaadin-upload-file-status-font-weight`     |
+ * | `--vaadin-upload-file-status-line-height`     |
+ * | `--vaadin-upload-file-warning-color`          |
+ * | `--vaadin-upload-gap`                         |
+ * | `--vaadin-upload-icon-color`                  |
+ * | `--vaadin-upload-padding`                     |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *


### PR DESCRIPTION
## Description

Added a bunch of custom CSS properties missing from API docs tables:

- `--vaadin-button-font-family`
- `--vaadin-card-subtitle-font-weight`
- `--vaadin-dialog-toolbar-gap`
- `--vaadin-icon-color`
- `--vaadin-login-overlay-shadow`
- `--vaadin-menu-bar-gap`
- `--vaadin-slider-thumb-background` 
- `--vaadin-slider-bubble-arrow-border-radius`
- `--vaadin-split-layout-handle-background`
- `--vaadin-tab-border-radius`
- `--vaadin-tab-line-height`
- `--vaadin-upload-icon-color`

Reformatted `vaadin-avatar` and `vaadin-icon` tables to match the other components.
Also formatted slider and upload JSDoc tables to add missing leading `|` for consistency.

## Type of change

- Documentation