### PR TITLE
refactor: remove __parentRow reference from grid cells

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -355,20 +355,22 @@ export const InlineEditingMixin = (superClass) =>
 
     /** @private */
     _startEdit(cell, column) {
-      const isCellEditable = this._isCellEditable(cell);
-
       // TODO: remove `_editingDisabled` after Flow counterpart is updated.
-      if (this.disabled || this._editingDisabled || !isCellEditable) {
+      if (this.disabled || this._editingDisabled) {
         return;
       }
-      // Cancel debouncer enqueued on focusout
-      this._cancelStopEdit();
 
       // Scroll column into view synchronously, which also triggers lazy column
       // rendering to ensure cells for that column are in the DOM.
       this.scrollToColumn(column);
 
-      const model = this.__getRowModel(cell.__parentRow);
+      if (!this._isCellEditable(cell)) {
+        return;
+      }
+      // Cancel debouncer enqueued on focusout
+      this._cancelStopEdit();
+
+      const model = this.__getRowModel(cell.parentElement);
       this.__edited = { cell, column, model };
       column._startCellEdit(cell, model);
 
@@ -515,7 +517,7 @@ export const InlineEditingMixin = (superClass) =>
           const nextRow = this._getRowByIndex(nextIndex);
           // eslint-disable-next-line no-loop-func
           nextCell = nextRow && Array.from(nextRow.__cells).find((cell) => cell._column === nextColumn);
-          if (nextCell && this._isCellEditable(nextCell)) {
+          if (nextCell && this._isCellEditable(nextCell, nextRow)) {
             break;
           }
         }
@@ -546,7 +548,7 @@ export const InlineEditingMixin = (superClass) =>
         if (!this._isCellEditable(cell)) {
           // Cell is no longer editable, cancel edit
           this._stopEdit(true, true);
-        } else if (cell.__parentRow === row && item && this.getItemId(model.item) !== this.getItemId(item)) {
+        } else if (cell.parentElement === row && item && this.getItemId(model.item) !== this.getItemId(item)) {
           // Edited item identity has changed, stop edit
           this._stopEdit();
         }
@@ -564,17 +566,21 @@ export const InlineEditingMixin = (superClass) =>
       super._generateCellPartNames(row, model);
 
       iterateRowCells(row, (cell) => {
-        const isEditable = !row.hasAttribute('loading') && this._isCellEditable(cell);
+        const isEditable = !row.hasAttribute('loading') && this._isCellEditable(cell, row);
         const target = cell._focusButton || cell;
         updatePart(target, 'editable-cell', isEditable);
       });
     }
 
     /** @private */
-    _isCellEditable(cell) {
+    _isCellEditable(cell, row = cell.parentElement) {
       const column = cell._column;
       // Not editable if the column is not an edit column
       if (!this._isEditColumn(column)) {
+        return false;
+      }
+      // Not editable if the cell is detached from its row
+      if (!row) {
         return false;
       }
       // Cell is editable by default if isCellEditable is not configured
@@ -582,7 +588,6 @@ export const InlineEditingMixin = (superClass) =>
         return true;
       }
       // Otherwise, check isCellEditable function
-      const model = this.__getRowModel(cell.__parentRow);
-      return column.isCellEditable(model);
+      return column.isCellEditable(this.__getRowModel(row));
     }
   };

--- a/packages/grid/src/vaadin-grid-event-context-mixin.js
+++ b/packages/grid/src/vaadin-grid-event-context-mixin.js
@@ -46,7 +46,7 @@ export const EventContextMixin = (superClass) =>
       }
 
       if (context.section === 'body' || context.section === 'details') {
-        Object.assign(context, this.__getRowModel(cell.__parentRow));
+        Object.assign(context, this.__getRowModel(cell.parentElement));
       }
 
       return context;

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -461,7 +461,6 @@ export const GridMixin = (superClass) =>
             }
             updatePart(cell, 'cell', true);
             updatePart(cell, 'body-cell', true);
-            cell.__parentRow = row;
             // Cache the cell reference
             row.__cells.push(cell);
 
@@ -487,7 +486,6 @@ export const GridMixin = (superClass) =>
                 contentsFragment.appendChild(detailsCell._content);
               }
               this._configureDetailsCell(detailsCell);
