### PR TITLE
fix: move dashboard widget padding to base styles

### DIFF
--- a/packages/dashboard/src/styles/vaadin-dashboard-widget-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-widget-base-styles.js
@@ -41,6 +41,7 @@ const widgetStyles = css`
     flex: 1;
     overflow: hidden;
     min-height: 1em;
+    padding: 0 var(--vaadin-dashboard-widget-padding, 0) var(--vaadin-dashboard-widget-padding, 0);
     border-bottom-left-radius: inherit;
     border-bottom-right-radius: inherit;
   }

--- a/packages/vaadin-lumo-styles/src/components/dashboard-widget.css
+++ b/packages/vaadin-lumo-styles/src/components/dashboard-widget.css
@@ -39,9 +39,6 @@
 
   #content {
     min-height: var(--lumo-size-m);
-    padding-inline: var(--vaadin-dashboard-widget-padding, 0);
-    padding-bottom: var(--vaadin-dashboard-widget-padding, 0);
-    padding-top: 0;
     border-radius: inherit;
     border-top-left-radius: 0;
     border-top-right-radius: 0;


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/11163

Currently `--vaadin-dashboard-widget-padding` only works in Lumo, despite being documented to work with Aura as well.

This change makes it work in base styles, Aura and Lumo.

## Type of change

- Bugfix
