### PR TITLE
fix: disable month calendar tap highlight and user select

### DIFF
--- a/packages/date-picker/src/styles/vaadin-month-calendar-base-styles.js
+++ b/packages/date-picker/src/styles/vaadin-month-calendar-base-styles.js
@@ -10,6 +10,9 @@ export const monthCalendarStyles = css`
   :host {
     display: block;
     padding: var(--vaadin-date-picker-month-padding, var(--vaadin-padding-s));
+    -webkit-tap-highlight-color: transparent;
+    -webkit-user-select: none;
+    user-select: none;
   }
 
   [part='month-header'] {


### PR DESCRIPTION
## Description

The following properties are set in Lumo but missing from base styles of `vaadin-month-calendar`:

https://github.com/vaadin/web-components/blob/88a65ac03e9294b8785c2c919f8be9187537cdde/packages/vaadin-lumo-styles/src/components/date-picker-month-calendar.css#L9-L11

As a result, it's possible to select text in cells, and default blue highlight is shown on date tap on Android.

Added missing styles. We might consider refactoring Lumo to use base styles separately later.

## Type of change

- Bugfix