-              detailsCell.__parentRow = row;
               row.appendChild(detailsCell);
               // Cache the details cell reference
               row.__detailsCell = detailsCell;

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -8,6 +8,7 @@ import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { getNormalizedScrollLeft } from '@vaadin/component-base/src/dir-utils.js';
 import { setOrRemoveAttribute } from '@vaadin/component-base/src/dom-utils.js';
 import { OverflowController } from '@vaadin/component-base/src/overflow-controller.js';
+import { getBodyRowCells, iterateChildren } from './vaadin-grid-helpers.js';
 
 const timeouts = {
   SCROLLING: 500,
@@ -266,37 +267,43 @@ export const ScrollMixin = (superClass) =>
       this.__scrollToPendingColumn();
 
       const columnsInOrder = this._getColumnsInOrder();
-      let bodyContentHiddenChanged = false;
+
+      // Columns whose body content visibility changes, mapped to the new state
+      const changedColumns = new Map();
+      columnsInOrder.forEach((column) => {
+        const bodyContentHidden = this._lazyColumns && !this.__isColumnInViewport(column);
+        if (column._bodyContentHidden !== bodyContentHidden) {
+          changedColumns.set(column, bodyContentHidden);
+        }
+      });
 
       // Remove the column cells from the DOM if the column is outside the viewport.
       // Add the column cells to the DOM if the column is inside the viewport.
-      //
+      iterateChildren(this.$.items, (row) => {
+        getBodyRowCells(row).forEach((cell) => {
+          if (!changedColumns.has(cell._column)) {
+            return;
+          }
+
+          if (changedColumns.get(cell._column)) {
+            cell.remove();
+          } else {
+            // Add the cell to the correct DOM position in the row
+            const followingColumnCell = [...row.children].find(
+              (child) => columnsInOrder.indexOf(child._column) > columnsInOrder.indexOf(cell._column),
+            );
+            row.insertBefore(cell, followingColumnCell);
+          }
+        });
+      });
+
       // Update the _bodyContentHidden property of the column to reflect the current
       // visibility state and make it run renderers for the cells if necessary.
-      columnsInOrder.forEach((column) => {
-        const bodyContentHidden = this._lazyColumns && !this.__isColumnInViewport(column);
-
-        if (column._bodyContentHidden !== bodyContentHidden) {
-          bodyContentHiddenChanged = true;
-          column._cells.forEach((cell) => {
-            if (cell !== column._sizerCell) {
-              if (bodyContentHidden) {
-                cell.remove();
-              } else if (cell.__parentRow) {
-                // Add the cell to the correct DOM position in the row
-                const followingColumnCell = [...cell.__parentRow.children].find(
-                  (child) => columnsInOrder.indexOf(child._column) > columnsInOrder.indexOf(column),
-                );
-                cell.__parentRow.insertBefore(cell, followingColumnCell);
-              }
-            }
-          });
-        }
-
+      changedColumns.forEach((bodyContentHidden, column) => {
         column._bodyContentHidden = bodyContentHidden;
       });
 
-      if (bodyContentHiddenChanged) {
+      if (changedColumns.size > 0) {
         // Frozen columns may have changed their visibility
         this._frozenCellsChanged();
       }

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -225,7 +225,8 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       // the row have run in the current task, as the selection column may
       // render before the row header column.
       queueMicrotask(() => {
-        const row = root.assignedSlot?.parentElement?.__parentRow;
+        const cell = root.assignedSlot?.parentElement;
+        const row = cell?.parentElement;
         if (!checkbox.isConnected || !row) {
           return;
         }


### PR DESCRIPTION
## Description

Related to #12626

Body and details cells carried a `__parentRow` reference so that code could find the row of a cell that lazy column rendering had detached from the DOM. The row is available as `parentElement` for every attached cell, and the few places that work with detached cells already know the row, so the extra reference can go.

- Removed the `__parentRow` property from body and details cells, readers use `parentElement` instead
- Rewrote the lazy column cell handling in `ScrollMixin` to walk the body rows and their cached `__cells` instead of `column._cells`, so detached cells are removed and re-inserted without a back reference to the row
- Changed `getEventContext` and the selection column accessible name lookup to read the row from `parentElement`
- Added a `row` parameter to grid-pro `_isCellEditable`, defaulting to `cell.parentElement`, and treat a detached cell as not editable
  - `_generateCellPartNames` and Tab navigation pass the row explicitly, since `row.__cells` includes cells detached by lazy column rendering
- Moved `scrollToColumn` before the editability check in `_startEdit`, so a lazily detached target cell is attached before it is checked

## Type of change

- Refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)
