### PR TITLE
fix: add type declaration for combo box placeholder module

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-placeholder.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-placeholder.d.ts
@@ -10,6 +10,10 @@
  * @private
  */
 declare class ComboBoxPlaceholder {
+  // Nominal brand: keeps structurally similar values from being assignable
+  // eslint-disable-next-line @typescript-eslint/no-unused-private-class-members
+  private __comboBoxPlaceholder: true;
+
   toString(): string;
 }
 

--- a/packages/combo-box/src/vaadin-combo-box-placeholder.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-placeholder.d.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright (c) 2015 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * Placeholder object class representing items being loaded.
+ *
+ * @private
+ */
+declare class ComboBoxPlaceholder {
+  toString(): string;
+}
+
+export { ComboBoxPlaceholder };

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -20,6 +20,7 @@ import type { ComboBoxItem } from '../../src/vaadin-combo-box-item';
 import type { ComboBoxItemMixinClass, ComboBoxItemRenderer } from '../../src/vaadin-combo-box-item-mixin';
 import type { ComboBoxItemsMixinClass } from '../../src/vaadin-combo-box-items-mixin';
 import type { ComboBoxMixinClass } from '../../src/vaadin-combo-box-mixin';
+import { ComboBoxPlaceholder } from '../../src/vaadin-combo-box-placeholder';
 import type {
   ComboBox,
   ComboBoxChangeEvent,
@@ -163,3 +164,15 @@ assertType<() => void>(narrowedItem.requestContentUpdate);
 assertType<ComboBoxItemMixinClass<TestComboBoxItem, ComboBox>>(narrowedItem);
 assertType<DirMixinClass>(narrowedItem);
 assertType<ThemableMixinClass>(narrowedItem);
+
+// Placeholder
+// @ts-expect-error the placeholder is nominal, structurally matching values are not assignable
+assertType<ComboBoxPlaceholder>('not a placeholder');
+
+const itemOrPlaceholder = narrowedItem.item as TestComboBoxItem | ComboBoxPlaceholder;
+const isPlaceholder = (item: unknown): item is ComboBoxPlaceholder => item instanceof ComboBoxPlaceholder;
+if (isPlaceholder(itemOrPlaceholder)) {
+  assertType<ComboBoxPlaceholder>(itemOrPlaceholder);
+} else {
+  assertType<string>(itemOrPlaceholder.testProperty);
+}


### PR DESCRIPTION
## Summary
- The Flow combo box connector imports `ComboBoxPlaceholder` from `@vaadin/combo-box/src/vaadin-combo-box-placeholder.js`, which shipped without a declaration file. Any project that type-checks the connector fails with TS7016.
- Adds the missing `.d.ts` so the import resolves to a typed module, matching the other combo box source files.
- Lets flow-components drop its local ambient shim for this module, and lets consumers drop their reference directives for it.