### PR TITLE
fix: wrap only getSVG for export events

### DIFF
--- a/dev/charts/exporting-local.html
+++ b/dev/charts/exporting-local.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vaadin charts | exporting (local)</title>
+    <script type="module" src="../common.js"></script>
+    <script type="module">
+      // Import order replicates the application in
+      // https://github.com/vaadin/web-components/issues/11911: Vaadin Charts first, then the
+      // optional Highcharts module added by the application itself. Once it is loaded, every
+      // download menu item exports client-side through `exportChartLocal`.
+      import '@vaadin/charts';
+      import 'highcharts/es-modules/masters/modules/offline-exporting.src.js';
+      import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+      // Styles defined in the shadow root: the exported image must keep these colors
+      registerStyles(
+        'vaadin-chart',
+        css`
+          .highcharts-color-0 {
+            fill: #7b2ff7;
+            stroke: #7b2ff7;
+          }
+
+          .highcharts-color-1 {
+            fill: #00c2a8;
+            stroke: #00c2a8;
+          }
+        `,
+      );
+
+      const log = document.querySelector('#log');
+      const chart = document.querySelector('vaadin-chart');
+
+      for (const name of ['chart-before-export', 'chart-after-export']) {
+        chart.addEventListener(name, () => {
+          log.textContent += `${name}\n`;
+        });
+      }
+
+      window.addEventListener('error', (e) => {
+        log.textContent += `ERROR: ${e.message}\n`;
+      });
+
+      document.querySelector('#clear').addEventListener('click', () => {
+        log.textContent = '';
+      });
+
+      // Same call the application in #11911 makes from its own menu item
+      document.querySelector('#export-local').addEventListener('click', () => {
+        chart.configuration.exportChartLocal();
+      });
+    </script>
+    <style>
+      #log {
+        background: #f4f4f4;
+        border-radius: 4px;
+        min-height: 6em;
+        padding: 0.5em 1em;
+      }
+    </style>
+  </head>
+  <body>
+    <theme-switcher></theme-switcher>
+
+    <h1>Client-side (local) exporting</h1>
+
+    <ol>
+      <li>
+        Press <em>Export locally</em>. It calls <code>exportChartLocal()</code> directly, the same way the reporting
+        application does from its own menu item. A PNG must download, keeping the purple and teal series colors defined
+        in the shadow root, and the log must show one <code>chart-before-export</code> / one
+        <code>chart-after-export</code>.
+      </li>
+      <li>
+        Open the chart's context menu (☰, top right) and pick <em>Download PNG image</em>. Same result: the download
+        happens in the browser, with no export server involved.
+      </li>
+    </ol>
+
+    <p>
+      Both steps fail on <code>main</code>: step 1 logs
+      <code>ERROR: Cannot read properties of undefined (reading 'apply')</code>, and step 2 silently posts to
+      <code>export.highcharts.com</code> instead of exporting in the browser — the broken wrapper also stops the module
+      from switching the menu items to their local variants.
+    </p>
+
+    <vaadin-chart style="height: 400px" title="Monthly sales" additional-options='{ "exporting": { "enabled": true } }'>
+      <vaadin-chart-series title="2025" values="[19, 12, 9, 24, 5]"></vaadin-chart-series>
+      <vaadin-chart-series title="2026" values="[14, 18, 21, 11, 17]"></vaadin-chart-series>
+    </vaadin-chart>
+
+    <p><button id="export-local">Export locally</button></p>
+
+    <h2>Export events <button id="clear">Clear</button></h2>
+    <pre id="log"></pre>
+  </body>
+</html>

--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -40,7 +40,7 @@ import { cleanupExport, inflateFunctions, prepareExport } from './helpers.js';
 // Highcharts moves a copy of the chart into the document body when exporting, losing the styles
 // defined in the shadow root. The `beforeExport` and `afterExport` events copy them over for the
 // duration of the export. Wrapping `getSVG` covers every export path, as both `exportChart` and
