### PR TITLE
fix: update Lumo for tree-toggle to use correct fallback

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/grid-tree-toggle.css
+++ b/packages/vaadin-lumo-styles/src/components/grid-tree-toggle.css
@@ -29,7 +29,7 @@
 
   #level-spacer {
     display: inline-block;
-    width: calc(var(--_level, '0') * var(--vaadin-grid-tree-toggle-level-offset));
+    width: calc(var(--_level, 0) * var(--vaadin-grid-tree-toggle-level-offset));
   }
 
   [part='toggle']::before {


### PR DESCRIPTION
## Description

Replaced `'0'` with `0` to avoid warning when upgrading `postcss-calc` in https://github.com/vaadin/web-components/pull/12547.
Using string here should not be necessary. Aligned with base styles, which uses `0` - the correct value:

https://github.com/vaadin/web-components/blob/658c3e5a0637908760de656da66557f8bcafbf49/packages/grid/src/styles/vaadin-grid-tree-toggle-base-styles.js#L35-L36

## Type of change

- Bugfix