### PR TITLE
refactor!: update month-calendar Lumo to use base styles

### DIFF
--- a/packages/date-picker/src/vaadin-month-calendar.js
+++ b/packages/date-picker/src/vaadin-month-calendar.js
@@ -26,6 +26,10 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolylitMixin(LumoIn
     return monthCalendarStyles;
   }
 
+  static get lumoInjector() {
+    return { ...super.lumoInjector, includeBaseStyles: true };
+  }
+
   /** @protected */
   render() {
     const weekDayNames = this.__computeWeekDayNames(this.i18n, this.showWeekNumbers);

--- a/packages/vaadin-lumo-styles/src/components/date-picker-month-calendar.css
+++ b/packages/vaadin-lumo-styles/src/components/date-picker-month-calendar.css
@@ -5,84 +5,74 @@
  */
 @media lumo_components_date-picker-month-calendar {
   :host {
-    display: block;
-    -webkit-user-select: none;
-    -webkit-tap-highlight-color: transparent;
-    user-select: none;
     font-size: var(--lumo-font-size-m);
     color: var(--lumo-body-text-color);
     text-align: center;
-    padding: 0 var(--lumo-space-xs);
     --_focus-ring-color: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
     --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);
     --_selection-color: var(--vaadin-selection-color, var(--lumo-primary-color));
     --_selection-color-text: var(--vaadin-selection-color-text, var(--lumo-primary-text-color));
-  }
-
-  #monthGrid {
-    width: 100%;
-    border-collapse: collapse;
-  }
-
-  #days-container tr,
-  #weekdays-container tr {
-    display: flex;
+    --vaadin-date-picker-month-padding: 0 var(--lumo-space-xs);
+    --vaadin-date-picker-month-header-color: var(--lumo-header-text-color);
+    --vaadin-date-picker-month-header-font-size: var(--lumo-font-size-l);
+    --vaadin-date-picker-weekday-color: var(--lumo-secondary-text-color);
+    --vaadin-date-picker-weekday-font-size: var(--lumo-font-size-xxs);
+    --vaadin-date-picker-weekday-font-weight: normal;
+    --vaadin-date-picker-week-number-color: var(--lumo-secondary-text-color);
+    --vaadin-date-picker-week-number-font-size: var(--lumo-font-size-xxs);
+    --vaadin-date-picker-date-border-radius: var(--lumo-border-radius-m);
+    --vaadin-date-picker-date-height: var(--lumo-size-m);
+    --vaadin-date-picker-date-today-color: var(--_selection-color-text);
+    --vaadin-date-picker-date-selected-color: var(--lumo-primary-contrast-color);
+    --vaadin-date-picker-date-selected-background: var(--_selection-color);
+    --vaadin-date-picker-date-disabled-color: var(--lumo-disabled-text-color);
   }
 
   [part~='disabled'] {
     pointer-events: none;
   }
 
+  [disabled] {
+    opacity: 1;
+  }
+
   /* Month header */
 
   [part='month-header'] {
-    color: var(--lumo-header-text-color);
-    font-size: var(--lumo-font-size-l);
-    line-height: 1;
-    font-weight: 500;
     margin-bottom: var(--lumo-space-m);
   }
 
   /* Week days and numbers */
 
