### PR TITLE
test: add charts coverage for a11y, events, exporting and layout

### DIFF
--- a/packages/charts/test/accessibility.test.js
+++ b/packages/charts/test/accessibility.test.js
@@ -51,9 +51,8 @@ describe('vaadin-chart accessibility', () => {
       expect(chart.shadowRoot.querySelector('.highcharts-focus-border')).to.exist;
     });
 
-    // `KeyboardNavigation.onMouseUp` is overridden in `vaadin-chart-mixin.js` to read
-    // `composedPath()[0]`: on a document listener the target is the <vaadin-chart> host,
-    // so every release would look like an outside one.
+    // On a document listener the event target is the <vaadin-chart> host, so without
+    // the composed path every mouse release would look like an outside one.
     // Workaround for https://github.com/highcharts/highcharts/issues/23490
     describe('pointer release', () => {
       beforeEach(async () => {

--- a/packages/charts/test/accessibility.test.js
+++ b/packages/charts/test/accessibility.test.js
@@ -1,0 +1,81 @@
+import { expect } from '@vaadin/chai-plugins';
+import { sendKeys } from '@vaadin/test-runner-commands';
+import { fixtureSync, mouseup, oneEvent } from '@vaadin/testing-helpers';
+import './chart-not-animated-styles.js';
+import '../src/vaadin-chart.js';
+
+function focusedPointIndex(chart) {
+  return chart.configuration.highlightedPoint?.index;
+}
+
+describe('vaadin-chart accessibility', () => {
+  let chart;
+
+  beforeEach(async () => {
+    chart = fixtureSync(`
+      <vaadin-chart title="Sales">
+        <vaadin-chart-series title="Installation" values="[19, 12, 9, 24, 5]"></vaadin-chart-series>
+        <vaadin-chart-series title="Manufacturing" values="[3, 8, 14, 2, 20]"></vaadin-chart-series>
+      </vaadin-chart>
+    `);
+    await oneEvent(chart, 'chart-load');
+    chart.shadowRoot.querySelector('.highcharts-a11y-proxy-element').focus();
+  });
+
+  describe('screen reader', () => {
+    it('should render the accessibility proxy elements inside the shadow root', () => {
+      expect(chart.shadowRoot.querySelector('.highcharts-a11y-proxy-container-before')).to.exist;
+      expect(chart.shadowRoot.querySelector('.highcharts-a11y-proxy-container-after')).to.exist;
+    });
+
+    it('should name every point after its value and series', () => {
+      const points = chart.configuration.series.flatMap((series) => series.points);
+      expect(points).to.have.lengthOf(10);
+      points.forEach((point) => {
+        expect(point.graphic.element.getAttribute('aria-label')).to.be.a('string').and.not.be.empty;
+      });
+      expect(points[0].graphic.element.getAttribute('aria-label')).to.contain('19').and.to.contain('Installation');
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('should move to the next point on each arrow press', async () => {
+      await sendKeys({ press: 'ArrowRight' });
+      expect(focusedPointIndex(chart)).to.equal(0);
+      await sendKeys({ press: 'ArrowRight' });
+      expect(focusedPointIndex(chart)).to.equal(1);
+    });
+
+    it('should draw a focus border around the focused point', async () => {
+      await sendKeys({ press: 'ArrowRight' });
+      expect(chart.shadowRoot.querySelector('.highcharts-focus-border')).to.exist;
+    });
+
+    // `KeyboardNavigation.onMouseUp` is overridden in `vaadin-chart-mixin.js` to read
+    // `composedPath()[0]`: on a document listener the target is the <vaadin-chart> host,
+    // so every release would look like an outside one.
+    // Workaround for https://github.com/highcharts/highcharts/issues/23490
+    describe('pointer release', () => {
+      beforeEach(async () => {
+        await sendKeys({ press: 'ArrowRight' });
+        await sendKeys({ press: 'ArrowRight' });
+        expect(focusedPointIndex(chart)).to.equal(1);
+      });
+
+      it('should restart navigation when released outside the chart', async () => {
+        mouseup(document.body);
+        expect(chart.configuration.focusElement).to.not.exist;
+
+        await sendKeys({ press: 'ArrowRight' });
+        expect(focusedPointIndex(chart)).to.equal(0);
+      });
+
+      it('should continue navigation when released on the chart', async () => {
+        mouseup(chart.configuration.container);
+
+        await sendKeys({ press: 'ArrowRight' });
+        expect(focusedPointIndex(chart)).to.equal(2);
+      });
+    });
+  });
+});

--- a/packages/charts/test/chart-element.test.js
+++ b/packages/charts/test/chart-element.test.js
@@ -83,54 +83,54 @@ describe('vaadin-chart', () => {
   describe('organization', () => {
     let chart;
 
+    // `__forceResize` in `vaadin-chart-mixin.js` re-measures the labels, which are
+    // otherwise positioned before the styled-mode label CSS applies.
+    // Workaround for https://github.com/highcharts/highcharts/issues/23443
+    // On 12.2.0: ~7 px deviation with the workaround, ~73 px without it.
+    function worstLabelDeviation() {
+      const nodes = chart.configuration.series[0].nodes.filter((node) => node.graphic && node.dataLabel);
+      // Fail loudly if a Highcharts upgrade leaves nothing to measure.
+      expect(nodes).to.have.lengthOf(13);
+
+      return nodes.reduce((worst, node) => {
+        const box = node.graphic.element.getBoundingClientRect();
+        const label = node.dataLabel.element.getBoundingClientRect();
+        const dx = label.left + label.width / 2 - (box.left + box.width / 2);
+        const dy = label.top + label.height / 2 - (box.top + box.height / 2);
+        return Math.max(worst, Math.hypot(dx, dy));
+      }, 0);
+    }
+
     beforeEach(async () => {
-      chart = fixtureSync('<vaadin-chart type="gantt"></vaadin-chart>');
-      chart.updateConfiguration(
-        {
-          chart: {
-            styledMode: true,
-            inverted: true,
-            type: 'organization',
-          },
-          title: {
-            text: 'Acme organization chart',
-          },
-          series: [
-            {
-              keys: ['from', 'to'],
-              nodes: [
-                {
-                  id: 'Acme',
-                },
-                {
-                  id: 'Head Office',
-                },
-                {
-                  id: 'Labs',
-                },
-              ],
-              name: 'Highsoft',
-              data: [
-                ['Acme', 'Head Office'],
-                ['Acme', 'Labs'],
-              ],
-            },
-          ],
-        },
-        true,
-      );
-      await oneEvent(chart, 'chart-end-resize');
+      chart = fixtureSync(`
+        <vaadin-chart type="organization" title="Acme" style="width: 800px; height: 500px"
+          additional-options='{ "chart": { "inverted": true } }'>
+          <vaadin-chart-series
+            title="Acme"
+            values='[
+              ["Acme", "Head Office"], ["Acme", "Labs"],
+              ["Head Office", "Coyote Building"], ["Head Office", "Road Runner Building"],
+              ["Coyote Building", "Sales"], ["Coyote Building", "Marketing"],
+              ["Road Runner Building", "Administration"], ["Road Runner Building", "MDs Office"],
+              ["Sales", "Joseph Miler"], ["Marketing", "Erik Perez"],
+              ["Administration", "Ewan Herbert"], ["MDs Office", "Sally Brown"]
+            ]'
+            additional-options='{
+              "keys": ["from", "to"],
+              "levels": [{ "level": 0, "height": 25 }, { "level": 1, "height": 25 }],
+              "nodeWidth": 65
+            }'
+          ></vaadin-chart-series>
+        </vaadin-chart>
+      `);
+      await oneEvent(chart, 'chart-load');
+      // `__initChart` schedules the label re-measure on the next animation frame.
+      await nextFrame();
+      await nextFrame();
     });
 
-    it('should have labels aligned with points', () => {
-      const renderElement = chart.$.chart;
-      const point = renderElement.querySelector('path.highcharts-node.highcharts-point.highcharts-color-0');
-      const label = renderElement.querySelector('div.highcharts-data-label.highcharts-data-label-color-0');
-
-      const { left: pointLeft, width: pointWidth } = point.getBoundingClientRect();
-      const { left: labelLeft, width: labelWidth } = label.getBoundingClientRect();
-
-      expect(pointLeft + pointWidth / 2).to.be.equal(labelLeft + labelWidth / 2);
+    it('should centre every data label on its own node', () => {
+      expect(worstLabelDeviation()).to.be.below(20);
     });
   });
 

--- a/packages/charts/test/chart-element.test.js
+++ b/packages/charts/test/chart-element.test.js
@@ -83,13 +83,11 @@ describe('vaadin-chart', () => {
   describe('organization', () => {
     let chart;
 
-    // `__forceResize` in `vaadin-chart-mixin.js` re-measures the labels, which are
-    // otherwise positioned before the styled-mode label CSS applies.
-    // Workaround for https://github.com/highcharts/highcharts/issues/23443
+    // Chart forces a resize to re-measure the labels, which are otherwise positioned
+    // before the styled-mode label CSS applies. See the TODO in vaadin-chart-mixin.js.
     // On 12.2.0: ~7 px deviation with the workaround, ~73 px without it.
     function worstLabelDeviation() {
       const nodes = chart.configuration.series[0].nodes.filter((node) => node.graphic && node.dataLabel);
-      // Fail loudly if a Highcharts upgrade leaves nothing to measure.
       expect(nodes).to.have.lengthOf(13);
 
       return nodes.reduce((worst, node) => {
@@ -124,7 +122,7 @@ describe('vaadin-chart', () => {
         </vaadin-chart>
       `);
       await oneEvent(chart, 'chart-load');
-      // `__initChart` schedules the label re-measure on the next animation frame.
+      // Wait to the next animation frame for label re-measurement.
       await nextFrame();
       await nextFrame();
     });

--- a/packages/charts/test/chart-series.test.js
+++ b/packages/charts/test/chart-series.test.js
@@ -395,11 +395,9 @@ describe('vaadin-chart-series', () => {
       expect(legend.classList.contains(HIDDEN)).to.be.true;
     });
   });
-  // `dataSorting` has no Vaadin or Flow API and is reachable only through
-  // `additionalOptions`, so nothing else in the suite exercises it. It moved out of
-  // the Highcharts core into `modules/data-sorting.js` in 13.x, which
-  // `vaadin-chart-mixin.js` does not import, and a missing module fails silently:
-  // the option is ignored and the points keep their input order.
+  // `dataSorting` moved out of the Highcharts core into `modules/data-sorting.js`
+  // in 13.x, which `vaadin-chart-mixin.js` does not import. A missing module fails
+  // silently: the option is ignored and the points keep their input order.
   describe('dataSorting', () => {
     let chart;
 

--- a/packages/charts/test/chart-series.test.js
+++ b/packages/charts/test/chart-series.test.js
@@ -395,4 +395,34 @@ describe('vaadin-chart-series', () => {
       expect(legend.classList.contains(HIDDEN)).to.be.true;
     });
   });
+  // `dataSorting` has no Vaadin or Flow API and is reachable only through
+  // `additionalOptions`, so nothing else in the suite exercises it. It moved out of
+  // the Highcharts core into `modules/data-sorting.js` in 13.x, which
+  // `vaadin-chart-mixin.js` does not import, and a missing module fails silently:
+  // the option is ignored and the points keep their input order.
+  describe('dataSorting', () => {
+    let chart;
+
+    beforeEach(async () => {
+      chart = fixtureSync(`
+        <vaadin-chart type="column">
+          <vaadin-chart-series
+            values='[{ "name": "A", "y": 3 }, { "name": "B", "y": 1 }, { "name": "C", "y": 2 }]'
+            additional-options='{ "dataSorting": { "enabled": true, "sortKey": "y" } }'
+          ></vaadin-chart-series>
+        </vaadin-chart>
+      `);
+      await oneEvent(chart, 'chart-load');
+    });
+
+    it('should order the points by the sort key rather than by input order', () => {
+      const names = chart.configuration.series[0].points
+        .slice()
+        .sort((a, b) => a.x - b.x)
+        .map((point) => point.name);
+
+      // Input order is A, B, C; sorted by descending `y` it is A(3), C(2), B(1).
+      expect(names).to.eql(['A', 'C', 'B']);
+    });
+  });
 });

--- a/packages/charts/test/events.test.js
+++ b/packages/charts/test/events.test.js
@@ -1,7 +1,9 @@
 import { expect } from '@vaadin/chai-plugins';
+import { resetMouse, sendMouse } from '@vaadin/test-runner-commands';
 import { click, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-chart.js';
+import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
 
 describe('vaadin-chart events', () => {
   let chart;
@@ -59,6 +61,77 @@ describe('vaadin-chart events', () => {
       chart.addEventListener('point-update', spy);
       chart.configuration.series[0].points[0].update({ y: 20 });
       expect(spy.calledOnce).to.be.true;
+    });
+  });
+
+  // `xAxisMin`/`xAxisMax`/`yAxisMin`/`yAxisMax` on `chart-selection` and
+  // `xValue`/`yValue` on `chart-click` are public API, read by Flow through
+  // `@EventData` in ChartSelectionEvent.java and ChartClickEvent.java.
+  describe('axis detail fields', () => {
+    let bounds;
+
+    beforeEach(async () => {
+      // Sized and zoomable so that a real drag produces a selection.
+      chart = fixtureSync(`
+        <vaadin-chart style="width: 600px; height: 400px"
+          additional-options='{ "chart": { "zooming": { "type": "xy" } } }'>
+          <vaadin-chart-series values="[10, 20, 30, 40, 50]"></vaadin-chart-series>
+        </vaadin-chart>
+      `);
+      await oneEvent(chart, 'chart-load');
+      const { left, top } = chart.getBoundingClientRect();
+      bounds = (x, y) => [Math.round(left + x), Math.round(top + y)];
+    });
+
+    afterEach(async () => {
+      await resetMouse();
+    });
+
+    it('should expose axis extremes on chart-selection', async () => {
+      const spy = sinon.spy();
+      chart.addEventListener('chart-selection', spy);
+
+      await sendMouse({ type: 'move', position: bounds(150, 150) });
+      await sendMouse({ type: 'down' });
+      await sendMouse({ type: 'move', position: bounds(350, 300) });
+      await sendMouse({ type: 'up' });
+
+      expect(spy).to.be.calledOnce;
+      const { xAxisMin, xAxisMax, yAxisMin, yAxisMax } = spy.firstCall.args[0].detail;
+      expect(xAxisMin).to.be.within(0, 4);
+      expect(xAxisMax).to.be.within(xAxisMin, 4);
+      expect(yAxisMin).to.be.a('number');
+      expect(yAxisMax).to.be.above(yAxisMin);
+    });
+
+    it('should expose axis values on chart-click', async () => {
+      const spy = sinon.spy();
+      chart.addEventListener('chart-click', spy);
+
+      await sendMouse({ type: 'click', position: bounds(300, 200) });
+
+      expect(spy).to.be.calledOnce;
+      const { xValue, yValue } = spy.firstCall.args[0].detail;
+      expect(xValue).to.be.within(0, 4);
+      expect(yValue).to.be.a('number');
+    });
+
+    // Highcharts always supplies both axes on a real interaction, so the guards'
+    // negative branch can only be driven with a synthetic payload. The keys must
+    // stay absent rather than be set to `undefined`, which is what replacing the
+    // guards with `Object.assign` would do.
+    it('should omit the axis fields the event does not carry', () => {
+      function detailOf(type, payload) {
+        const spy = sinon.spy();
+        chart.addEventListener(`chart-${type}`, spy);
+        Highcharts.fireEvent(chart.configuration, type, payload);
+        expect(spy).to.be.calledOnce;
+        return spy.firstCall.args[0].detail;
+      }
+
+      expect(detailOf('selection', {})).to.not.have.any.keys('xAxisMin', 'xAxisMax', 'yAxisMin', 'yAxisMax');
+      expect(detailOf('click', {})).to.not.have.any.keys('xValue', 'yValue');
+      expect(detailOf('selection', { xAxis: [{ min: 0, max: 5 }] })).to.not.have.any.keys('yAxisMin', 'yAxisMax');
     });
   });
 

--- a/packages/charts/test/events.test.js
+++ b/packages/charts/test/events.test.js
@@ -116,10 +116,8 @@ describe('vaadin-chart events', () => {
       expect(yValue).to.be.a('number');
     });
 
-    // Highcharts always supplies both axes on a real interaction, so the guards'
-    // negative branch can only be driven with a synthetic payload. The keys must
-    // stay absent rather than be set to `undefined`, which is what replacing the
-    // guards with `Object.assign` would do.
+    // A real interaction always carries both axes, so only a synthetic payload can
+    // cover this branch. The keys must stay absent rather than be set to `undefined`.
     it('should omit the axis fields the event does not carry', () => {
       function detailOf(type, payload) {
         const spy = sinon.spy();

--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -112,6 +112,14 @@ describe('vaadin-chart exporting', () => {
     expect(styleRemovedFromBody).to.be.true;
   });
 
+  // The export copy renders outside the shadow root, so without the style copying
+  // above the SVG loses its paint attributes (~35 `fill=` with the copy, a handful
+  // without). Workaround for https://github.com/vaadin/vaadin-charts/issues/389
+  it('should inline paint attributes into the exported SVG', () => {
+    const svg = chart.configuration.getSVGForExport({}, {});
+    expect(svg.match(/fill="/gu)).to.have.length.above(20);
+  });
+
   it('should dispatch export events once per export', () => {
     const events = [];
     chart.addEventListener('chart-before-export', () => events.push('before'));

--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -113,8 +113,8 @@ describe('vaadin-chart exporting', () => {
   });
 
   // The export copy renders outside the shadow root, so without the style copying
-  // above the SVG loses its paint attributes (~35 `fill=` with the copy, a handful
-  // without). Workaround for https://github.com/vaadin/vaadin-charts/issues/389
+  // above the SVG loses its paint attributes.
+  // Workaround for https://github.com/vaadin/vaadin-charts/issues/389
   it('should inline paint attributes into the exported SVG', () => {
     const svg = chart.configuration.getSVGForExport({}, {});
     expect(svg.match(/fill="/gu)).to.have.length.above(20);


### PR DESCRIPTION
## Description

Part of #12213

Preparation for the Highcharts 13 upgrade. Several integration points the
upgrade touches had no unit coverage, which is how the dead `tooltip.isSticky`
check in `onDocumentMouseMove` survived three Highcharts majors. Each test here
was checked by mutating the code it guards and confirming it fails.

- Added `accessibility.test.js` covering the screen-reader proxy elements,
  per-point accessible names, and keyboard navigation. The package had no
  accessibility tests at all while carrying a full-method override of
  `KeyboardNavigation.onMouseUp`
  - Releasing the pointer outside the chart restarts keyboard navigation while
    releasing it on the chart continues it. The second case fails when the
    override reads `e.target` instead of `composedPath()[0]`, which is the whole
    reason the override exists
- Added tests in `events.test.js` for the `chart-selection` and `chart-click`
  axis detail fields, which are public API read by Flow through `@EventData` in
  `ChartSelectionEvent.java` and `ChartClickEvent.java`
  - A real drag and a real click drive them with `sendMouse`, so they cover the
    payload Highcharts actually produces rather than a hand-built one that would
    stay green if the upstream shape changed in 13.x
  - A third test pins that the keys stay absent rather than becoming `undefined`,
    which is what replacing the guards with `Object.assign` would do. Highcharts
    always supplies both axes on a real interaction, so that branch is the one
    place a synthetic payload is still needed
- Added a content guard in `exporting.test.js` asserting the exported SVG still
  carries inlined paint attributes, so it cannot silently lose them again
- Replaced `should have labels aligned with points` in `chart-element.test.js`,
  which compared one organization node on one axis, with a measurement across
  all thirteen nodes on both axes
- Added a `dataSorting` test to `chart-series.test.js`, since that option moves
  out of the Highcharts core into `modules/data-sorting.js` in 13.x and a
  missing module degrades silently

## Type of change

- Tests

## How to test

Each step edits `packages/charts/src/vaadin-chart-mixin.js`, runs one file, then
reverts. Every mutation must fail, otherwise the test is not earning its place.

1. Comment out `this.__forceResize();` in `__initChart`. Run
   `yarn test --group charts --glob="chart-element*"` and expect
   `should centre every data label on its own node` to fail with
   `expected 73.16… to be below 20`.
2. In `KeyboardNavigation.prototype.onMouseUp`, change
   `const target = e.composedPath()[0];` to `const target = e.target;`. Run
   `yarn test --group charts --glob="accessibility*"` and expect
   `should continue navigation when released on the chart` to fail.
3. Delete the `event.type === 'selection'` and `event.type === 'click'` blocks
   that write the axis fields. Run `yarn test --group charts --glob="events*"`
   and expect two of the three `axis detail fields` tests to fail, with
   `should omit the axis fields the event does not carry` still passing.
4. Revert all edits and run `yarn test --group charts` — 219 passing.

> [!NOTE]
> `getSVGForExport` is on the chart prototype in 12.x and moves to the
> `Exporting` class in 12.3, so the export test's call site has to be updated as
> part of the upgrade. It will fail loudly rather than skip.
