### PR TITLE
fix: support per-corner radius properties in message input

### DIFF
--- a/packages/message-input/src/styles/vaadin-message-input-base-styles.js
+++ b/packages/message-input/src/styles/vaadin-message-input-base-styles.js
@@ -14,8 +14,23 @@ export const messageInputStyles = css`
     flex-shrink: 0;
     border: var(--vaadin-input-field-border-width, 1px) solid
       var(--vaadin-input-field-border-color, var(--vaadin-border-color));
-    border-radius: var(--vaadin-input-field-border-radius, var(--vaadin-radius-m));
+    --_radius: var(--vaadin-input-field-border-radius, var(--vaadin-radius-m));
+    border-radius:
+      /* See https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius */
+      var(--vaadin-input-field-top-start-radius, var(--_radius))
+      var(--vaadin-input-field-top-end-radius, var(--_radius))
+      var(--vaadin-input-field-bottom-end-radius, var(--_radius))
+      var(--vaadin-input-field-bottom-start-radius, var(--_radius));
     background: var(--vaadin-input-field-background, var(--vaadin-background-color));
+  }
+
+  :host([dir='rtl']) {
+    border-radius:
+      /* Don't use logical props, see https://github.com/vaadin/vaadin-time-picker/issues/145 */
+      var(--vaadin-input-field-top-end-radius, var(--_radius))
+      var(--vaadin-input-field-top-start-radius, var(--_radius))
+      var(--vaadin-input-field-bottom-start-radius, var(--_radius))
+      var(--vaadin-input-field-bottom-end-radius, var(--_radius));
   }
 
   :host([hidden]) {


### PR DESCRIPTION
## Description

Part of #11163

The component draws the field border on its own host instead of using
`vaadin-input-container`, and its `border-radius` only read
`--vaadin-input-field-border-radius`. Setting one of the per-corner
properties on the component had no effect, because no style rule in the
component used them.

- Built the host `border-radius` from the four per-corner properties
  (`--vaadin-input-field-top-start-radius`, `--vaadin-input-field-top-end-radius`,
  `--vaadin-input-field-bottom-end-radius`, `--vaadin-input-field-bottom-start-radius`),
  each falling back to `--vaadin-input-field-border-radius`, using the same
  pattern as `vaadin-input-container`
- Added a `:host([dir='rtl'])` rule that mirrors the corners with physical
  values, because logical `border-radius` properties are avoided
  (see https://github.com/vaadin/vaadin-time-picker/issues/145)

## Type of change

- Bugfix
