### PR TITLE
fix: apply custom marker color to checked checkbox and radio button

### DIFF
--- a/packages/aura/src/components/checkbox-radio.css
+++ b/packages/aura/src/components/checkbox-radio.css
@@ -32,14 +32,16 @@ vaadin-radio-button:not([checked])::part(radio) {
 
 vaadin-checkbox:is([checked], [indeterminate]):not([readonly], [disabled])::part(checkbox) {
   --vaadin-checkbox-background: var(--aura-accent-color);
-  --_marker-color: var(--aura-accent-contrast-color);
+  --_color: var(--vaadin-checkbox-marker-color, var(--aura-accent-contrast-color));
+  --_filter: none;
   --vaadin-checkbox-border-color: var(--vaadin-border-color-secondary);
   box-shadow: var(--aura-shadow-s);
 }
 
 vaadin-radio-button[checked]:not([readonly], [disabled])::part(radio) {
   --vaadin-radio-button-background: var(--aura-accent-color);
-  --_marker-color: var(--aura-accent-contrast-color);
+  --_color: var(--vaadin-radio-button-marker-color, var(--aura-accent-contrast-color));
+  --_filter: none;
   --vaadin-radio-button-border-color: var(--vaadin-border-color-secondary);
   box-shadow: var(--aura-shadow-s);
 }

--- a/packages/aura/src/components/checkbox-radio.css
+++ b/packages/aura/src/components/checkbox-radio.css
@@ -32,14 +32,14 @@ vaadin-radio-button:not([checked])::part(radio) {
 
 vaadin-checkbox:is([checked], [indeterminate]):not([readonly], [disabled])::part(checkbox) {
   --vaadin-checkbox-background: var(--aura-accent-color);
-  --vaadin-checkbox-marker-color: var(--aura-accent-contrast-color);
+  --_marker-color: var(--aura-accent-contrast-color);
   --vaadin-checkbox-border-color: var(--vaadin-border-color-secondary);
   box-shadow: var(--aura-shadow-s);
 }
 
 vaadin-radio-button[checked]:not([readonly], [disabled])::part(radio) {
   --vaadin-radio-button-background: var(--aura-accent-color);
-  --vaadin-radio-button-marker-color: var(--aura-accent-contrast-color);
+  --_marker-color: var(--aura-accent-contrast-color);
   --vaadin-radio-button-border-color: var(--vaadin-border-color-secondary);
   box-shadow: var(--aura-shadow-s);
 }

--- a/packages/aura/src/components/checkbox-radio.css
+++ b/packages/aura/src/components/checkbox-radio.css
@@ -32,16 +32,16 @@ vaadin-radio-button:not([checked])::part(radio) {
 
 vaadin-checkbox:is([checked], [indeterminate]):not([readonly], [disabled])::part(checkbox) {
   --vaadin-checkbox-background: var(--aura-accent-color);
-  --_color: var(--vaadin-checkbox-marker-color, var(--aura-accent-contrast-color));
-  --_filter: none;
+  --_marker-color: var(--vaadin-checkbox-marker-color, var(--aura-accent-contrast-color));
+  --_marker-filter: none;
   --vaadin-checkbox-border-color: var(--vaadin-border-color-secondary);
   box-shadow: var(--aura-shadow-s);
 }
 
 vaadin-radio-button[checked]:not([readonly], [disabled])::part(radio) {
   --vaadin-radio-button-background: var(--aura-accent-color);
-  --_color: var(--vaadin-radio-button-marker-color, var(--aura-accent-contrast-color));
-  --_filter: none;
+  --_marker-color: var(--vaadin-radio-button-marker-color, var(--aura-accent-contrast-color));
+  --_marker-filter: none;
   --vaadin-radio-button-border-color: var(--vaadin-border-color-secondary);
   box-shadow: var(--aura-shadow-s);
 }

--- a/packages/checkbox/src/styles/vaadin-checkbox-base-styles.js
+++ b/packages/checkbox/src/styles/vaadin-checkbox-base-styles.js
@@ -10,14 +10,14 @@ import { field } from '@vaadin/field-base/src/styles/field-base-styles.js';
 
 const checkbox = css`
   [part='checkbox'] {
-    color: var(--vaadin-checkbox-checkmark-color, var(--_color));
+    color: var(--vaadin-checkbox-checkmark-color, var(--_marker-color));
   }
 
   [part='checkbox']::after {
     inset: 0;
     mask: var(--_vaadin-icon-checkmark) 50% /
       var(--vaadin-checkbox-checkmark-size, var(--vaadin-checkbox-marker-size, 100%)) no-repeat;
-    filter: var(--vaadin-checkbox-checkmark-color, var(--_filter));
+    filter: var(--vaadin-checkbox-checkmark-color, var(--_marker-filter));
   }
 
   :host([indeterminate]) [part='checkbox']::after {

--- a/packages/field-base/src/styles/checkable-base-styles.js
+++ b/packages/field-base/src/styles/checkable-base-styles.js
@@ -88,7 +88,7 @@ export const checkable = (part, propName = part) => css`
     --_border-width: var(--vaadin-${unsafeCSS(propName)}-border-width, var(--vaadin-input-field-border-width, 1px));
     border-width: var(--_border-width);
     box-sizing: border-box;
-    --_color: var(--vaadin-${unsafeCSS(propName)}-marker-color, var(--vaadin-${unsafeCSS(propName)}-background, var(--vaadin-background-color)));
+    --_color: var(--vaadin-${unsafeCSS(propName)}-marker-color, var(--_marker-color, var(--vaadin-${unsafeCSS(propName)}-background, var(--vaadin-background-color))));
     color: var(--_color);
     height: var(--vaadin-${unsafeCSS(propName)}-size, round(1.125em, 2px));
     width: var(--vaadin-${unsafeCSS(propName)}-size, round(1.125em, 2px));
@@ -147,7 +147,7 @@ export const checkable = (part, propName = part) => css`
     border-radius: inherit;
     display: flex;
     align-items: center;
-    --_filter: var(--vaadin-${unsafeCSS(propName)}-marker-color, saturate(0) invert(1) hue-rotate(180deg) contrast(100) brightness(100));
+    --_filter: var(--vaadin-${unsafeCSS(propName)}-marker-color, var(--_marker-color, saturate(0) invert(1) hue-rotate(180deg) contrast(100) brightness(100)));
     filter: var(--_filter);
   }
 

--- a/packages/field-base/src/styles/checkable-base-styles.js
+++ b/packages/field-base/src/styles/checkable-base-styles.js
@@ -16,6 +16,8 @@ export const checkable = (part, propName = part) => css`
     grid-template-rows: repeat(auto-fill, minmax(0, max-content));
     -webkit-tap-highlight-color: transparent;
     --_cursor: var(--vaadin-clickable-cursor);
+    --_color: var(--vaadin-${unsafeCSS(propName)}-marker-color, var(--vaadin-${unsafeCSS(propName)}-background, var(--vaadin-background-color)));
+    --_filter: var(--vaadin-${unsafeCSS(propName)}-marker-color, saturate(0) invert(1) hue-rotate(180deg) contrast(100) brightness(100));
   }
 
   :host(:not([has-label])) {
@@ -88,7 +90,6 @@ export const checkable = (part, propName = part) => css`
     --_border-width: var(--vaadin-${unsafeCSS(propName)}-border-width, var(--vaadin-input-field-border-width, 1px));
     border-width: var(--_border-width);
     box-sizing: border-box;
-    --_color: var(--vaadin-${unsafeCSS(propName)}-marker-color, var(--_marker-color, var(--vaadin-${unsafeCSS(propName)}-background, var(--vaadin-background-color))));
     color: var(--_color);
     height: var(--vaadin-${unsafeCSS(propName)}-size, round(1.125em, 2px));
     width: var(--vaadin-${unsafeCSS(propName)}-size, round(1.125em, 2px));
@@ -147,7 +148,6 @@ export const checkable = (part, propName = part) => css`
     border-radius: inherit;
     display: flex;
     align-items: center;
-    --_filter: var(--vaadin-${unsafeCSS(propName)}-marker-color, var(--_marker-color, saturate(0) invert(1) hue-rotate(180deg) contrast(100) brightness(100)));
     filter: var(--_filter);
   }
 

--- a/packages/field-base/src/styles/checkable-base-styles.js
+++ b/packages/field-base/src/styles/checkable-base-styles.js
@@ -16,8 +16,8 @@ export const checkable = (part, propName = part) => css`
     grid-template-rows: repeat(auto-fill, minmax(0, max-content));
     -webkit-tap-highlight-color: transparent;
     --_cursor: var(--vaadin-clickable-cursor);
-    --_color: var(--vaadin-${unsafeCSS(propName)}-marker-color, var(--vaadin-${unsafeCSS(propName)}-background, var(--vaadin-background-color)));
-    --_filter: var(--vaadin-${unsafeCSS(propName)}-marker-color, saturate(0) invert(1) hue-rotate(180deg) contrast(100) brightness(100));
+    --_marker-color: var(--vaadin-${unsafeCSS(propName)}-marker-color, var(--vaadin-${unsafeCSS(propName)}-background, var(--vaadin-background-color)));
+    --_marker-filter: var(--vaadin-${unsafeCSS(propName)}-marker-color, saturate(0) invert(1) hue-rotate(180deg) contrast(100) brightness(100));
   }
 
   :host(:not([has-label])) {
@@ -90,7 +90,7 @@ export const checkable = (part, propName = part) => css`
     --_border-width: var(--vaadin-${unsafeCSS(propName)}-border-width, var(--vaadin-input-field-border-width, 1px));
     border-width: var(--_border-width);
     box-sizing: border-box;
-    color: var(--_color);
+    color: var(--_marker-color);
     height: var(--vaadin-${unsafeCSS(propName)}-size, round(1.125em, 2px));
     width: var(--vaadin-${unsafeCSS(propName)}-size, round(1.125em, 2px));
     position: relative;
@@ -148,7 +148,7 @@ export const checkable = (part, propName = part) => css`
     border-radius: inherit;
     display: flex;
     align-items: center;
-    filter: var(--_filter);
+    filter: var(--_marker-filter);
   }
 
   :host(:not([checked], [indeterminate])) [part='${unsafeCSS(part)}']::after {

--- a/packages/radio-group/src/styles/vaadin-radio-button-base-styles.js
+++ b/packages/radio-group/src/styles/vaadin-radio-button-base-styles.js
@@ -10,14 +10,14 @@ import { field } from '@vaadin/field-base/src/styles/field-base-styles.js';
 const radioButton = css`
   [part='radio'] {
     border-radius: 50%;
-    color: var(--vaadin-radio-button-dot-color, var(--_color));
+    color: var(--vaadin-radio-button-dot-color, var(--_marker-color));
   }
 
   [part='radio']::after {
     width: var(--vaadin-radio-button-dot-size, var(--vaadin-radio-button-marker-size, 50%));
     height: var(--vaadin-radio-button-dot-size, var(--vaadin-radio-button-marker-size, 50%));
     border-radius: 50%;
-    filter: var(--vaadin-radio-button-dot-color, var(--_filter));
+    filter: var(--vaadin-radio-button-dot-color, var(--_marker-filter));
   }
 `;
 

--- a/packages/radio-group/src/styles/vaadin-radio-group-base-styles.js
+++ b/packages/radio-group/src/styles/vaadin-radio-group-base-styles.js
@@ -14,7 +14,8 @@ export const radioGroupStyles = [
     :host([readonly]) ::slotted(vaadin-radio-button) {
       --vaadin-radio-button-background: transparent;
       --vaadin-radio-button-border-color: var(--vaadin-border-color);
-      --_marker-color: var(--vaadin-text-color);
+      --_color: var(--vaadin-radio-button-marker-color, var(--vaadin-text-color));
+      --_filter: none;
       --_border-style: dashed;
       --_cursor: var(--vaadin-disabled-cursor);
     }

--- a/packages/radio-group/src/styles/vaadin-radio-group-base-styles.js
+++ b/packages/radio-group/src/styles/vaadin-radio-group-base-styles.js
@@ -14,7 +14,7 @@ export const radioGroupStyles = [
     :host([readonly]) ::slotted(vaadin-radio-button) {
       --vaadin-radio-button-background: transparent;
       --vaadin-radio-button-border-color: var(--vaadin-border-color);
-      --vaadin-radio-button-marker-color: var(--vaadin-text-color);
+      --_marker-color: var(--vaadin-text-color);
       --_border-style: dashed;
       --_cursor: var(--vaadin-disabled-cursor);
     }

--- a/packages/radio-group/src/styles/vaadin-radio-group-base-styles.js
+++ b/packages/radio-group/src/styles/vaadin-radio-group-base-styles.js
@@ -14,8 +14,8 @@ export const radioGroupStyles = [
     :host([readonly]) ::slotted(vaadin-radio-button) {
       --vaadin-radio-button-background: transparent;
       --vaadin-radio-button-border-color: var(--vaadin-border-color);
-      --_color: var(--vaadin-radio-button-marker-color, var(--vaadin-text-color));
-      --_filter: none;
+      --_marker-color: var(--vaadin-radio-button-marker-color, var(--vaadin-text-color));
+      --_marker-filter: none;
       --_border-style: dashed;
       --_cursor: var(--vaadin-disabled-cursor);
     }


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/11163

In Aura, the checked-state rules set `--vaadin-checkbox-marker-color` and `--vaadin-radio-button-marker-color` directly on the part, overriding developer-defined values in the only state where the marker is visible. 

Theme defaults now use an internal `--_marker-color` that the public properties take precedence over.

## Type of change

- Bugfix