-  [part='weekdays'],
-  [part='weekday'],
-  [part='week-number'] {
-    font-size: var(--lumo-font-size-xxs);
+  [part~='weekday'] {
     line-height: 1;
-    color: var(--lumo-secondary-text-color);
-  }
-
-  [part='weekdays'] {
     margin-bottom: var(--lumo-space-s);
   }
 
-  [part='weekday']:empty,
-  [part='week-number'] {
-    flex-shrink: 0;
-    padding: 0;
-    width: var(--lumo-size-xs);
+  table {
+    grid-template-columns: repeat(7, calc(100% / 7));
   }
 
-  [part='week-number'][hidden],
-  [part='weekday'][hidden] {
+  :host([week-numbers]) table {
+    grid-template-columns: var(--lumo-size-xs) repeat(7, calc((100% - var(--lumo-size-xs)) / 7));
+  }
+
+  :host([week-numbers]) [part~='weekday']:empty {
+    display: flex;
+  }
+
+  [part~='week-number'] {
+    grid-column: auto;
+    margin: 0;
+  }
+
+  [part~='week-number']::after {
     display: none;
   }
 
-  /* Date and week number cells */
-
-  [part~='date'],
-  [part='week-number'] {
-    box-sizing: border-box;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    height: var(--lumo-size-m);
-    position: relative;
-  }
+  /* Date cells */
 
   [part~='date'] {
-    outline: none;
     transition: color 0.1s;
   }
 
@@ -90,49 +80,29 @@
     cursor: var(--lumo-clickable-cursor);
   }
 
-  [part='weekday'],
-  [part~='date'] {
-    width: calc(100% / 7);
-    padding: 0;
-    font-weight: normal;
-  }
+  /* Selection, hover and focus indicator */
 
-  :host([week-numbers]) [part='weekday']:not(:empty),
-  :host([week-numbers]) [part~='date'] {
-    width: calc((100% - var(--lumo-size-xs)) / 7);
-  }
-
-  /* Today date */
-
-  [part~='date'][part~='today'] {
-    color: var(--_selection-color-text);
-  }
-
-  /* Focused date */
-
-  [part~='date']::before {
-    content: '';
-    position: absolute;
-    z-index: -1;
+  [part~='date']::after {
     top: 50%;
     left: 50%;
-    transform: translate(-50%, -50%);
-    min-width: 2em;
-    min-height: 2em;
+    translate: -50% -50%;
     width: 80%;
     height: 80%;
-    max-height: 100%;
+    min-width: 2em;
+    min-height: 2em;
     max-width: 100%;
-    border-radius: var(--lumo-border-radius-m);
+    max-height: 100%;
+    aspect-ratio: auto;
+    outline: none;
   }
 
-  [part~='date'][part~='focused']::before {
+  [part~='date'][part~='focused']::after {
     box-shadow:
       0 0 0 1px var(--lumo-base-color),
       0 0 0 calc(var(--_focus-ring-width) + 1px) var(--_focus-ring-color);
   }
 
-  :host(:not([focused])) [part~='date'][part~='focused']::before {
+  :host(:not([focused])) [part~='date'][part~='focused']::after {
     animation: vaadin-date-picker-month-calendar-focus-date 1.4s infinite;
   }
 
@@ -144,36 +114,25 @@
     }
   }
 
-  [part~='date']:not(:empty):not([part~='disabled']):not([part~='selected']):hover::before {
+  [part~='date']:not(:empty):not([part~='disabled']):not([part~='selected']):hover::after {
     background-color: var(--lumo-primary-color-10pct);
   }
 
-  [part~='date'][part~='selected'] {
-    color: var(--lumo-primary-contrast-color);
-  }
-
-  [part~='date'][part~='selected']::before {
-    background-color: var(--_selection-color);
-  }
-
-  [part~='date'][part~='disabled'] {
-    color: var(--lumo-disabled-text-color);
-  }
-
   @media (pointer: coarse) {
-    [part~='date']:hover:not([part~='selected'])::before,
-    :host(:not([focus-ring])) [part~='focused']:not([part~='selected'])::before {
+    [part~='date']:hover:not([part~='selected'])::after,
+    :host(:not([focus-ring])) [part~='focused']:not([part~='selected'])::after {
       display: none;
     }
 
-    [part~='date']:not(:empty):not([part~='disabled']):active::before {
+    [part~='date']:not(:empty):not([part~='disabled']):active::after {
       display: block;
     }
 
-    :host(:not([focus-ring])) [part~='date'][part~='selected']::before {
+    :host(:not([focus-ring])) [part~='date'][part~='selected']::after {
       box-shadow: none;
     }
   }
+
   /* Disabled */
 
   :host([disabled]) * {

--- a/packages/vaadin-lumo-styles/src/components/date-picker-month-calendar.css
+++ b/packages/vaadin-lumo-styles/src/components/date-picker-month-calendar.css
@@ -8,43 +8,31 @@
     font-size: var(--lumo-font-size-m);
     color: var(--lumo-body-text-color);
     text-align: center;
+    padding: var(--vaadin-date-picker-month-padding, 0 var(--lumo-space-xs));
     --_focus-ring-color: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
     --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);
     --_selection-color: var(--vaadin-selection-color, var(--lumo-primary-color));
     --_selection-color-text: var(--vaadin-selection-color-text, var(--lumo-primary-text-color));
-    --vaadin-date-picker-month-padding: 0 var(--lumo-space-xs);
-    --vaadin-date-picker-month-header-color: var(--lumo-header-text-color);
-    --vaadin-date-picker-month-header-font-size: var(--lumo-font-size-l);
-    --vaadin-date-picker-weekday-color: var(--lumo-secondary-text-color);
-    --vaadin-date-picker-weekday-font-size: var(--lumo-font-size-xxs);
-    --vaadin-date-picker-weekday-font-weight: normal;
-    --vaadin-date-picker-week-number-color: var(--lumo-secondary-text-color);
-    --vaadin-date-picker-week-number-font-size: var(--lumo-font-size-xxs);
-    --vaadin-date-picker-date-border-radius: var(--lumo-border-radius-m);
-    --vaadin-date-picker-date-height: var(--lumo-size-m);
-    --vaadin-date-picker-date-today-color: var(--_selection-color-text);
-    --vaadin-date-picker-date-selected-color: var(--lumo-primary-contrast-color);
-    --vaadin-date-picker-date-selected-background: var(--_selection-color);
-    --vaadin-date-picker-date-disabled-color: var(--lumo-disabled-text-color);
   }
 
   [part~='disabled'] {
     pointer-events: none;
   }
 
-  [disabled] {
-    opacity: 1;
-  }
-
   /* Month header */
 
   [part='month-header'] {
+    color: var(--vaadin-date-picker-month-header-color, var(--lumo-header-text-color));
+    font-size: var(--vaadin-date-picker-month-header-font-size, var(--lumo-font-size-l));
     margin-bottom: var(--lumo-space-m);
   }
 
   /* Week days and numbers */
 
   [part~='weekday'] {
+    color: var(--vaadin-date-picker-weekday-color, var(--lumo-secondary-text-color));
+    font-size: var(--vaadin-date-picker-weekday-font-size, var(--lumo-font-size-xxs));
+    font-weight: var(--vaadin-date-picker-weekday-font-weight, normal);
     line-height: 1;
     margin-bottom: var(--lumo-space-s);
   }
@@ -62,6 +50,8 @@
   }
 
   [part~='week-number'] {
+    color: var(--vaadin-date-picker-week-number-color, var(--lumo-secondary-text-color));
+    font-size: var(--vaadin-date-picker-week-number-font-size, var(--lumo-font-size-xxs));
     grid-column: auto;
     margin: 0;
   }
@@ -73,11 +63,25 @@
   /* Date cells */
 
   [part~='date'] {
+    border-radius: var(--vaadin-date-picker-date-border-radius, var(--lumo-border-radius-m));
+    height: var(--vaadin-date-picker-date-height, var(--lumo-size-m));
     transition: color 0.1s;
   }
 
   [part~='date']:not(:empty) {
     cursor: var(--lumo-clickable-cursor);
+  }
+
+  [part~='today'] {
+    color: var(--vaadin-date-picker-date-today-color, var(--_selection-color-text));
+  }
+
+  [part~='selected'] {
+    color: var(--vaadin-date-picker-date-selected-color, var(--lumo-primary-contrast-color));
+  }
+
+  [part~='selected']::after {
+    background: var(--vaadin-date-picker-date-selected-background, var(--_selection-color));
   }
 
   /* Selection, hover and focus indicator */
@@ -134,6 +138,11 @@
   }
 
   /* Disabled */
+
+  [disabled] {
+    color: var(--vaadin-date-picker-date-disabled-color, var(--lumo-disabled-text-color));
+    opacity: 1;
+  }
 
   :host([disabled]) * {
     color: var(--lumo-disabled-text-color) !important;

--- a/packages/vaadin-lumo-styles/src/components/date-picker-month-calendar.css
+++ b/packages/vaadin-lumo-styles/src/components/date-picker-month-calendar.css
@@ -80,10 +80,6 @@
     color: var(--vaadin-date-picker-date-selected-color, var(--lumo-primary-contrast-color));
   }
 
-  [part~='selected']::after {
-    background: var(--vaadin-date-picker-date-selected-background, var(--_selection-color));
-  }
-
   /* Selection, hover and focus indicator */
 
   [part~='date']::after {
@@ -98,6 +94,10 @@
     max-height: 100%;
     aspect-ratio: auto;
     outline: none;
+  }
+
+  [part~='selected']::after {
+    background: var(--vaadin-date-picker-date-selected-background, var(--_selection-color));
   }
 
   [part~='date'][part~='focused']::after {

--- a/packages/vaadin-lumo-styles/src/components/date-picker-month-calendar.css
+++ b/packages/vaadin-lumo-styles/src/components/date-picker-month-calendar.css
@@ -37,12 +37,8 @@
     margin-bottom: var(--lumo-space-s);
   }
 
-  table {
-    grid-template-columns: repeat(7, calc(100% / 7));
-  }
-
   :host([week-numbers]) table {
-    grid-template-columns: var(--lumo-size-xs) repeat(7, calc((100% - var(--lumo-size-xs)) / 7));
+    grid-template-columns: var(--lumo-size-xs) repeat(7, 1fr);
   }
 
   :host([week-numbers]) [part~='weekday']:empty {

--- a/packages/vaadin-lumo-styles/src/components/date-picker-overlay-content.css
+++ b/packages/vaadin-lumo-styles/src/components/date-picker-overlay-content.css
@@ -27,9 +27,9 @@
     /* prettier-ignore */
     --vaadin-infinite-scroller-item-height:
       calc(
-          var(--lumo-font-size-l) + var(--lumo-space-m)
-        + var(--lumo-font-size-xs) + var(--lumo-space-s)
-        + var(--lumo-size-m) * 6
+          var(--vaadin-date-picker-month-header-font-size, var(--lumo-font-size-l)) + var(--lumo-space-m)
+        + var(--vaadin-date-picker-weekday-font-size, var(--lumo-font-size-xs)) + var(--lumo-space-s)
+        + var(--vaadin-date-picker-date-height, var(--lumo-size-m)) * 6
         + var(--lumo-space-s)
       );
     --vaadin-infinite-scroller-buffer-offset: 10%;


### PR DESCRIPTION
## Description

Updated `vaadin-month-calendar` Lumo to use base styles and added overrides to keep the original appearance.

> [!WARNING] 
> Breaking change: date focus indicators are now using `[part~='date']::after` instead of `::before` - affects custom themes, even though docs don't currently list this as public styling API.

## Type of change

- Refactor