### PR TITLE
refactor: extract allowed text checks into _shouldAcceptText method

### DIFF
--- a/packages/field-base/src/input-control-mixin.d.ts
+++ b/packages/field-base/src/input-control-mixin.d.ts
@@ -76,4 +76,11 @@ export declare class InputControlMixinClass {
    * The text usually displayed in a tooltip popup when the mouse is over the field.
    */
   title: string;
+
+  /**
+   * Returns true when the given text may be inserted into the field.
+   * Override to accept text that the raw `allowedCharPattern` test would reject,
+   * for example a formatted string that is valid once unformatted.
+   */
+  protected _shouldAcceptText(text: string): boolean;
 }

--- a/packages/field-base/src/input-control-mixin.d.ts
+++ b/packages/field-base/src/input-control-mixin.d.ts
@@ -78,7 +78,9 @@ export declare class InputControlMixinClass {
   title: string;
 
   /**
-   * Returns true when the given text may be inserted into the field.
+   * Returns true when text that is being pasted, dropped or inserted may enter
+   * the field. Called only while `allowedCharPattern` is set; typed characters
+   * are checked separately on `keydown`, against the pattern alone.
    * Override to accept text that the raw `allowedCharPattern` test would reject,
    * for example a formatted string that is valid once unformatted.
    */

--- a/packages/field-base/src/input-control-mixin.d.ts
+++ b/packages/field-base/src/input-control-mixin.d.ts
@@ -78,11 +78,9 @@ export declare class InputControlMixinClass {
   title: string;
 
   /**
-   * Returns true when text that is being pasted, dropped or inserted may enter
-   * the field. Called only while `allowedCharPattern` is set; typed characters
-   * are checked separately on `keydown`, against the pattern alone.
-   * Override to accept text that the raw `allowedCharPattern` test would reject,
-   * for example a formatted string that is valid once unformatted.
+   * Returns true when pasted, dropped or inserted text passes `allowedCharPattern`.
+   * Only called while the pattern is set. Override to accept text that the raw
+   * pattern test would reject.
    */
   protected _shouldAcceptText(text: string): boolean;
 }

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -186,6 +186,18 @@ export const InputControlMixin = (superclass) =>
       });
     }
 
+    /**
+     * Returns true when the given text may be inserted into the field.
+     * Override to accept text that the raw `allowedCharPattern` test would reject,
+     * for example a formatted string that is valid once unformatted.
+     * @param {string} text
+     * @return {boolean}
+     * @protected
+     */
+    _shouldAcceptText(text) {
+      return !this.allowedCharPattern || this.__allowedTextRegExp.test(text);
+    }
+
     /** @private */
     __shouldAcceptKey(event) {
       return (
@@ -201,7 +213,7 @@ export const InputControlMixin = (superclass) =>
     _onPaste(e) {
       if (this.allowedCharPattern) {
         const pastedText = e.clipboardData.getData('text');
-        if (!this.__allowedTextRegExp.test(pastedText)) {
+        if (!this._shouldAcceptText(pastedText)) {
           e.preventDefault();
           this._markInputPrevented();
         }
@@ -212,7 +224,7 @@ export const InputControlMixin = (superclass) =>
     _onDrop(e) {
       if (this.allowedCharPattern) {
         const draggedText = e.dataTransfer.getData('text');
-        if (!this.__allowedTextRegExp.test(draggedText)) {
+        if (!this._shouldAcceptText(draggedText)) {
           e.preventDefault();
           this._markInputPrevented();
         }
@@ -225,7 +237,7 @@ export const InputControlMixin = (superclass) =>
       // but it is still experimental technology so we can't rely on it. It's used here just as an additional check,
       // because it seems to be the only way to detect and prevent specific keys on mobile devices.
       // See https://github.com/vaadin/vaadin-text-field/issues/429
-      if (this.allowedCharPattern && e.data && !this.__allowedTextRegExp.test(e.data)) {
+      if (this.allowedCharPattern && e.data && !this._shouldAcceptText(e.data)) {
         e.preventDefault();
         this._markInputPrevented();
       }

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -187,7 +187,9 @@ export const InputControlMixin = (superclass) =>
     }
 
     /**
-     * Returns true when the given text may be inserted into the field.
+     * Returns true when text that is being pasted, dropped or inserted may enter
+     * the field. Called only while `allowedCharPattern` is set; typed characters
+     * are checked separately on `keydown`, against the pattern alone.
      * Override to accept text that the raw `allowedCharPattern` test would reject,
      * for example a formatted string that is valid once unformatted.
      * @param {string} text

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -187,11 +187,9 @@ export const InputControlMixin = (superclass) =>
     }
 
     /**
-     * Returns true when text that is being pasted, dropped or inserted may enter
-     * the field. Called only while `allowedCharPattern` is set; typed characters
-     * are checked separately on `keydown`, against the pattern alone.
-     * Override to accept text that the raw `allowedCharPattern` test would reject,
-     * for example a formatted string that is valid once unformatted.
+     * Returns true when pasted, dropped or inserted text passes `allowedCharPattern`.
+     * Only called while the pattern is set. Override to accept text that the raw
+     * pattern test would reject.
      * @param {string} text
      * @return {boolean}
      * @protected

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -197,7 +197,7 @@ export const InputControlMixin = (superclass) =>
      * @protected
      */
     _shouldAcceptText(text) {
-      return !this.allowedCharPattern || this.__allowedTextRegExp.test(text);
+      return this.__allowedTextRegExp.test(text);
     }
 
     /** @private */


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/platform/issues/9364

- Added a protected `_shouldAcceptText(text)` predicate to `InputControlMixin` that holds the `allowedCharPattern` test for a piece of text
- Routed the `paste`, `drop` and `beforeinput` checks through it instead of testing `__allowedTextRegExp` at each site
  - A subclass can now accept text that the raw pattern would reject, for example a formatted string that is valid once unformatted
  - The predicate is consulted only while `allowedCharPattern` is set; typed characters are still checked on `keydown` against the pattern alone (routing that check too is a follow-up, since it changes behavior for patterns with a top-level alternation)
- Declared the method in `input-control-mixin.d.ts`

No behavior change: the three call sites keep their `allowedCharPattern` guards and the predicate returns the same result the inline regexp test did.

## Type of change

- Refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)