### PR TITLE
refactor!: move date cell semantics to a button inside the cell

### DIFF
--- a/packages/date-picker/src/styles/vaadin-month-calendar-base-styles.js
+++ b/packages/date-picker/src/styles/vaadin-month-calendar-base-styles.js
@@ -69,7 +69,8 @@ export const monthCalendarStyles = css`
 
   [part~='weekday'],
   [part~='week-number'],
-  [part~='date'] {
+  [part~='date'],
+  [part~='date-button'] {
     align-items: center;
     display: flex;
     justify-content: center;
@@ -81,7 +82,6 @@ export const monthCalendarStyles = css`
     position: relative;
     height: var(--vaadin-date-picker-date-height, 2rem);
     cursor: var(--vaadin-clickable-cursor);
-    outline: none;
   }
 
   [part~='date']:empty {
@@ -97,7 +97,13 @@ export const monthCalendarStyles = css`
     aspect-ratio: 1;
   }
 
-  :where([part~='date']:focus-visible)::after {
+  [part~='date-button'] {
+    flex: 1;
+    align-self: stretch;
+    outline: none;
+  }
+
+  :where([part~='date']:has(:focus-visible))::after {
     outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
     outline-offset: calc(var(--vaadin-focus-ring-width) * -1);
   }

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -230,6 +230,10 @@ export const DatePickerOverlayContentMixin = (superClass) =>
       return this.calendars.map((calendar) => calendar.focusableDateElement).find(Boolean);
     }
 
+    get focusableDateButton() {
+      return this.calendars.map((calendar) => calendar.focusableDateButton).find(Boolean);
+    }
+
     /** @protected */
     _initControllers() {
       this.addController(
@@ -897,12 +901,12 @@ export const DatePickerOverlayContentMixin = (superClass) =>
     __tryFocusDate() {
       const dateToFocus = this.__pendingDateFocus;
       if (dateToFocus) {
-        // Check the date element with tabindex="0"
+        // Check the cell of the date that has the focusable button
         const dateElement = this.focusableDateElement;
 
         if (dateElement && dateEquals(dateElement.date, this.__pendingDateFocus)) {
           delete this.__pendingDateFocus;
-          dateElement.focus();
+          this.focusableDateButton.focus();
         }
       }
     }

--- a/packages/date-picker/src/vaadin-month-calendar-mixin.js
+++ b/packages/date-picker/src/vaadin-month-calendar-mixin.js
@@ -146,15 +146,32 @@ export const MonthCalendarMixin = (superClass) =>
       return ['__focusedDateChanged(focusedDate, _days)', '_showWeekNumbersChanged(showWeekNumbers, i18n)'];
     }
 
+    /**
+     * The date cell of the focused date. It carries the `date` property and the date part names,
+     * while the button inside it is the element that takes DOM focus.
+     */
     get focusableDateElement() {
       return [...this.shadowRoot.querySelectorAll('[part~=date]')].find((datePart) => {
         return dateEquals(datePart.date, this.focusedDate);
       });
     }
 
+    /**
+     * The button inside the cell of the focused date. Screen readers get the date's name and state
+     * from this element, so it is also the element that takes DOM focus.
+     */
+    get focusableDateButton() {
+      const cell = this.focusableDateElement;
+      return cell ? cell.querySelector('[part~=date-button]') : undefined;
+    }
+
     /** @protected */
     ready() {
       super.ready();
+
+      // Use application to enforce focus mode for date cells in NVDA
+      this.setAttribute('role', 'application');
+
       addListener(this.$.monthGrid, 'tap', this._handleTap.bind(this));
     }
 
@@ -294,11 +311,11 @@ export const MonthCalendarMixin = (superClass) =>
 
     /** @protected */
     _handleTap(e) {
-      if (!this.ignoreTaps && !this._notTapping && e.target.date && !e.target.hasAttribute('disabled')) {
-        this.selectedDate = e.target.date;
-        this.dispatchEvent(
-          new CustomEvent('date-tap', { detail: { date: e.target.date }, bubbles: true, composed: true }),
-        );
+      // A tap can land on the button or on the cell padding around it.
+      const cell = e.target.closest('[part~=date]');
+      if (!this.ignoreTaps && !this._notTapping && cell?.date && !cell.hasAttribute('disabled')) {
+        this.selectedDate = cell.date;
+        this.dispatchEvent(new CustomEvent('date-tap', { detail: { date: cell.date }, bubbles: true, composed: true }));
       }
     }
 

--- a/packages/date-picker/src/vaadin-month-calendar.js
+++ b/packages/date-picker/src/vaadin-month-calendar.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { html, LitElement } from 'lit';
+import { html, LitElement, nothing } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { LumoInjectionMixin } from '@vaadin/vaadin-themable-mixin/lumo-injection-mixin.js';
@@ -80,16 +80,24 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolylitMixin(LumoIn
                       )}"
                       .date="${date}"
                       ?disabled="${this.__isDayDisabled(date, this.minDate, this.maxDate, this.isDateDisabled)}"
-                      tabindex="${this.__computeDayTabIndex(date, this.focusedDate)}"
                       aria-selected="${this.__computeDayAriaSelected(date, this.selectedDate)}"
-                      aria-disabled="${this.__computeDayAriaDisabled(
-                        date,
-                        this.minDate,
-                        this.maxDate,
-                        this.isDateDisabled,
-                      )}"
-                      aria-label="${this.__computeDayAriaLabel(date)}"
-                      >${this._getDate(date)}</td
+                      >${
+                        date
+                          ? html`<div
+                              part="date-button"
+                              role="button"
+                              tabindex="${this.__computeDayTabIndex(date, this.focusedDate)}"
+                              aria-label="${this.__computeDayAriaLabel(date)}"
+                              aria-disabled="${this.__computeDayAriaDisabled(
+                                date,
+                                this.minDate,
+                                this.maxDate,
+                                this.isDateDisabled,
+                              )}"
+                              >${this._getDate(date)}</div
+                            >`
+                          : nothing
+                      }</td
                     >
                   `;
                 })}

