### PR TITLE
refactor: define grid areas for both helper positions in fields

### DIFF
--- a/packages/field-base/src/styles/field-base-styles.js
+++ b/packages/field-base/src/styles/field-base-styles.js
@@ -20,11 +20,13 @@ export const field = css`
     --_gap-s: round(var(--_gap) / 3, 2px);
     display: inline-grid;
     grid-template:
-      'label' auto var(--_helper-above-field, 'helper' auto) 'baseline' 0 'input' 1fr var(
-        --_helper-below-field,
-        'helper' auto
-      )
-      'error' auto / 100%;
+      'label' auto
+      'top-helper' auto
+      'baseline' 0
+      'input' 1fr
+      'bottom-helper' auto
+      'error' auto
+      / 100%;
     height: fit-content;
     outline: none;
     cursor: default;
@@ -168,7 +170,7 @@ export const field = css`
     line-height: var(--vaadin-input-field-helper-line-height, inherit);
     font-weight: var(--vaadin-input-field-helper-font-weight, 400);
     color: var(--vaadin-input-field-helper-color, var(--vaadin-text-color-secondary));
-    grid-area: helper;
+    grid-area: var(--_helper-above-field, top-helper) var(--_helper-below-field, bottom-helper);
     margin-top: var(--_helper-above-field, var(--_gap-s)) var(--_helper-below-field, var(--_gap));
     margin-bottom: var(--_helper-above-field, var(--_gap));
   }

--- a/packages/slider/src/styles/vaadin-slider-base-styles.js
+++ b/packages/slider/src/styles/vaadin-slider-base-styles.js
@@ -39,11 +39,14 @@ export const sliderStyles = css`
 
   :host([min-max-visible]) {
     grid-template:
-      'label' auto var(--_helper-above-field, 'helper' auto) 'baseline' 0 'input' 1fr 'marks' auto var(
-        --_helper-below-field,
-        'helper' auto
-      )
-      'error' auto / 100%;
+      'label' auto
+      'top-helper' auto
+      'baseline' 0
+      'input' 1fr
+      'marks' auto
+      'bottom-helper' auto
+      'error' auto
+      / 100%;
   }
 
   #controls {


### PR DESCRIPTION
## Description

- Defined a grid row for the helper both above and below the input (`top-helper` / `bottom-helper` areas) in the field grid template
- The helper picks its row through `grid-area`, and the empty row collapses to zero height
  - This makes the template static instead of inserting rows with custom property toggles
- Applied the same change to the slider's `min-max-visible` grid template

## Type of change

- Refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)