### PR TITLE
refactor!: remove margin reset from auto-responsive form layout children

### DIFF
--- a/packages/form-layout/src/styles/vaadin-form-layout-base-styles.js
+++ b/packages/form-layout/src/styles/vaadin-form-layout-base-styles.js
@@ -146,9 +146,6 @@ export const formLayoutStyles = css`
 
     /* By default, place each child on a new row */
     grid-column: 1 / span min(var(--_grid-colspan, 1), var(--_grid-rendered-column-count));
-
-    /* Form items do not need margins in auto-responsive mode */
-    margin: 0;
   }
 
   :host([auto-responsive][auto-rows]) #layout ::slotted(*) {


### PR DESCRIPTION
## Description

- Removed the `margin: 0` reset from the auto-responsive layout's slotted children
  - #9743 added it to cancel the row spacing margin that `vaadin-form-item` used to carry on its host
  - #10291 moved the row spacing to the layout and removed that margin, so nothing is left to reset

## Type of change

- Refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)