### PR TITLE
refactor: remove experimental feature flag from breadcrumbs component

### DIFF
--- a/dev/breadcrumbs.html
+++ b/dev/breadcrumbs.html
@@ -7,11 +7,6 @@
     <title>Breadcrumbs</title>
     <script type="module" src="./common.js"></script>
     <script type="module">
-      // Enable feature flag
-      window.Vaadin ||= {};
-      window.Vaadin.featureFlags ||= {};
-      window.Vaadin.featureFlags.breadcrumbsComponent = true;
-
       import '@vaadin/breadcrumbs';
     </script>
   </head>

--- a/dev/playground/breadcrumbs.html
+++ b/dev/playground/breadcrumbs.html
@@ -8,11 +8,6 @@
     <script type="module" src="../common.js"></script>
 
     <script type="module">
-      window.Vaadin ||= {};
-      window.Vaadin.featureFlags ||= {};
-      window.Vaadin.featureFlags.breadcrumbsComponent = true;
-    </script>
-    <script type="module">
       import '@vaadin/breadcrumbs';
       import '@vaadin/icon';
       import '@vaadin/icons';

--- a/packages/breadcrumbs/README.md
+++ b/packages/breadcrumbs/README.md
@@ -2,8 +2,6 @@
 
 A web component that displays the user's location within a hierarchy as a trail of links from the root to the current page.
 
