### PR TITLE
refactor: render grid body rows declaratively with Lit

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -460,51 +460,15 @@ export class IronListAdapter {
 
   /** @private */
   _createPool(size) {
+    const physicalItems = this.createElements(size);
     const fragment = document.createDocumentFragment();
-
-    const physicalItems = this.createElements(size).map((elementOrFragment) => {
-      let element = elementOrFragment;
-
-      // An element may come wrapped in a fragment together with marker nodes
-      // that must stay with the element when it moves in the DOM
-      if (elementOrFragment.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
-        element = elementOrFragment.firstElementChild;
-        element.__startMarker = elementOrFragment.firstChild;
-        element.__endMarker = elementOrFragment.lastChild;
-      }
-
-      element.style.position = 'absolute';
-      this.__resizeObserver.observe(element, { box: 'border-box' });
-
-      // Appending a fragment moves its contents, markers included
-      fragment.appendChild(elementOrFragment);
-      return element;
+    physicalItems.forEach((el) => {
+      el.style.position = 'absolute';
+      fragment.append(...[el.__startMarker, el, el.__endMarker].filter(Boolean));
+      this.__resizeObserver.observe(el, { box: 'border-box' });
     });
-
     this.elementsContainer.appendChild(fragment);
     return physicalItems;
-  }
-
-  /**
-   * Moves an element to a new position in the elements container, keeping
-   * any associated marker nodes (`__startMarker` / `__endMarker`, e.g. Lit
-   * part markers) together with it.
-   *
-   * @param {HTMLElement} el The element to move
-   * @param {Node | null} refNode The node before which to insert, or null to append
-   * @private
-   */
-  __moveElement(el, refNode = null) {
-    let node = el.__startMarker || el;
-    const lastNode = el.__endMarker || el;
-    while (node) {
-      const nextNode = node.nextSibling;
-      this.elementsContainer.insertBefore(node, refNode);
-      if (node === lastNode) {
-        break;
-      }
-      node = nextNode;
-    }
   }
 
   /** @private */
@@ -828,14 +792,13 @@ export class IronListAdapter {
     const delta = visibleElements.indexOf(targetElement) - targetPhysicalIndex;
     if (delta > 0) {
       for (let i = 0; i < delta; i++) {
-        this.__moveElement(visibleElements[i]);
+        const el = visibleElements[i];
+        this.elementsContainer.append(...[el.__startMarker, el, el.__endMarker].filter(Boolean));
       }
     } else if (delta < 0) {
-      // Insert before the first element's start marker to avoid breaking up
-      // the marker-delimited span of the first element
-      const refNode = visibleElements[0].__startMarker || visibleElements[0];
-      for (let i = visibleElements.length + delta; i < visibleElements.length; i++) {
-        this.__moveElement(visibleElements[i], refNode);
+      for (let i = visibleElements.length - 1; i >= visibleElements.length + delta; i--) {
+        const el = visibleElements[i];
+        this.elementsContainer.prepend(...[el.__startMarker, el, el.__endMarker].filter(Boolean));
       }
     }
 

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -460,15 +460,51 @@ export class IronListAdapter {
 
   /** @private */
   _createPool(size) {
-    const physicalItems = this.createElements(size);
     const fragment = document.createDocumentFragment();
-    physicalItems.forEach((el) => {
-      el.style.position = 'absolute';
-      fragment.appendChild(el);
-      this.__resizeObserver.observe(el, { box: 'border-box' });
+
+    const physicalItems = this.createElements(size).map((elementOrFragment) => {
+      let element = elementOrFragment;
+
+      // An element may come wrapped in a fragment together with marker nodes
+      // that must stay with the element when it moves in the DOM
+      if (elementOrFragment.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+        element = elementOrFragment.firstElementChild;
+        element.__startMarker = elementOrFragment.firstChild;
+        element.__endMarker = elementOrFragment.lastChild;
+      }
+
+      element.style.position = 'absolute';
+      this.__resizeObserver.observe(element, { box: 'border-box' });
+
+      // Appending a fragment moves its contents, markers included
+      fragment.appendChild(elementOrFragment);
+      return element;
     });
+
     this.elementsContainer.appendChild(fragment);
     return physicalItems;
+  }
+
+  /**
+   * Moves an element to a new position in the elements container, keeping
+   * any associated marker nodes (`__startMarker` / `__endMarker`, e.g. Lit
+   * part markers) together with it.
+   *
+   * @param {HTMLElement} el The element to move
+   * @param {Node | null} refNode The node before which to insert, or null to append
+   * @private
+   */
+  __moveElement(el, refNode = null) {
+    let node = el.__startMarker || el;
+    const lastNode = el.__endMarker || el;
+    while (node) {
+      const nextNode = node.nextSibling;
+      this.elementsContainer.insertBefore(node, refNode);
+      if (node === lastNode) {
+        break;
+      }
+      node = nextNode;
+    }
   }
 
   /** @private */
@@ -792,11 +828,14 @@ export class IronListAdapter {
     const delta = visibleElements.indexOf(targetElement) - targetPhysicalIndex;
     if (delta > 0) {
       for (let i = 0; i < delta; i++) {
-        this.elementsContainer.appendChild(visibleElements[i]);
+        this.__moveElement(visibleElements[i]);
       }
     } else if (delta < 0) {
+      // Insert before the first element's start marker to avoid breaking up
+      // the marker-delimited span of the first element
+      const refNode = visibleElements[0].__startMarker || visibleElements[0];
       for (let i = visibleElements.length + delta; i < visibleElements.length; i++) {
-        this.elementsContainer.insertBefore(visibleElements[i], visibleElements[0]);
+        this.__moveElement(visibleElements[i], refNode);
       }
     }
 

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -464,7 +464,7 @@ export class IronListAdapter {
     const fragment = document.createDocumentFragment();
     physicalItems.forEach((el) => {
       el.style.position = 'absolute';
-      fragment.append(...[el.__startMarker, el, el.__endMarker].filter(Boolean));
+      fragment.appendChild(el);
       this.__resizeObserver.observe(el, { box: 'border-box' });
     });
     this.elementsContainer.appendChild(fragment);
@@ -792,13 +792,11 @@ export class IronListAdapter {
     const delta = visibleElements.indexOf(targetElement) - targetPhysicalIndex;
     if (delta > 0) {
       for (let i = 0; i < delta; i++) {
-        const el = visibleElements[i];
-        this.elementsContainer.append(...[el.__startMarker, el, el.__endMarker].filter(Boolean));
+        this.elementsContainer.appendChild(visibleElements[i]);
       }
     } else if (delta < 0) {
-      for (let i = visibleElements.length - 1; i >= visibleElements.length + delta; i--) {
-        const el = visibleElements[i];
-        this.elementsContainer.prepend(...[el.__startMarker, el, el.__endMarker].filter(Boolean));
+      for (let i = visibleElements.length + delta; i < visibleElements.length; i++) {
+        this.elementsContainer.insertBefore(visibleElements[i], visibleElements[0]);
       }
     }
 

--- a/packages/grid/src/vaadin-grid-body-rendering-mixin.js
+++ b/packages/grid/src/vaadin-grid-body-rendering-mixin.js
@@ -13,21 +13,28 @@ export const BodyRenderingMixin = (superClass) =>
     /** @private */
     __createBodyRow() {
       const fragment = document.createDocumentFragment();
-      fragment.appendChild(document.createComment(' vaadin-grid-row-start '));
-      fragment.appendChild(document.createComment(' vaadin-grid-row-end '));
-      this.__renderBodyRow(fragment, fragment.lastChild);
-      return fragment;
+      const endMarker = fragment.appendChild(document.createComment(''));
+
+      const litPart = render(this.#bodyRowTemplate(), fragment, {
+        host: this,
+        renderBefore: endMarker,
+      });
+
+      const row = fragment.firstElementChild;
+      row.__startMarker = litPart.startNode;
+      row.__endMarker = endMarker;
+      return row;
     }
 
     /** @private */
-    __renderBodyRow(container, renderBefore, index) {
-      return render(this.#renderBodyRow(index), container, {
-        renderBefore,
+    __renderBodyRow(row, index) {
+      render(this.#bodyRowTemplate(index), row.parentNode, {
         host: this,
+        renderBefore: row.__endMarker,
       });
     }
 
-    #renderBodyRow = (index) => {
+    #bodyRowTemplate = (index) => {
       return html`<tr role="row" tabindex="-1" part="row body-row" class="row body-row" .index="${index}"></tr>`;
     };
   };

--- a/packages/grid/src/vaadin-grid-body-rendering-mixin.js
+++ b/packages/grid/src/vaadin-grid-body-rendering-mixin.js
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, render } from 'lit';
+
+/**
+ * A mixin providing rendering of body rows.
+ */
+export const BodyRenderingMixin = (superClass) =>
+  class BodyRenderingMixin extends superClass {
+    /** @private */
+    __createBodyRow() {
+      const fragment = document.createDocumentFragment();
+      fragment.appendChild(document.createComment(' vaadin-grid-row-start '));
+      fragment.appendChild(document.createComment(' vaadin-grid-row-end '));
+      this.__renderBodyRow(fragment, fragment.lastChild);
+      return fragment;
+    }
+
+    /** @private */
+    __renderBodyRow(container, renderBefore, index) {
+      return render(this.#renderBodyRow(index), container, {
+        renderBefore,
+        host: this,
+      });
+    }
+
+    #renderBodyRow = (index) => {
+      return html`<tr role="row" tabindex="-1" part="row body-row" class="row body-row" .index="${index}"></tr>`;
+    };
+  };

--- a/packages/grid/src/vaadin-grid-body-rendering-mixin.js
+++ b/packages/grid/src/vaadin-grid-body-rendering-mixin.js
@@ -27,14 +27,16 @@ export const BodyRenderingMixin = (superClass) =>
     }
 
     /** @private */
-    __renderBodyRow(row, index) {
-      render(this.#bodyRowTemplate(index), row.parentNode, {
+    __renderBodyRow(row) {
+      const item = this.__getRowItem(row);
+
+      render(this.#bodyRowTemplate({ item }), row.parentNode, {
         host: this,
         renderBefore: row.__endMarker,
       });
     }
 
-    #bodyRowTemplate = (index) => {
-      return html`<tr role="row" tabindex="-1" part="row body-row" class="row body-row" .index="${index}"></tr>`;
+    #bodyRowTemplate = ({ item } = {}) => {
+      return html`<tr role="row" tabindex="-1" part="row body-row" class="row body-row" ?loading="${!item}"></tr>`;
     };
   };

--- a/packages/grid/src/vaadin-grid-body-rendering-mixin.js
+++ b/packages/grid/src/vaadin-grid-body-rendering-mixin.js
@@ -12,28 +12,18 @@ export const BodyRenderingMixin = (superClass) =>
   class BodyRenderingMixin extends superClass {
     /** @private */
     __createBodyRow() {
-      const fragment = document.createDocumentFragment();
-      const endMarker = fragment.appendChild(document.createComment(''));
+      const renderRoot = document.createDocumentFragment();
+      render(this.#bodyRowTemplate(), renderRoot, { host: this });
 
-      const litPart = render(this.#bodyRowTemplate(), fragment, {
-        host: this,
-        renderBefore: endMarker,
-      });
-
-      const row = fragment.firstElementChild;
-      row.__startMarker = litPart.startNode;
-      row.__endMarker = endMarker;
+      const row = renderRoot.firstElementChild;
+      row.__renderRoot = renderRoot;
       return row;
     }
 
     /** @private */
     __renderBodyRow(row) {
       const item = this.__getRowItem(row);
-
-      render(this.#bodyRowTemplate({ item }), row.parentNode, {
-        host: this,
-        renderBefore: row.__endMarker,
-      });
+      render(this.#bodyRowTemplate({ item }), row.__renderRoot, { host: this });
     }
 
     #bodyRowTemplate = ({ item } = {}) => {

--- a/packages/grid/src/vaadin-grid-header-footer-rendering-mixin.js
+++ b/packages/grid/src/vaadin-grid-header-footer-rendering-mixin.js
@@ -95,7 +95,7 @@ export const HeaderFooterRenderingMixin = (superClass) =>
 
     #renderHeader(columnTree) {
       const rows = this.#getRows(columnTree, 'header');
-      render(rows.map(this.#renderHeaderRow), this.$.header, { host: this });
+      render(rows.map(this.#headerRowTemplate), this.$.header, { host: this });
 
       this.$.table.toggleAttribute('has-header', !!this.$.header.querySelector('tr:not([hidden])'));
 
@@ -110,7 +110,7 @@ export const HeaderFooterRenderingMixin = (superClass) =>
       });
     }
 
-    #renderHeaderRow = ({ level, cells, isLastRow, isFirstRow, isRowVisible }) => {
+    #headerRowTemplate = ({ level, cells, isLastRow, isFirstRow, isRowVisible }) => {
       const rowParts = {
         'first-header-row': isFirstRow,
         'last-header-row': isLastRow,
@@ -178,7 +178,7 @@ export const HeaderFooterRenderingMixin = (superClass) =>
 
     #renderFooter(columnTree) {
       const rows = this.#getRows(columnTree, 'footer');
-      render(rows.map(this.#renderFooterRow), this.$.footer, { host: this });
+      render(rows.map(this.#footerRowTemplate), this.$.footer, { host: this });
 
       this.$.table.toggleAttribute('has-footer', !!this.$.footer.querySelector('tr:not([hidden])'));
 
@@ -193,7 +193,7 @@ export const HeaderFooterRenderingMixin = (superClass) =>
       });
     }
 
-    #renderFooterRow = ({ level, cells, isLastRow, isFirstRow, isRowVisible }) => {
+    #footerRowTemplate = ({ level, cells, isLastRow, isFirstRow, isRowVisible }) => {
       const rowParts = {
         'first-footer-row': isFirstRow,
         'last-footer-row': isLastRow,

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -12,6 +12,7 @@ import { Virtualizer } from '@vaadin/component-base/src/virtualizer.js';
 import { A11yMixin } from './vaadin-grid-a11y-mixin.js';
 import { ActiveItemMixin } from './vaadin-grid-active-item-mixin.js';
 import { ArrayDataProviderMixin } from './vaadin-grid-array-data-provider-mixin.js';
+import { BodyRenderingMixin } from './vaadin-grid-body-rendering-mixin.js';
 import { ColumnAutoWidthMixin } from './vaadin-grid-column-auto-width-mixin.js';
 import { ColumnReorderingMixin } from './vaadin-grid-column-reordering-mixin.js';
 import { ColumnResizingMixin } from './vaadin-grid-column-resizing-mixin.js';
@@ -48,18 +49,20 @@ export const GridMixin = (superClass) =>
       DataProviderMixin(
         DynamicColumnsMixin(
           HeaderFooterRenderingMixin(
-            ActiveItemMixin(
-              ScrollMixin(
-                SelectionMixin(
-                  SortMixin(
-                    RowDetailsMixin(
-                      KeyboardNavigationMixin(
-                        A11yMixin(
-                          FilterMixin(
-                            ColumnReorderingMixin(
-                              ColumnResizingMixin(
-                                EventContextMixin(
-                                  DragAndDropMixin(StylingMixin(TabindexMixin(ResizeMixin(superClass)))),
+            BodyRenderingMixin(
+              ActiveItemMixin(
+                ScrollMixin(
+                  SelectionMixin(
+                    SortMixin(
+                      RowDetailsMixin(
+                        KeyboardNavigationMixin(
+                          A11yMixin(
+                            FilterMixin(
+                              ColumnReorderingMixin(
+                                ColumnResizingMixin(
+                                  EventContextMixin(
+                                    DragAndDropMixin(StylingMixin(TabindexMixin(ResizeMixin(superClass)))),
+                                  ),
                                 ),
                               ),
                             ),
@@ -328,19 +331,17 @@ export const GridMixin = (superClass) =>
     __createVirtualizerElements(count) {
       const rows = [];
       for (let i = 0; i < count; i++) {
-        const row = document.createElement('tr');
-        row.setAttribute('role', 'row');
-        row.setAttribute('tabindex', '-1');
-        updatePart(row, 'row', true);
-        updatePart(row, 'body-row', true);
+        const rowFragment = this.__createBodyRow();
+
         if (this._columnTree) {
-          this.__initRow(row, this._columnTree[this._columnTree.length - 1], 'body', true);
+          this.__initRow(rowFragment.firstElementChild, this._columnTree.at(-1), 'body', true);
         }
-        rows.push(row);
+
+        rows.push(rowFragment);
       }
 
       if (this._columnTree) {
-        this._columnTree[this._columnTree.length - 1].forEach((c) => {
+        this._columnTree.at(-1).forEach((c) => {
           if (c.isConnected && c._cells) {
             c._cells = [...c._cells];
           }
@@ -521,7 +522,7 @@ export const GridMixin = (superClass) =>
         return;
       }
 
-      row.index = index;
+      this.__renderBodyRow(row.parentElement, row.__endMarker, index);
       this.__ensureRowItem(row);
       this.__ensureRowHierarchy(row);
       this.__updateRow(row);

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -331,17 +331,15 @@ export const GridMixin = (superClass) =>
     __createVirtualizerElements(count) {
       const rows = [];
       for (let i = 0; i < count; i++) {
-        const rowFragment = this.__createBodyRow();
-
+        const row = this.__createBodyRow();
         if (this._columnTree) {
-          this.__initRow(rowFragment.firstElementChild, this._columnTree.at(-1), 'body', true);
+          this.__initRow(row, this._columnTree[this._columnTree.length - 1], 'body', true);
         }
-
-        rows.push(rowFragment);
+        rows.push(row);
       }
 
       if (this._columnTree) {
-        this._columnTree.at(-1).forEach((c) => {
+        this._columnTree[this._columnTree.length - 1].forEach((c) => {
           if (c.isConnected && c._cells) {
             c._cells = [...c._cells];
           }
@@ -522,7 +520,7 @@ export const GridMixin = (superClass) =>
         return;
       }
 
-      this.__renderBodyRow(row.parentElement, row.__endMarker, index);
+      this.__renderBodyRow(row, index);
       this.__ensureRowItem(row);
       this.__ensureRowHierarchy(row);
       this.__updateRow(row);

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -30,7 +30,6 @@ import {
   updateBooleanRowStates,
   updateCellsPart,
   updatePart,
-  updateState,
 } from './vaadin-grid-helpers.js';
 import { KeyboardNavigationMixin } from './vaadin-grid-keyboard-navigation-mixin.js';
 import { ResizeMixin } from './vaadin-grid-resize-mixin.js';
@@ -520,7 +519,7 @@ export const GridMixin = (superClass) =>
         return;
       }
 
-      this.__renderBodyRow(row, index);
+      row.index = index;
       this.__ensureRowItem(row);
       this.__ensureRowHierarchy(row);
       this.__updateRow(row);
@@ -584,11 +583,8 @@ export const GridMixin = (superClass) =>
      * @param {boolean} loading
      * @private
      */
-    __updateRowLoading(row, loading) {
+    __updateRowCellsLoading(row, loading) {
       const cells = getBodyRowCells(row);
-
-      // Row state attribute
-      updateState(row, 'loading', loading);
 
       // Cells part attribute
       updateCellsPart(cells, 'loading-row-cell', loading);
@@ -604,14 +600,16 @@ export const GridMixin = (superClass) =>
      * @private
      */
     __updateRow(row) {
+      this.__renderBodyRow(row);
+
       this.__a11yUpdateRowRowindex(row);
       this.__updateRowOrderParts(row);
 
       const item = this.__getRowItem(row);
       if (item) {
-        this.__updateRowLoading(row, false);
+        this.__updateRowCellsLoading(row, false);
       } else {
-        this.__updateRowLoading(row, true);
+        this.__updateRowCellsLoading(row, true);
         return;
       }
 


### PR DESCRIPTION
## Description

This PR takes the first step in moving body row rendering to declarative Lit templates: body rows are now created and updated with Lit `render()` instead of imperative DOM calls, the same way header and footer rows already are. Cell content and various row state are still applied imperatively on top of the rendered DOM. They will be gradually moved into the templates in future PRs.

A few notes on the implementation: each row is rendered into its own detached `DocumentFragment`, which stays with the row as its render root. Lit updates the `<tr>` through the references held by its template instance, so the row can live in the `tbody` while its Lit part stays in the fragment. An earlier revision of this PR moved Lit's marker comments together with the row inside the virtualizer. However, it turned out to be unnecessary: Lit only reads the position of the root part when the root of the template changes, which never happens here: a row is always the same `<tr>` node for its entire lifetime, with updates limited to its attributes and children. As a result, the virtualizer remains completely untouched.

Part of https://github.com/vaadin/web-components/issues/10789

## Type of change

- Refactor
