### PR TITLE
fix: use composed focus target when scrolling oversized row into view

### DIFF
--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -111,15 +111,17 @@ export const ScrollMixin = (superClass) =>
             // is inside the viewport. If the whole row fits into the viewport, then scroll
             // the row into view. This ensures that labels, helper texts and other related
             // elements of focusable elements within cells also become visible. When the row
-            // is larger than the viewport, scroll the focus event target into the viewport.
+            // is larger than the viewport, scroll the actually focused element into the viewport.
             // This works better when focusing elements within cells, which could otherwise
             // still be outside the viewport when scrolling to the top or bottom of the row.
+            // The composed path is used instead of the event target, which would be
+            // retargeted to the host element when focus lands inside a nested shadow root.
             const tableHeight = this.$.table.clientHeight;
             const headerHeight = this.$.header.clientHeight;
             const footerHeight = this.$.footer.clientHeight;
             const viewportHeight = tableHeight - headerHeight - footerHeight;
             const isRowLargerThanViewport = row.clientHeight > viewportHeight;
-            const scrollTarget = isRowLargerThanViewport ? e.target : row;
+            const scrollTarget = isRowLargerThanViewport ? composedPath[0] : row;
 
             this.__scrollIntoViewport(scrollTarget);
           }

--- a/packages/grid/test/scroll-into-view.test.js
+++ b/packages/grid/test/scroll-into-view.test.js
@@ -135,4 +135,54 @@ describe('scroll into view', () => {
       verifyNotFullyVisible(secondRow);
     });
   });
+
+  describe('nested grid in row details', () => {
+    let nestedGrid, nestedFirstCell, nestedMiddleCell;
+
+    beforeEach(async () => {
+      grid.rowDetailsRenderer = (root) => {
+        if (!root.firstElementChild) {
+          root.innerHTML = `
+            <vaadin-grid all-rows-visible>
+              <vaadin-grid-column path="name"></vaadin-grid-column>
+            </vaadin-grid>
+          `;
+          root.firstElementChild.items = Array.from({ length: 20 }, (_, i) => ({ name: `Nested ${i}` }));
+        }
+      };
+      grid.openItemDetails(grid.items[0]);
+      flushGrid(grid);
+      await nextFrame();
+
+      nestedGrid = grid.querySelector('vaadin-grid');
+      flushGrid(nestedGrid);
+      await nextFrame();
+      await nextFrame();
+
+      nestedFirstCell = getContainerCell(nestedGrid.$.items, 0, 0);
+      nestedMiddleCell = getContainerCell(nestedGrid.$.items, 10, 0);
+    });
+
+    it('should not change scroll position when focused nested grid cell is visible', async () => {
+      // Scroll the outer grid so that the first nested cell is at the top of the viewport
+      const scrollerTop = grid.$.scroller.getBoundingClientRect().top;
+      grid.$.table.scrollTop = nestedFirstCell.getBoundingClientRect().top - scrollerTop;
+      await nextFrame();
+      verifyFullyVisible(nestedFirstCell);
+      const scrollTop = grid.$.table.scrollTop;
+
+      nestedFirstCell.focus();
+
+      expect(grid.$.table.scrollTop).to.equal(scrollTop);
+      verifyFullyVisible(nestedFirstCell);
+    });
+
+    it('should scroll focused nested grid cell into view', () => {
+      verifyNotFullyVisible(nestedMiddleCell);
+
+      nestedMiddleCell.focus();
+
+      verifyFullyVisible(nestedMiddleCell);
+    });
+  });
 });


### PR DESCRIPTION
## Description

When a grid row is larger than the viewport, the `focusin` handler in `vaadin-grid-scroll-mixin.js` scrolls the focus event target into view (#9475). If the focused element is inside a nested shadow root, for example a nested `<vaadin-grid all-rows-visible>` rendered in row details, `e.target` as seen by the outer grid is retargeted to the nested component's host element. That host can be thousands of pixels tall, so aligning its bottom with the footer scrolls the actually focused cell far out of view. This happens whenever focus is restored without a preceding mousedown, for example when the browser window regains focus after switching windows, or when tabbing.

This PR uses `composedPath[0]`, the element that actually received focus, as the scroll target instead of `e.target`, so the outer grid keeps the focused nested cell in view instead of jumping. `_onFocusIn` in the keyboard navigation mixin already resolves the focus target the same way.

Tests: two new tests with a nested grid in row details. One asserts that the outer scroll position does not change when the focused nested cell is already visible, the other asserts that a nested cell outside the viewport is scrolled into view. Both fail before the change (scrollTop 170 -> 743; cell 212 px outside the viewport) and pass after it.

Fixes #10823

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.