-// `exportChartLocal` call it through `getSVGForExport` (#11911).
+// `exportChartLocal` call it through `getSVGForExport`.
 // Workaround for https://github.com/vaadin/vaadin-charts/issues/389
 /* eslint-disable @typescript-eslint/no-invalid-this, prefer-arrow-callback */
 Highcharts.wrap(Highcharts.Chart.prototype, 'getSVG', function (proceed, ...args) {

--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -37,16 +37,19 @@ import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
 import { cleanupExport, inflateFunctions, prepareExport } from './helpers.js';
 
-['exportChart', 'exportChartLocal', 'getSVG'].forEach((methodName) => {
-  /* eslint-disable @typescript-eslint/no-invalid-this, prefer-arrow-callback */
-  Highcharts.wrap(Highcharts.Chart.prototype, methodName, function (proceed, ...args) {
-    Highcharts.fireEvent(this, 'beforeExport');
-    const result = proceed.apply(this, args);
-    Highcharts.fireEvent(this, 'afterExport');
-    return result;
-  });
-  /* eslint-enable @typescript-eslint/no-invalid-this, prefer-arrow-callback */
+// Highcharts moves a copy of the chart into the document body when exporting, losing the styles
+// defined in the shadow root. The `beforeExport` and `afterExport` events copy them over for the
+// duration of the export. Wrapping `getSVG` covers every export path, as both `exportChart` and
+// `exportChartLocal` call it through `getSVGForExport` (#11911).
+// Workaround for https://github.com/vaadin/vaadin-charts/issues/389
+/* eslint-disable @typescript-eslint/no-invalid-this, prefer-arrow-callback */
+Highcharts.wrap(Highcharts.Chart.prototype, 'getSVG', function (proceed, ...args) {
+  Highcharts.fireEvent(this, 'beforeExport');
+  const result = proceed.apply(this, args);
+  Highcharts.fireEvent(this, 'afterExport');
+  return result;
 });
+/* eslint-enable @typescript-eslint/no-invalid-this, prefer-arrow-callback */
 
 // Monkeypatch the onDocumentMouseMove method to fix the check for the source of the event
 // Due to the fact that the event is attached to the document, the target of the event is

--- a/packages/charts/test/exporting-local.test.js
+++ b/packages/charts/test/exporting-local.test.js
@@ -3,10 +3,10 @@ import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './exporting-styles.js';
 import '../src/vaadin-chart.js';
-// Loaded after Vaadin Charts, like an app adding the optional module itself (#11911)
+// Loaded after Vaadin Charts, like an app adding the optional module itself, see
+// https://github.com/vaadin/web-components/issues/11911
 import 'highcharts/es-modules/masters/modules/offline-exporting.src.js';
 import OfflineExporting from 'highcharts/es-modules/Extensions/OfflineExporting/OfflineExporting.js';
-import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
 
 describe('vaadin-chart local exporting', () => {
   let chart, downloadStub;
@@ -27,13 +27,10 @@ describe('vaadin-chart local exporting', () => {
     downloadStub.resetHistory();
   });
 
-  it('should let the offline-exporting module install exportChartLocal', () => {
-    expect(Highcharts.Chart.prototype.exportChartLocal).to.be.a('function');
-  });
-
   it('should export locally without throwing', () => {
     chart.configuration.exportChartLocal();
-    expect(downloadStub.calledOnce).to.be.true;
+
+    expect(downloadStub).to.be.calledOnce;
   });
 
   it('should dispatch export events once per local export', () => {

--- a/packages/charts/test/exporting-local.test.js
+++ b/packages/charts/test/exporting-local.test.js
@@ -46,15 +46,11 @@ describe('vaadin-chart local exporting', () => {
     expect(events).to.eql(['before', 'after']);
   });
 
-  it('should copy shadow styles to the body during a local export', () => {
-    let styleContent;
-    chart.addEventListener('chart-before-export', () => {
-      styleContent = document.body.contains(chart.tempBodyStyle) && chart.tempBodyStyle.textContent;
-    });
-
+  it('should apply the shadow styles to the exported SVG', () => {
     chart.configuration.exportChartLocal();
 
-    expect(styleContent).to.include('.highcharts-color-0');
+    // Blue comes from the `:host(#chart)` rule in exporting-styles.js
+    expect(downloadStub.firstCall.args[0]).to.include('fill="rgb(0, 0, 255)"');
   });
 
   it('should not leave the temporary style in the document body', () => {

--- a/packages/charts/test/exporting-local.test.js
+++ b/packages/charts/test/exporting-local.test.js
@@ -1,0 +1,65 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import './exporting-styles.js';
+import '../src/vaadin-chart.js';
+// Loaded after Vaadin Charts, like an app adding the optional module itself (#11911)
+import 'highcharts/es-modules/masters/modules/offline-exporting.src.js';
+import OfflineExporting from 'highcharts/es-modules/Extensions/OfflineExporting/OfflineExporting.js';
+import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
+
+describe('vaadin-chart local exporting', () => {
+  let chart, downloadStub;
+
+  before(() => {
+    // Prevent downloading the export
+    downloadStub = sinon.stub(OfflineExporting, 'downloadSVGLocal');
+  });
+
+  beforeEach(async () => {
+    chart = fixtureSync(`
+      <vaadin-chart id="chart">
+        <vaadin-chart-series values="[19,12,9,24,5]"></vaadin-chart-series>
+      </vaadin-chart>
+    `);
+    chart.additionalOptions = { exporting: { enabled: true } };
+    await oneEvent(chart, 'chart-add-series');
+    downloadStub.resetHistory();
+  });
+
+  it('should let the offline-exporting module install exportChartLocal', () => {
+    expect(Highcharts.Chart.prototype.exportChartLocal).to.be.a('function');
+  });
+
+  it('should export locally without throwing', () => {
+    chart.configuration.exportChartLocal();
+    expect(downloadStub.calledOnce).to.be.true;
+  });
+
+  it('should dispatch export events once per local export', () => {
+    const events = [];
+    chart.addEventListener('chart-before-export', () => events.push('before'));
+    chart.addEventListener('chart-after-export', () => events.push('after'));
+
+    chart.configuration.exportChartLocal();
+
+    expect(events).to.eql(['before', 'after']);
+  });
+
+  it('should copy shadow styles to the body during a local export', () => {
+    let styleContent;
+    chart.addEventListener('chart-before-export', () => {
+      styleContent = document.body.contains(chart.tempBodyStyle) && chart.tempBodyStyle.textContent;
+    });
+
+    chart.configuration.exportChartLocal();
+
+    expect(styleContent).to.include('.highcharts-color-0');
+  });
+
+  it('should not leave the temporary style in the document body', () => {
+    chart.configuration.exportChartLocal();
+    expect(chart.tempBodyStyle).to.be.undefined;
+    expect(document.body.hasAttribute('styled-mode')).to.be.false;
+  });
+});

--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -112,6 +112,16 @@ describe('vaadin-chart exporting', () => {
     expect(styleRemovedFromBody).to.be.true;
   });
 
+  it('should dispatch export events once per export', () => {
+    const events = [];
+    chart.addEventListener('chart-before-export', () => events.push('before'));
+    chart.addEventListener('chart-after-export', () => events.push('after'));
+
+    chart.configuration.exportChart();
+
+    expect(events).to.eql(['before', 'after']);
+  });
+
   it('should add styled-mode attribute to body before export and delete it afterwards', async () => {
     expect(document.body.hasAttribute(attributeName)).to.be.false;
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/11911

`exportChartLocal` is only installed once the optional Highcharts `offline-exporting` module is
loaded, which Vaadin Charts does not bundle. `Highcharts.wrap` still installs a wrapper for a
missing method, capturing `proceed` as `undefined`, and that placeholder made
`OfflineExporting.compose()` skip its own setup — so an application loading the module itself got a
`TypeError` on local export, and its download menu items kept going to the export server. Wrapping
`getSVG` is enough, because both `exportChart` and `exportChartLocal` reach it through
`getSVGForExport`.

- Wrapped only `getSVG` to fire the `beforeExport` / `afterExport` events, instead of also wrapping
  `exportChart` and `exportChartLocal`
- Fixed client-side exporting for applications that load the Highcharts `offline-exporting` module
  themselves
- `chart-before-export` and `chart-after-export` now fire once per export instead of twice, since
  the outer and inner wrappers both fired before
- Added `exporting-local.test.js`, which loads `offline-exporting` after Vaadin Charts and covers
  the local export path, and a test asserting the export events fire once per export
- Added `dev/charts/exporting-local.html`, which logs the export events and keeps the expected
  outcome next to the chart

## Type of change

- Bugfix

## How to test

1. Open `dev/charts/exporting-local.html`. It imports `offline-exporting` after Vaadin Charts, the
   same order the reporting application uses.
2. Press **Export locally**, which calls `exportChartLocal()` directly.
3. A PNG downloads, keeping the purple and teal series colors defined in the shadow root, and the
   log below the chart shows one `chart-before-export` and one `chart-after-export`.
4. Open the chart's context menu (☰) and pick **Download PNG image**. Same result, and no request
   to `export.highcharts.com`.
5. On `main`, step 2 logs `ERROR: Cannot read properties of undefined (reading 'apply')` and step 4
   silently posts to the export server instead of exporting in the browser.
6. For the export server path, open `dev/charts/organization.html` and pick **Download PNG image**
   from the context menu, or **Print chart** for an offline check. The result keeps the colors the
   chart has on screen.

> [!NOTE]
> The `exportChartLocal` wrapper never worked in any released version — the method has been absent
> at wrap time since it was added in vaadin/vaadin-charts#394. It only started throwing when
> Highcharts moved to a guarded `compose()`; before that, the module silently overwrote the broken
> wrapper.