--- a/packages/date-picker/test/date-metadata-provider.test.js
+++ b/packages/date-picker/test/date-metadata-provider.test.js
@@ -4,7 +4,16 @@ import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
 import { DateMetadataController } from '../src/vaadin-date-metadata-controller.js';
 import { formatISODate, monthIndex, parseDate } from '../src/vaadin-date-picker-helper.js';
-import { getCalendars, getDateCell, getDateCells, getMonthCalendar, isoDate, isoDateInMonth, open } from './helpers.js';
+import {
+  getCalendars,
+  getDateButton,
+  getDateCell,
+  getDateCells,
+  getMonthCalendar,
+  isoDate,
+  isoDateInMonth,
+  open,
+} from './helpers.js';
 
 describe('dateMetadataProvider integration', () => {
   let datePicker, overlayContent, today, year, month;
@@ -84,8 +93,8 @@ describe('dateMetadataProvider integration', () => {
     });
 
     it('should set aria-disabled on a provider-disabled date', () => {
-      expect(cell15.getAttribute('aria-disabled')).to.equal('true');
-      expect(cell16.getAttribute('aria-disabled')).to.equal('false');
+      expect(getDateButton(cell15).getAttribute('aria-disabled')).to.equal('true');
+      expect(getDateButton(cell16).getAttribute('aria-disabled')).to.equal('false');
     });
 
     it('should not report loading for an answer that needs no waiting', () => {
@@ -121,7 +130,7 @@ describe('dateMetadataProvider integration', () => {
 
     it('should keep the dates of a pending month selectable', () => {
       expect(isDisabled(cell15)).to.be.false;
-      expect(cell15.getAttribute('aria-disabled')).to.equal('false');
+      expect(getDateButton(cell15).getAttribute('aria-disabled')).to.equal('false');
     });
 
     it('should commit a date picked from a month being fetched', async () => {
@@ -144,10 +153,10 @@ describe('dateMetadataProvider integration', () => {
       expect(overlayContent.hasAttribute('aria-busy')).to.be.false;
 
       expect(isDisabled(cell15)).to.be.true;
-      expect(cell15.getAttribute('aria-disabled')).to.equal('true');
+      expect(getDateButton(cell15).getAttribute('aria-disabled')).to.equal('true');
 
       expect(isDisabled(cell16)).to.be.false;
-      expect(cell16.getAttribute('aria-disabled')).to.equal('false');
+      expect(getDateButton(cell16).getAttribute('aria-disabled')).to.equal('false');
 
       expect(cell15.part.contains('loading')).to.be.false;
       expect(cell16.part.contains('loading')).to.be.false;

--- a/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
+++ b/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
@@ -389,27 +389,42 @@ snapshots["vaadin-date-picker host opened default"] =
     </vaadin-button>
     <vaadin-date-picker-month-scroller slot="months">
       <div slot="vaadin-infinite-scroller-item-content-4">
-        <vaadin-month-calendar aria-hidden="true">
+        <vaadin-month-calendar
+          aria-hidden="true"
+          role="application"
+        >
         </vaadin-month-calendar>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-5">
-        <vaadin-month-calendar aria-hidden="true">
+        <vaadin-month-calendar
+          aria-hidden="true"
+          role="application"
+        >
         </vaadin-month-calendar>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-6">
-        <vaadin-month-calendar aria-hidden="true">
+        <vaadin-month-calendar
+          aria-hidden="true"
+          role="application"
+        >
         </vaadin-month-calendar>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-7">
-        <vaadin-month-calendar>
+        <vaadin-month-calendar role="application">
         </vaadin-month-calendar>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-8">
-        <vaadin-month-calendar aria-hidden="true">
+        <vaadin-month-calendar
+          aria-hidden="true"
+          role="application"
+        >
         </vaadin-month-calendar>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-9">
-        <vaadin-month-calendar aria-hidden="true">
+        <vaadin-month-calendar
+          aria-hidden="true"
+          role="application"
+        >
         </vaadin-month-calendar>
       </div>
     </vaadin-date-picker-month-scroller>

--- a/packages/date-picker/test/dom/__snapshots__/month-calendar.test.snap.js
+++ b/packages/date-picker/test/dom/__snapshots__/month-calendar.test.snap.js
@@ -2,7 +2,10 @@
 export const snapshots = {};
 
 snapshots["vaadin-month-calendar host default"] = 
-`<vaadin-month-calendar aria-hidden="true">
+`<vaadin-month-calendar
+  aria-hidden="true"
+  role="application"
+>
 </vaadin-month-calendar>
 `;
 /* end snapshot vaadin-month-calendar host default */
@@ -106,73 +109,100 @@ snapshots["vaadin-month-calendar shadow default"] =
         5
       </td>
       <td
-        aria-disabled="false"
-        aria-label=""
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
       </td>
       <td
-        aria-disabled="false"
-        aria-label="1 February 2016, Monday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        1
+        <div
+          aria-disabled="false"
+          aria-label="1 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          1
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="2 February 2016, Tuesday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        2
+        <div
+          aria-disabled="false"
+          aria-label="2 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          2
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="3 February 2016, Wednesday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        3
+        <div
+          aria-disabled="false"
+          aria-label="3 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          3
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="4 February 2016, Thursday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        4
+        <div
+          aria-disabled="false"
+          aria-label="4 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          4
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="5 February 2016, Friday, Today"
         aria-selected="false"
         part="date today"
         role="gridcell"
-        tabindex="-1"
       >
-        5
+        <div
+          aria-disabled="false"
+          aria-label="5 February 2016, Friday, Today"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          5
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="6 February 2016, Saturday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        6
+        <div
+          aria-disabled="false"
+          aria-label="6 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          6
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -184,74 +214,109 @@ snapshots["vaadin-month-calendar shadow default"] =
         5
       </td>
       <td
-        aria-disabled="false"
-        aria-label="7 February 2016, Sunday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        7
+        <div
+          aria-disabled="false"
+          aria-label="7 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          7
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="8 February 2016, Monday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        8
+        <div
+          aria-disabled="false"
+          aria-label="8 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          8
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="9 February 2016, Tuesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        9
+        <div
+          aria-disabled="false"
+          aria-label="9 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          9
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="10 February 2016, Wednesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        10
+        <div
+          aria-disabled="false"
+          aria-label="10 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          10
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="11 February 2016, Thursday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        11
+        <div
+          aria-disabled="false"
+          aria-label="11 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          11
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="12 February 2016, Friday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        12
+        <div
+          aria-disabled="false"
+          aria-label="12 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          12
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="13 February 2016, Saturday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        13
+        <div
+          aria-disabled="false"
+          aria-label="13 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          13
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -263,74 +328,109 @@ snapshots["vaadin-month-calendar shadow default"] =
         6
       </td>
       <td
-        aria-disabled="false"
-        aria-label="14 February 2016, Sunday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        14
+        <div
+          aria-disabled="false"
+          aria-label="14 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          14
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="15 February 2016, Monday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        15
+        <div
+          aria-disabled="false"
+          aria-label="15 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          15
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="16 February 2016, Tuesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        16
+        <div
+          aria-disabled="false"
+          aria-label="16 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          16
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="17 February 2016, Wednesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        17
+        <div
+          aria-disabled="false"
+          aria-label="17 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          17
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="18 February 2016, Thursday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        18
+        <div
+          aria-disabled="false"
+          aria-label="18 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          18
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="19 February 2016, Friday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        19
+        <div
+          aria-disabled="false"
+          aria-label="19 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          19
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="20 February 2016, Saturday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        20
+        <div
+          aria-disabled="false"
+          aria-label="20 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          20
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -342,74 +442,109 @@ snapshots["vaadin-month-calendar shadow default"] =
         7
       </td>
       <td
-        aria-disabled="false"
-        aria-label="21 February 2016, Sunday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        21
+        <div
+          aria-disabled="false"
+          aria-label="21 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          21
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="22 February 2016, Monday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        22
+        <div
+          aria-disabled="false"
+          aria-label="22 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          22
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="23 February 2016, Tuesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        23
+        <div
+          aria-disabled="false"
+          aria-label="23 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          23
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="24 February 2016, Wednesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        24
+        <div
+          aria-disabled="false"
+          aria-label="24 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          24
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="25 February 2016, Thursday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        25
+        <div
+          aria-disabled="false"
+          aria-label="25 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          25
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="26 February 2016, Friday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        26
+        <div
+          aria-disabled="false"
+          aria-label="26 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          26
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="27 February 2016, Saturday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        27
+        <div
+          aria-disabled="false"
+          aria-label="27 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          27
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -421,24 +556,34 @@ snapshots["vaadin-month-calendar shadow default"] =
         8
       </td>
       <td
-        aria-disabled="false"
-        aria-label="28 February 2016, Sunday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        28
+        <div
+          aria-disabled="false"
+          aria-label="28 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          28
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="29 February 2016, Monday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        29
+        <div
+          aria-disabled="false"
+          aria-label="29 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          29
+        </div>
       </td>
     </tr>
   </tbody>
@@ -545,73 +690,100 @@ snapshots["vaadin-month-calendar shadow max date"] =
         5
       </td>
       <td
-        aria-disabled="false"
-        aria-label=""
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
       </td>
       <td
-        aria-disabled="false"
-        aria-label="1 February 2016, Monday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        1
+        <div
+          aria-disabled="false"
+          aria-label="1 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          1
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="2 February 2016, Tuesday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        2
+        <div
+          aria-disabled="false"
+          aria-label="2 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          2
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="3 February 2016, Wednesday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        3
+        <div
+          aria-disabled="false"
+          aria-label="3 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          3
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="4 February 2016, Thursday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        4
+        <div
+          aria-disabled="false"
+          aria-label="4 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          4
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="5 February 2016, Friday, Today"
         aria-selected="false"
         part="date today"
         role="gridcell"
-        tabindex="-1"
       >
-        5
+        <div
+          aria-disabled="false"
+          aria-label="5 February 2016, Friday, Today"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          5
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="6 February 2016, Saturday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        6
+        <div
+          aria-disabled="false"
+          aria-label="6 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          6
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -623,77 +795,112 @@ snapshots["vaadin-month-calendar shadow max date"] =
         5
       </td>
       <td
-        aria-disabled="false"
-        aria-label="7 February 2016, Sunday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        7
+        <div
+          aria-disabled="false"
+          aria-label="7 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          7
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="8 February 2016, Monday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        8
+        <div
+          aria-disabled="false"
+          aria-label="8 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          8
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="9 February 2016, Tuesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        9
+        <div
+          aria-disabled="false"
+          aria-label="9 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          9
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="10 February 2016, Wednesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        10
+        <div
+          aria-disabled="false"
+          aria-label="10 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          10
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="11 February 2016, Thursday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        11
+        <div
+          aria-disabled="true"
+          aria-label="11 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          11
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="12 February 2016, Friday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        12
+        <div
+          aria-disabled="true"
+          aria-label="12 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          12
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="13 February 2016, Saturday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        13
+        <div
+          aria-disabled="true"
+          aria-label="13 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          13
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -705,81 +912,116 @@ snapshots["vaadin-month-calendar shadow max date"] =
         6
       </td>
       <td
-        aria-disabled="true"
-        aria-label="14 February 2016, Sunday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        14
+        <div
+          aria-disabled="true"
+          aria-label="14 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          14
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="15 February 2016, Monday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        15
+        <div
+          aria-disabled="true"
+          aria-label="15 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          15
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="16 February 2016, Tuesday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        16
+        <div
+          aria-disabled="true"
+          aria-label="16 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          16
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="17 February 2016, Wednesday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        17
+        <div
+          aria-disabled="true"
+          aria-label="17 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          17
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="18 February 2016, Thursday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        18
+        <div
+          aria-disabled="true"
+          aria-label="18 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          18
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="19 February 2016, Friday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        19
+        <div
+          aria-disabled="true"
+          aria-label="19 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          19
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="20 February 2016, Saturday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        20
+        <div
+          aria-disabled="true"
+          aria-label="20 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          20
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -791,81 +1033,116 @@ snapshots["vaadin-month-calendar shadow max date"] =
         7
       </td>
       <td
-        aria-disabled="true"
-        aria-label="21 February 2016, Sunday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        21
+        <div
+          aria-disabled="true"
+          aria-label="21 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          21
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="22 February 2016, Monday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        22
+        <div
+          aria-disabled="true"
+          aria-label="22 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          22
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="23 February 2016, Tuesday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        23
+        <div
+          aria-disabled="true"
+          aria-label="23 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          23
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="24 February 2016, Wednesday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        24
+        <div
+          aria-disabled="true"
+          aria-label="24 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          24
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="25 February 2016, Thursday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        25
+        <div
+          aria-disabled="true"
+          aria-label="25 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          25
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="26 February 2016, Friday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        26
+        <div
+          aria-disabled="true"
+          aria-label="26 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          26
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="27 February 2016, Saturday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        27
+        <div
+          aria-disabled="true"
+          aria-label="27 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          27
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -877,26 +1154,36 @@ snapshots["vaadin-month-calendar shadow max date"] =
         8
       </td>
       <td
-        aria-disabled="true"
-        aria-label="28 February 2016, Sunday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        28
+        <div
+          aria-disabled="true"
+          aria-label="28 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          28
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="29 February 2016, Monday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        29
+        <div
+          aria-disabled="true"
+          aria-label="29 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          29
+        </div>
       </td>
     </tr>
   </tbody>
@@ -1001,74 +1288,109 @@ snapshots["vaadin-month-calendar shadow week numbers"] =
         5
       </td>
       <td
-        aria-disabled="false"
-        aria-label="1 February 2016, Monday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        1
+        <div
+          aria-disabled="false"
+          aria-label="1 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          1
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="2 February 2016, Tuesday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        2
+        <div
+          aria-disabled="false"
+          aria-label="2 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          2
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="3 February 2016, Wednesday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        3
+        <div
+          aria-disabled="false"
+          aria-label="3 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          3
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="4 February 2016, Thursday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        4
+        <div
+          aria-disabled="false"
+          aria-label="4 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          4
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="5 February 2016, Friday, Today"
         aria-selected="false"
         part="date today"
         role="gridcell"
-        tabindex="-1"
       >
-        5
+        <div
+          aria-disabled="false"
+          aria-label="5 February 2016, Friday, Today"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          5
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="6 February 2016, Saturday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        6
+        <div
+          aria-disabled="false"
+          aria-label="6 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          6
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="7 February 2016, Sunday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        7
+        <div
+          aria-disabled="false"
+          aria-label="7 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          7
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -1079,74 +1401,109 @@ snapshots["vaadin-month-calendar shadow week numbers"] =
         6
       </td>
       <td
-        aria-disabled="false"
-        aria-label="8 February 2016, Monday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        8
+        <div
+          aria-disabled="false"
+          aria-label="8 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          8
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="9 February 2016, Tuesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        9
+        <div
+          aria-disabled="false"
+          aria-label="9 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          9
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="10 February 2016, Wednesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        10
+        <div
+          aria-disabled="false"
+          aria-label="10 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          10
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="11 February 2016, Thursday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        11
+        <div
+          aria-disabled="false"
+          aria-label="11 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          11
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="12 February 2016, Friday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        12
+        <div
+          aria-disabled="false"
+          aria-label="12 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          12
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="13 February 2016, Saturday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        13
+        <div
+          aria-disabled="false"
+          aria-label="13 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          13
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="14 February 2016, Sunday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        14
+        <div
+          aria-disabled="false"
+          aria-label="14 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          14
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -1157,74 +1514,109 @@ snapshots["vaadin-month-calendar shadow week numbers"] =
         7
       </td>
       <td
-        aria-disabled="false"
-        aria-label="15 February 2016, Monday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        15
+        <div
+          aria-disabled="false"
+          aria-label="15 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          15
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="16 February 2016, Tuesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        16
+        <div
+          aria-disabled="false"
+          aria-label="16 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          16
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="17 February 2016, Wednesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        17
+        <div
+          aria-disabled="false"
+          aria-label="17 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          17
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="18 February 2016, Thursday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        18
+        <div
+          aria-disabled="false"
+          aria-label="18 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          18
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="19 February 2016, Friday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        19
+        <div
+          aria-disabled="false"
+          aria-label="19 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          19
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="20 February 2016, Saturday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        20
+        <div
+          aria-disabled="false"
+          aria-label="20 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          20
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="21 February 2016, Sunday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        21
+        <div
+          aria-disabled="false"
+          aria-label="21 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          21
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -1235,74 +1627,109 @@ snapshots["vaadin-month-calendar shadow week numbers"] =
         8
       </td>
       <td
-        aria-disabled="false"
-        aria-label="22 February 2016, Monday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        22
+        <div
+          aria-disabled="false"
+          aria-label="22 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          22
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="23 February 2016, Tuesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        23
+        <div
+          aria-disabled="false"
+          aria-label="23 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          23
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="24 February 2016, Wednesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        24
+        <div
+          aria-disabled="false"
+          aria-label="24 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          24
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="25 February 2016, Thursday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        25
+        <div
+          aria-disabled="false"
+          aria-label="25 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          25
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="26 February 2016, Friday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        26
+        <div
+          aria-disabled="false"
+          aria-label="26 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          26
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="27 February 2016, Saturday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        27
+        <div
+          aria-disabled="false"
+          aria-label="27 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          27
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="28 February 2016, Sunday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        28
+        <div
+          aria-disabled="false"
+          aria-label="28 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          28
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -1313,14 +1740,19 @@ snapshots["vaadin-month-calendar shadow week numbers"] =
         9
       </td>
       <td
-        aria-disabled="false"
-        aria-label="29 February 2016, Monday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        29
+        <div
+          aria-disabled="false"
+          aria-label="29 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          29
+        </div>
       </td>
     </tr>
   </tbody>
@@ -1427,76 +1859,103 @@ snapshots["vaadin-month-calendar shadow disabled dates"] =
         5
       </td>
       <td
-        aria-disabled="false"
-        aria-label=""
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
       </td>
       <td
-        aria-disabled="true"
-        aria-label="1 February 2016, Monday"
         aria-selected="false"
         disabled=""
         part="date disabled past"
         role="gridcell"
-        tabindex="-1"
       >
-        1
+        <div
+          aria-disabled="true"
+          aria-label="1 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          1
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="2 February 2016, Tuesday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        2
+        <div
+          aria-disabled="false"
+          aria-label="2 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          2
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="3 February 2016, Wednesday"
         aria-selected="false"
         disabled=""
         part="date disabled past"
         role="gridcell"
-        tabindex="-1"
       >
-        3
+        <div
+          aria-disabled="true"
+          aria-label="3 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          3
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="4 February 2016, Thursday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        4
+        <div
+          aria-disabled="false"
+          aria-label="4 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          4
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="5 February 2016, Friday, Today"
         aria-selected="false"
         disabled=""
         part="date disabled today"
         role="gridcell"
-        tabindex="-1"
       >
-        5
+        <div
+          aria-disabled="true"
+          aria-label="5 February 2016, Friday, Today"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          5
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="6 February 2016, Saturday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        6
+        <div
+          aria-disabled="false"
+          aria-label="6 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          6
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -1508,78 +1967,113 @@ snapshots["vaadin-month-calendar shadow disabled dates"] =
         5
       </td>
       <td
-        aria-disabled="true"
-        aria-label="7 February 2016, Sunday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        7
+        <div
+          aria-disabled="true"
+          aria-label="7 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          7
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="8 February 2016, Monday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        8
+        <div
+          aria-disabled="false"
+          aria-label="8 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          8
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="9 February 2016, Tuesday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        9
+        <div
+          aria-disabled="true"
+          aria-label="9 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          9
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="10 February 2016, Wednesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        10
+        <div
+          aria-disabled="false"
+          aria-label="10 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          10
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="11 February 2016, Thursday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        11
+        <div
+          aria-disabled="true"
+          aria-label="11 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          11
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="12 February 2016, Friday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        12
+        <div
+          aria-disabled="false"
+          aria-label="12 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          12
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="13 February 2016, Saturday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        13
+        <div
+          aria-disabled="true"
+          aria-label="13 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          13
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -1591,77 +2085,112 @@ snapshots["vaadin-month-calendar shadow disabled dates"] =
         6
       </td>
       <td
-        aria-disabled="false"
-        aria-label="14 February 2016, Sunday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        14
+        <div
+          aria-disabled="false"
+          aria-label="14 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          14
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="15 February 2016, Monday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        15
+        <div
+          aria-disabled="true"
+          aria-label="15 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          15
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="16 February 2016, Tuesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        16
+        <div
+          aria-disabled="false"
+          aria-label="16 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          16
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="17 February 2016, Wednesday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        17
+        <div
+          aria-disabled="true"
+          aria-label="17 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          17
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="18 February 2016, Thursday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        18
+        <div
+          aria-disabled="false"
+          aria-label="18 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          18
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="19 February 2016, Friday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        19
+        <div
+          aria-disabled="true"
+          aria-label="19 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          19
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="20 February 2016, Saturday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        20
+        <div
+          aria-disabled="false"
+          aria-label="20 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          20
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -1673,78 +2202,113 @@ snapshots["vaadin-month-calendar shadow disabled dates"] =
         7
       </td>
       <td
-        aria-disabled="true"
-        aria-label="21 February 2016, Sunday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        21
+        <div
+          aria-disabled="true"
+          aria-label="21 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          21
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="22 February 2016, Monday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        22
+        <div
+          aria-disabled="false"
+          aria-label="22 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          22
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="23 February 2016, Tuesday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        23
+        <div
+          aria-disabled="true"
+          aria-label="23 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          23
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="24 February 2016, Wednesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        24
+        <div
+          aria-disabled="false"
+          aria-label="24 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          24
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="25 February 2016, Thursday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        25
+        <div
+          aria-disabled="true"
+          aria-label="25 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          25
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="26 February 2016, Friday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        26
+        <div
+          aria-disabled="false"
+          aria-label="26 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          26
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="27 February 2016, Saturday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        27
+        <div
+          aria-disabled="true"
+          aria-label="27 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          27
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -1756,25 +2320,35 @@ snapshots["vaadin-month-calendar shadow disabled dates"] =
         8
       </td>
       <td
-        aria-disabled="false"
-        aria-label="28 February 2016, Sunday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        28
+        <div
+          aria-disabled="false"
+          aria-label="28 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          28
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="29 February 2016, Monday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        29
+        <div
+          aria-disabled="true"
+          aria-label="29 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          29
+        </div>
       </td>
     </tr>
   </tbody>
@@ -1881,73 +2455,100 @@ snapshots["vaadin-month-calendar shadow date metadata loading month"] =
         5
       </td>
       <td
-        aria-disabled="false"
-        aria-label=""
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
       </td>
       <td
-        aria-disabled="false"
-        aria-label="1 February 2016, Monday"
         aria-selected="false"
         part="date loading past"
         role="gridcell"
-        tabindex="-1"
       >
-        1
+        <div
+          aria-disabled="false"
+          aria-label="1 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          1
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="2 February 2016, Tuesday"
         aria-selected="false"
         part="date loading past"
         role="gridcell"
-        tabindex="-1"
       >
-        2
+        <div
+          aria-disabled="false"
+          aria-label="2 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          2
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="3 February 2016, Wednesday"
         aria-selected="false"
         part="date loading past"
         role="gridcell"
-        tabindex="-1"
       >
-        3
+        <div
+          aria-disabled="false"
+          aria-label="3 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          3
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="4 February 2016, Thursday"
         aria-selected="false"
         part="date loading past"
         role="gridcell"
-        tabindex="-1"
       >
-        4
+        <div
+          aria-disabled="false"
+          aria-label="4 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          4
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="5 February 2016, Friday, Today"
         aria-selected="false"
         part="date loading today"
         role="gridcell"
-        tabindex="-1"
       >
-        5
+        <div
+          aria-disabled="false"
+          aria-label="5 February 2016, Friday, Today"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          5
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="6 February 2016, Saturday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        6
+        <div
+          aria-disabled="false"
+          aria-label="6 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          6
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -1959,74 +2560,109 @@ snapshots["vaadin-month-calendar shadow date metadata loading month"] =
         5
       </td>
       <td
-        aria-disabled="false"
-        aria-label="7 February 2016, Sunday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        7
+        <div
+          aria-disabled="false"
+          aria-label="7 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          7
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="8 February 2016, Monday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        8
+        <div
+          aria-disabled="false"
+          aria-label="8 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          8
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="9 February 2016, Tuesday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        9
+        <div
+          aria-disabled="false"
+          aria-label="9 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          9
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="10 February 2016, Wednesday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        10
+        <div
+          aria-disabled="false"
+          aria-label="10 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          10
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="11 February 2016, Thursday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        11
+        <div
+          aria-disabled="false"
+          aria-label="11 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          11
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="12 February 2016, Friday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        12
+        <div
+          aria-disabled="false"
+          aria-label="12 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          12
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="13 February 2016, Saturday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        13
+        <div
+          aria-disabled="false"
+          aria-label="13 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          13
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -2038,74 +2674,109 @@ snapshots["vaadin-month-calendar shadow date metadata loading month"] =
         6
       </td>
       <td
-        aria-disabled="false"
-        aria-label="14 February 2016, Sunday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        14
+        <div
+          aria-disabled="false"
+          aria-label="14 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          14
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="15 February 2016, Monday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        15
+        <div
+          aria-disabled="false"
+          aria-label="15 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          15
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="16 February 2016, Tuesday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        16
+        <div
+          aria-disabled="false"
+          aria-label="16 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          16
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="17 February 2016, Wednesday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        17
+        <div
+          aria-disabled="false"
+          aria-label="17 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          17
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="18 February 2016, Thursday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        18
+        <div
+          aria-disabled="false"
+          aria-label="18 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          18
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="19 February 2016, Friday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        19
+        <div
+          aria-disabled="false"
+          aria-label="19 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          19
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="20 February 2016, Saturday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        20
+        <div
+          aria-disabled="false"
+          aria-label="20 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          20
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -2117,74 +2788,109 @@ snapshots["vaadin-month-calendar shadow date metadata loading month"] =
         7
       </td>
       <td
-        aria-disabled="false"
-        aria-label="21 February 2016, Sunday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        21
+        <div
+          aria-disabled="false"
+          aria-label="21 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          21
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="22 February 2016, Monday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        22
+        <div
+          aria-disabled="false"
+          aria-label="22 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          22
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="23 February 2016, Tuesday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        23
+        <div
+          aria-disabled="false"
+          aria-label="23 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          23
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="24 February 2016, Wednesday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        24
+        <div
+          aria-disabled="false"
+          aria-label="24 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          24
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="25 February 2016, Thursday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        25
+        <div
+          aria-disabled="false"
+          aria-label="25 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          25
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="26 February 2016, Friday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        26
+        <div
+          aria-disabled="false"
+          aria-label="26 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          26
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="27 February 2016, Saturday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        27
+        <div
+          aria-disabled="false"
+          aria-label="27 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          27
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -2196,24 +2902,34 @@ snapshots["vaadin-month-calendar shadow date metadata loading month"] =
         8
       </td>
       <td
-        aria-disabled="false"
-        aria-label="28 February 2016, Sunday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        28
+        <div
+          aria-disabled="false"
+          aria-label="28 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          28
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="29 February 2016, Monday"
         aria-selected="false"
         part="date loading future"
         role="gridcell"
-        tabindex="-1"
       >
-        29
+        <div
+          aria-disabled="false"
+          aria-label="29 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          29
+        </div>
       </td>
     </tr>
   </tbody>
@@ -2320,76 +3036,103 @@ snapshots["vaadin-month-calendar shadow date metadata provider disabled dates"] 
         5
       </td>
       <td
-        aria-disabled="false"
-        aria-label=""
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
       </td>
       <td
-        aria-disabled="true"
-        aria-label="1 February 2016, Monday"
         aria-selected="false"
         disabled=""
         part="date disabled past"
         role="gridcell"
-        tabindex="-1"
       >
-        1
+        <div
+          aria-disabled="true"
+          aria-label="1 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          1
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="2 February 2016, Tuesday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        2
+        <div
+          aria-disabled="false"
+          aria-label="2 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          2
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="3 February 2016, Wednesday"
         aria-selected="false"
         disabled=""
         part="date disabled past"
         role="gridcell"
-        tabindex="-1"
       >
-        3
+        <div
+          aria-disabled="true"
+          aria-label="3 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          3
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="4 February 2016, Thursday"
         aria-selected="false"
         part="date past"
         role="gridcell"
-        tabindex="-1"
       >
-        4
+        <div
+          aria-disabled="false"
+          aria-label="4 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          4
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="5 February 2016, Friday, Today"
         aria-selected="false"
         disabled=""
         part="date disabled today"
         role="gridcell"
-        tabindex="-1"
       >
-        5
+        <div
+          aria-disabled="true"
+          aria-label="5 February 2016, Friday, Today"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          5
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="6 February 2016, Saturday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        6
+        <div
+          aria-disabled="false"
+          aria-label="6 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          6
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -2401,78 +3144,113 @@ snapshots["vaadin-month-calendar shadow date metadata provider disabled dates"] 
         5
       </td>
       <td
-        aria-disabled="true"
-        aria-label="7 February 2016, Sunday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        7
+        <div
+          aria-disabled="true"
+          aria-label="7 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          7
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="8 February 2016, Monday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        8
+        <div
+          aria-disabled="false"
+          aria-label="8 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          8
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="9 February 2016, Tuesday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        9
+        <div
+          aria-disabled="true"
+          aria-label="9 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          9
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="10 February 2016, Wednesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        10
+        <div
+          aria-disabled="false"
+          aria-label="10 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          10
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="11 February 2016, Thursday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        11
+        <div
+          aria-disabled="true"
+          aria-label="11 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          11
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="12 February 2016, Friday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        12
+        <div
+          aria-disabled="false"
+          aria-label="12 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          12
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="13 February 2016, Saturday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        13
+        <div
+          aria-disabled="true"
+          aria-label="13 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          13
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -2484,77 +3262,112 @@ snapshots["vaadin-month-calendar shadow date metadata provider disabled dates"] 
         6
       </td>
       <td
-        aria-disabled="false"
-        aria-label="14 February 2016, Sunday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        14
+        <div
+          aria-disabled="false"
+          aria-label="14 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          14
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="15 February 2016, Monday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        15
+        <div
+          aria-disabled="true"
+          aria-label="15 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          15
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="16 February 2016, Tuesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        16
+        <div
+          aria-disabled="false"
+          aria-label="16 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          16
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="17 February 2016, Wednesday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        17
+        <div
+          aria-disabled="true"
+          aria-label="17 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          17
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="18 February 2016, Thursday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        18
+        <div
+          aria-disabled="false"
+          aria-label="18 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          18
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="19 February 2016, Friday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        19
+        <div
+          aria-disabled="true"
+          aria-label="19 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          19
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="20 February 2016, Saturday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        20
+        <div
+          aria-disabled="false"
+          aria-label="20 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          20
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -2566,78 +3379,113 @@ snapshots["vaadin-month-calendar shadow date metadata provider disabled dates"] 
         7
       </td>
       <td
-        aria-disabled="true"
-        aria-label="21 February 2016, Sunday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        21
+        <div
+          aria-disabled="true"
+          aria-label="21 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          21
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="22 February 2016, Monday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        22
+        <div
+          aria-disabled="false"
+          aria-label="22 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          22
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="23 February 2016, Tuesday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        23
+        <div
+          aria-disabled="true"
+          aria-label="23 February 2016, Tuesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          23
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="24 February 2016, Wednesday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        24
+        <div
+          aria-disabled="false"
+          aria-label="24 February 2016, Wednesday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          24
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="25 February 2016, Thursday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        25
+        <div
+          aria-disabled="true"
+          aria-label="25 February 2016, Thursday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          25
+        </div>
       </td>
       <td
-        aria-disabled="false"
-        aria-label="26 February 2016, Friday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        26
+        <div
+          aria-disabled="false"
+          aria-label="26 February 2016, Friday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          26
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="27 February 2016, Saturday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        27
+        <div
+          aria-disabled="true"
+          aria-label="27 February 2016, Saturday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          27
+        </div>
       </td>
     </tr>
     <tr role="row">
@@ -2649,25 +3497,35 @@ snapshots["vaadin-month-calendar shadow date metadata provider disabled dates"] 
         8
       </td>
       <td
-        aria-disabled="false"
-        aria-label="28 February 2016, Sunday"
         aria-selected="false"
         part="date future"
         role="gridcell"
-        tabindex="-1"
       >
-        28
+        <div
+          aria-disabled="false"
+          aria-label="28 February 2016, Sunday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          28
+        </div>
       </td>
       <td
-        aria-disabled="true"
-        aria-label="29 February 2016, Monday"
         aria-selected="false"
         disabled=""
         part="date disabled future"
         role="gridcell"
-        tabindex="-1"
       >
-        29
+        <div
+          aria-disabled="true"
+          aria-label="29 February 2016, Monday"
+          part="date-button"
+          role="button"
+          tabindex="-1"
+        >
+          29
+        </div>
       </td>
     </tr>
   </tbody>

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -3,7 +3,7 @@ import { resetMouse, sendKeys, sendMouse } from '@vaadin/test-runner-commands';
 import { aTimeout, fire, fixtureSync, mousedown, nextRender, oneEvent, touchstart } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
-import { getFocusableCell, monthsEqual, open, untilOverlayRendered } from './helpers.js';
+import { getFocusableDateButton, monthsEqual, open, untilOverlayRendered } from './helpers.js';
 
 describe('dropdown', () => {
   let datePicker, input, overlay;
@@ -273,10 +273,10 @@ describe('dropdown', () => {
 
   describe('date tap', () => {
     function dateTap() {
-      const date = getFocusableCell(datePicker);
-      mousedown(date);
-      date.focus();
-      date.click();
+      const button = getFocusableDateButton(datePicker);
+      mousedown(button);
+      button.focus();
+      button.click();
     }
 
     it('should close the overlay on date tap', async () => {

--- a/packages/date-picker/test/fullscreen.test.js
+++ b/packages/date-picker/test/fullscreen.test.js
@@ -3,7 +3,7 @@ import { resetMouse, sendKeys, sendMouse, setViewport } from '@vaadin/test-runne
 import { aTimeout, fixtureSync, nextRender, nextUpdate, outsideClick, tabKeyDown, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
-import { getFocusableCell, open, touchTap, untilOverlayRendered } from './helpers.js';
+import { getFocusableCell, getFocusableDateButton, open, touchTap, untilOverlayRendered } from './helpers.js';
 
 describe('fullscreen mode', () => {
   let datePicker, input, overlay, width, height;
@@ -333,9 +333,9 @@ describe('fullscreen mode', () => {
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should move focus to date cell button on Cancel button Tab', async () => {
-      const cell = getFocusableCell(datePicker);
-      const spy = sinon.spy(cell, 'focus');
+    it('should move focus to date button on Cancel button Tab', async () => {
+      const button = getFocusableDateButton(datePicker);
+      const spy = sinon.spy(button, 'focus');
 
       // Move focus to Cancel button
       await sendKeys({ press: 'Shift+Tab' });

--- a/packages/date-picker/test/helpers.js
+++ b/packages/date-picker/test/helpers.js
@@ -188,9 +188,22 @@ export function getWeekDayCells(calendar) {
 }
 
 /**
+ * The button inside a date cell. It takes DOM focus and carries the date's accessible name and
+ * ARIA state, while the cell carries the `date` property and the part names.
+ *
+ * @param {HTMLElement} cell a date cell of a month calendar
+ * @return {HTMLElement | null}
+ */
+export function getDateButton(cell) {
+  return cell.querySelector('[part~="date-button"]');
+}
+
+/**
+ * The date button that is in the tab sequence, i.e. the one the calendar focuses.
+ *
  * @param {HTMLElement} root vaadin-date-picker or vaadin-date-picker-overlay-content
  */
-export function getFocusableCell(root) {
+export function getFocusableDateButton(root) {
   const focusableMonth = getCalendars(root).find((month) => {
     return !!month.shadowRoot.querySelector('[tabindex="0"]');
   });
@@ -201,12 +214,26 @@ export function getFocusableCell(root) {
 }
 
 /**
+ * The cell of the date button that is in the tab sequence.
+ *
+ * @param {HTMLElement} root vaadin-date-picker or vaadin-date-picker-overlay-content
+ */
+export function getFocusableCell(root) {
+  const button = getFocusableDateButton(root);
+  if (button) {
+    return button.closest('[part~="date"]');
+  }
+}
+
+/**
+ * The cell of the date button that currently has DOM focus.
+ *
  * @param {HTMLElement} root vaadin-date-picker or vaadin-date-picker-overlay-content
  */
 export function getFocusedCell(root) {
-  const focusableCell = getFocusableCell(root);
-  if (focusableCell && isElementFocused(focusableCell)) {
-    return focusableCell;
+  const button = getFocusableDateButton(root);
+  if (button && isElementFocused(button)) {
+    return button.closest('[part~="date"]');
   }
 }
 

--- a/packages/date-picker/test/month-calendar.test.js
+++ b/packages/date-picker/test/month-calendar.test.js
@@ -2,7 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, makeSoloTouchEvent, nextFrame, nextRender, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-month-calendar.js';
-import { getDateCell, getDateCells, getDefaultI18n, getWeekDayCells } from './helpers.js';
+import { getDateButton, getDateCell, getDateCells, getDefaultI18n, getWeekDayCells } from './helpers.js';
 
 describe('vaadin-month-calendar', () => {
   let monthCalendar, valueChangedSpy;
@@ -99,6 +99,13 @@ describe('vaadin-month-calendar', () => {
     expect(monthCalendar.selectedDate.getDate()).to.equal(10);
   });
 
+  it('should update value on tapping the date button', () => {
+    tap(getDateButton(getDateCell(monthCalendar, 10)));
+    expect(monthCalendar.selectedDate.getFullYear()).to.equal(2016);
+    expect(monthCalendar.selectedDate.getMonth()).to.equal(1);
+    expect(monthCalendar.selectedDate.getDate()).to.equal(10);
+  });
+
   it('should not react if the tap takes more than 300ms', async () => {
     const tapSpy = sinon.spy();
     monthCalendar.addEventListener('date-tap', tapSpy);
@@ -179,7 +186,7 @@ describe('vaadin-month-calendar', () => {
     it('should label dates in correct locale', () => {
       const dates = getDateCells(monthCalendar);
       dates.slice(0, 7).forEach((date, index) => {
-        const label = date.getAttribute('aria-label');
+        const label = getDateButton(date).getAttribute('aria-label');
         const day = ['maanantai', 'tiistai', 'keskiviikko', 'torstai', 'perjantai', 'lauantai', 'sunnuntai'][index];
         expect(label).to.equal(`${index + 1} helmikuu 2016, ${day}`);
       });
@@ -189,7 +196,7 @@ describe('vaadin-month-calendar', () => {
       monthCalendar.month = new Date();
       await nextRender();
       const today = getDateCells(monthCalendar).find((date) => date.getAttribute('part').includes('today'));
-      expect(today.getAttribute('aria-label').split(', ').pop()).to.equal('Tänään');
+      expect(getDateButton(today).getAttribute('aria-label').split(', ').pop()).to.equal('Tänään');
     });
 
     it('should render month name in correct locale', () => {

--- a/packages/date-picker/test/wai-aria.test.js
+++ b/packages/date-picker/test/wai-aria.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-date-picker.js';
-import { activateScroller, getCalendars, getDefaultI18n, open } from './helpers.js';
+import { activateScroller, getCalendars, getDateButton, getDefaultI18n, open } from './helpers.js';
 
 describe('WAI-ARIA', () => {
   describe('date picker', () => {
@@ -126,11 +126,11 @@ describe('WAI-ARIA', () => {
       await nextRender();
     });
 
-    it('should indicate today on date cells', async () => {
+    it('should indicate today on date buttons', async () => {
       monthCalendar.month = new Date();
       await nextFrame();
       const todayElement = monthCalendar.shadowRoot.querySelector('[part~="today"]');
-      expect(todayElement.getAttribute('aria-label')).to.match(/, Today$/u);
+      expect(getDateButton(todayElement).getAttribute('aria-label')).to.match(/, Today$/u);
     });
   });
 


### PR DESCRIPTION
## Description

Part of #12398

Changed DOM structure to use the [React Aria Calendar](https://react-aria.adobe.com/Calendar) approach.


- Added `<div part="date-button" role="button">`  inside `<td role="gridcell">` as the focus target
- Moved the `aria-label`, `aria-disabled` and `tabindex` from `<td>` element to `<div role="button">` 
  - needed because on iOS VoiceOver reads text content of `gridcell` and ignores its `aria-label`.
- Set `role="application"` on `vaadin-month-calendar` to enforce NVDA to switch to focus mode
  - needed as by default, NVDA remains in browse mode, where arrow keys do not move to other dates
- Button is stretched using CSS to cover the whole cell, so that cell remains a pointer and touch target
- No whitespace in cell template so blank cells remain empty and the `:empty` CSS selector applies
- Updated focus ring to `:has(:focus-visible)`, so it shows on keyboard focus but not after a click
- Split the calendar getters into `focusableDateElement` and `focusableDateButton` for the cell / button
- Modified test helpers, added `getDateButton` and `getFocusableDateButton` for getting focus target
- Updated tests, added unit tests for tapping the date button and for selection staying on the cell
- Regenerated the month calendar DOM snapshots to cover the new markup and the application role

## Type of change

- Refactor

## Note

> [!NOTE]
> NVDA announces a date twice, once for the cell and once for the focused button, because the cell
> takes its name from its content. That is inherent to a labelled focusable element inside a
> `gridcell` rather than something this PR can attribute away, and react-spectrum ships the same
> behavior.

> [!WARNING]
> Date cell markup changed: `aria-label`, `tabindex` and `aria-disabled` are now on a
> button inside the cell rather than on the cell itself. Code that queried a date cell for
> any of these needs to be updated accordingly, including Flow component ITs.

## Screen readers

With using `role="application"` on `vaadin-month-calendar`, arrow key navigation works correctly.

### VoiceOver on Safari 26

<img width="358" height="188" alt="cell-button-voiceover-safari" src="https://github.com/user-attachments/assets/7879c8e5-c71f-4612-8fc5-2fda9ebb8ad5" />

### NVDA 2026.02

<img width="359" height="110" alt="cell-button-nvda" src="https://github.com/user-attachments/assets/417c33a1-287c-440f-88b8-1d0704a557b9" />

### JAWS 2026.2608.25

<img width="292" height="187" alt="cell-button-jaws" src="https://github.com/user-attachments/assets/7f7f6ce8-76b0-4c1c-83ea-fce5ee6fccbe" />