-> ⚠️ This component is experimental and the API may change. In order to use it, enable the feature flag by setting `window.Vaadin.featureFlags.breadcrumbsComponent = true`.
-
 ```html
 <vaadin-breadcrumbs>
   <vaadin-breadcrumbs-item></vaadin-breadcrumbs-item>

--- a/packages/breadcrumbs/src/vaadin-breadcrumbs-item.js
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs-item.js
@@ -97,10 +97,6 @@ class BreadcrumbsItem extends FocusMixin(DisabledMixin(ElementMixin(PolylitMixin
     return breadcrumbsItemStyles;
   }
 
-  static get experimental() {
-    return 'breadcrumbsComponent';
-  }
-
   /** @protected */
   firstUpdated() {
     super.firstUpdated();

--- a/packages/breadcrumbs/src/vaadin-breadcrumbs.js
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs.js
@@ -86,10 +86,6 @@ class Breadcrumbs extends KeyboardDirectionMixin(
     return breadcrumbsStyles;
   }
 
-  static get experimental() {
-    return 'breadcrumbsComponent';
-  }
-
   static get properties() {
     return {
       /** @private */

--- a/packages/breadcrumbs/test/breadcrumbs-item.test.js
+++ b/packages/breadcrumbs/test/breadcrumbs-item.test.js
@@ -3,10 +3,6 @@ import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import '../vaadin-breadcrumbs-item.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.breadcrumbsComponent = true;
-
 describe('vaadin-breadcrumbs-item', () => {
   let item;
 

--- a/packages/breadcrumbs/test/breadcrumbs.test.js
+++ b/packages/breadcrumbs/test/breadcrumbs.test.js
@@ -2,10 +2,6 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../vaadin-breadcrumbs.js';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.breadcrumbsComponent = true;
-
 describe('vaadin-breadcrumbs', () => {
   let breadcrumbs;
 

--- a/packages/breadcrumbs/test/dom/breadcrumbs-item.test.js
+++ b/packages/breadcrumbs/test/dom/breadcrumbs-item.test.js
@@ -3,10 +3,6 @@ import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import '../../src/vaadin-breadcrumbs-item.js';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.breadcrumbsComponent = true;
-
 describe('vaadin-breadcrumbs-item', () => {
   let item;
 

--- a/packages/breadcrumbs/test/dom/breadcrumbs.test.js
+++ b/packages/breadcrumbs/test/dom/breadcrumbs.test.js
@@ -2,10 +2,6 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextResize, oneEvent } from '@vaadin/testing-helpers';
 import '../../src/vaadin-breadcrumbs.js';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.breadcrumbsComponent = true;
-
 describe('vaadin-breadcrumbs', () => {
   let breadcrumbs;
 

--- a/packages/breadcrumbs/test/overflow.test.js
+++ b/packages/breadcrumbs/test/overflow.test.js
@@ -4,10 +4,6 @@ import { fixtureSync, nextRender, nextResize, oneEvent } from '@vaadin/testing-h
 import '../vaadin-breadcrumbs.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.breadcrumbsComponent = true;
-
 describe('overflow', () => {
   let breadcrumbs, items, button, overlay;
 

--- a/packages/breadcrumbs/test/visual/aura/breadcrumbs-item.test.js
+++ b/packages/breadcrumbs/test/visual/aura/breadcrumbs-item.test.js
@@ -7,10 +7,6 @@ import '../../../src/vaadin-breadcrumbs-item.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.breadcrumbsComponent = true;
-
 describe('breadcrumbs-item', () => {
   let div, element;
 

--- a/packages/breadcrumbs/test/visual/aura/breadcrumbs.test.js
+++ b/packages/breadcrumbs/test/visual/aura/breadcrumbs.test.js
@@ -5,10 +5,6 @@ import '@vaadin/aura/aura.css';
 import '../not-animated-styles.css';
 import '../../../src/vaadin-breadcrumbs.js';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.breadcrumbsComponent = true;
-
 describe('breadcrumbs', () => {
   let div;
 

--- a/packages/breadcrumbs/test/visual/base/breadcrumbs-item.test.js
+++ b/packages/breadcrumbs/test/visual/base/breadcrumbs-item.test.js
@@ -4,10 +4,6 @@ import { visualDiff } from '@web/test-runner-visual-regression';
 import '../not-animated-styles.css';
 import '../../../src/vaadin-breadcrumbs-item.js';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.breadcrumbsComponent = true;
-
 describe('breadcrumbs-item', () => {
   let div, element;
 

--- a/packages/breadcrumbs/test/visual/base/breadcrumbs.test.js
+++ b/packages/breadcrumbs/test/visual/base/breadcrumbs.test.js
@@ -4,10 +4,6 @@ import { visualDiff } from '@web/test-runner-visual-regression';
 import '../not-animated-styles.css';
 import '../../../src/vaadin-breadcrumbs.js';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.breadcrumbsComponent = true;
-
 /*
  * Note: there is no `forced-colors: active` visual test here. The repository
  * has no `emulateMedia` / forced-colors infrastructure today, so a real

--- a/packages/breadcrumbs/test/visual/lumo/breadcrumbs-item.test.js
+++ b/packages/breadcrumbs/test/visual/lumo/breadcrumbs-item.test.js
@@ -9,10 +9,6 @@ import '../../../src/vaadin-breadcrumbs-item.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.breadcrumbsComponent = true;
-
 describe('breadcrumbs-item', () => {
   let div, element;
 

--- a/packages/breadcrumbs/test/visual/lumo/breadcrumbs.test.js
+++ b/packages/breadcrumbs/test/visual/lumo/breadcrumbs.test.js
@@ -6,10 +6,6 @@ import '@vaadin/vaadin-lumo-styles/components/breadcrumbs.css';
 import '../not-animated-styles.css';
 import '../../../src/vaadin-breadcrumbs.js';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.breadcrumbsComponent = true;
-
 describe('breadcrumbs', () => {
   let div;
 


### PR DESCRIPTION
## Description

- Removed the `experimental` static getter from `vaadin-breadcrumbs` and `vaadin-breadcrumbs-item` so the components register without the `breadcrumbsComponent` feature flag
- Removed the `window.Vaadin.featureFlags.breadcrumbsComponent = true` setup from all breadcrumbs unit, DOM snapshot, and visual tests
- Removed the feature flag setup from `dev/breadcrumbs.html` and `dev/playground/breadcrumbs.html`
- Removed the experimental warning from the package README

## Type of change

- Refactor
