### PR TITLE
fix: re-measure organization data labels without resizing the chart

### DIFF
--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -724,7 +724,7 @@ export const ChartMixin = (superClass) =>
         this.configuration = Highcharts.chart(this.$.chart, options);
       }
 
-      this.__forceResize();
+      this.__redrawOrganizationDataLabels();
     }
 
     /** @protected */
@@ -1480,24 +1480,26 @@ export const ChartMixin = (superClass) =>
     /**
      * @private
      * Workaround for https://github.com/highcharts/highcharts/issues/23443
-     * Forces a resize in the chart to make it calculate the labels positions
-     * correctly in a chart with "organization" series
+     * In styled mode the label CSS is not applied yet when "organization" data
+     * labels are first measured, so they need a second measurement pass.
      *
      * TODO: Remove when the related ticket is fixed
      */
-    __forceResize() {
-      const chart = this.configuration;
-      const { options } = chart;
-      const hasOrganizationSeries =
-        options.chart.styledMode &&
-        (options.chart.type === 'organization' || options.series.some((series) => series.type === 'organization'));
-      if (!hasOrganizationSeries) {
+    __redrawOrganizationDataLabels() {
+      if (!this.configuration.options.chart.styledMode) {
         return;
       }
 
+      // Series declared as <vaadin-chart-series> children are not on the chart yet,
+      // so the organization check waits for the frame too. Reading the chart there
+      // rather than capturing it also keeps a pending frame from holding a
+      // destroyed chart alive.
       requestAnimationFrame(() => {
-        chart.setSize(chart.chartWidth - 10, chart.chartHeight);
-        chart.setSize(null, null);
+        this.configuration?.series.forEach((series) => {
+          if (series.type === 'organization') {
+            series.drawDataLabels?.();
+          }
+        });
       });
     }
 

--- a/packages/charts/test/chart-element.test.js
+++ b/packages/charts/test/chart-element.test.js
@@ -83,8 +83,8 @@ describe('vaadin-chart', () => {
   describe('organization', () => {
     let chart;
 
-    // Chart forces a resize to re-measure the labels, which are otherwise positioned
-    // before the styled-mode label CSS applies. See the TODO in vaadin-chart-mixin.js.
+    // Chart re-measures the labels, which are otherwise positioned before the
+    // styled-mode label CSS applies. See the TODO in vaadin-chart-mixin.js.
     // On 12.2.0: ~7 px deviation with the workaround, ~73 px without it.
     function worstLabelDeviation() {
       const nodes = chart.configuration.series[0].nodes.filter((node) => node.graphic && node.dataLabel);
@@ -99,11 +99,14 @@ describe('vaadin-chart', () => {
       }, 0);
     }
 
-    beforeEach(async () => {
-      chart = fixtureSync(`
-        <vaadin-chart type="organization" title="Acme" style="width: 800px; height: 500px"
+    // The type can sit on the chart or on the series, and only the series knows it
+    // by the time the labels are re-measured.
+    function fixtureWithType({ chartType = '', seriesType = '' } = {}) {
+      return fixtureSync(`
+        <vaadin-chart ${chartType} title="Acme" style="width: 800px; height: 500px"
           additional-options='{ "chart": { "inverted": true } }'>
           <vaadin-chart-series
+            ${seriesType}
             title="Acme"
             values='[
               ["Acme", "Head Office"], ["Acme", "Labs"],
@@ -121,14 +124,33 @@ describe('vaadin-chart', () => {
           ></vaadin-chart-series>
         </vaadin-chart>
       `);
+    }
+
+    async function whenLabelsMeasured() {
       await oneEvent(chart, 'chart-load');
       // Wait to the next animation frame for label re-measurement.
       await nextFrame();
       await nextFrame();
+    }
+
+    it('should centre every data label on its own node', async () => {
+      chart = fixtureWithType({ chartType: 'type="organization"' });
+      await whenLabelsMeasured();
+      expect(worstLabelDeviation()).to.be.below(20);
     });
 
-    it('should centre every data label on its own node', () => {
+    it('should centre the labels when only the series declares the type', async () => {
+      chart = fixtureWithType({ seriesType: 'type="organization"' });
+      await whenLabelsMeasured();
       expect(worstLabelDeviation()).to.be.below(20);
+    });
+
+    it('should not resize the chart while re-measuring the labels', async () => {
+      chart = fixtureWithType({ chartType: 'type="organization"' });
+      const spy = sinon.spy();
+      chart.addEventListener('chart-end-resize', spy);
+      await whenLabelsMeasured();
+      expect(spy).to.not.be.called;
     });
   });
 


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/12213
Depends on #12597

Organization data labels are measured before the styled-mode label CSS applies, so
they land far outside their nodes. The workaround for
[highcharts#23443](https://github.com/highcharts/highcharts/issues/23443) forced a
second measurement by resizing the chart twice — `setSize(width - 10, height)` and
then `setSize(null, null)`.

The check that decided whether to run it never matched a chart whose organization
type sits on the series rather than on the chart. Highcharts empties
`options.series` during init, so `options.series.some(…)` was always false and
detection rested entirely on `options.chart.type`.

- Re-measure with `drawDataLabels()` on the organization series instead of two full chart reflows
- Check the series type inside the animation frame, where series declared as `<vaadin-chart-series>` children are present, which fixes the case where only the series carries `type="organization"`
  - On `dev/charts/organization.html` the worst label was 85.4 px from its node centre, on nodes 215 x 65 px. It is now 7.1 px
- Read the chart inside the frame rather than capturing it, so a pending frame cannot keep a destroyed chart alive
- Renamed `__forceResize` to `__redrawOrganizationDataLabels`, since the resize it named is gone
- Added tests for the series-declared type and for the absence of `chart-end-resize` during init

## Type of change

- Bugfix

## How to test

1. Run `yarn start` and open `dev/charts/organization.html`.
2. Move the type from the chart to the series: remove `type="organization"` from `<vaadin-chart>` and add it to `<vaadin-chart-series>`.
3. Every node label is centred on its node. Before this change the labels were offset by more than a node's height, many of them overlapping neighbouring nodes.

> [!NOTE]
> The two `setSize` calls fired two `chart-end-resize` events on every organization
> chart init. The label pass fires none — measured 2 to 0.

> [!NOTE]
> `drawDataLabels` is not in Highcharts' public typings, and the maintainer's
> suggested workaround was to resize on `load`. Worth re-checking on the 13.x
> upgrade; this site is not in the epic's audit list.
