### PR TITLE
fix: focus popover content on Tab when popover host has focus

### DIFF
--- a/packages/popover/src/vaadin-popover-focus-controller.js
+++ b/packages/popover/src/vaadin-popover-focus-controller.js
@@ -148,6 +148,11 @@ export class PopoverFocusController {
     if (event.key !== 'Tab') {
       return;
     }
+    // Another controller (e.g. the one of a parent popover) has already moved
+    // focus for this event, so this one must not move it a second time.
+    if (event.defaultPrevented) {
+      return;
+    }
     if (event.shiftKey) {
       this.__handleShiftTab(event);
     } else {

--- a/packages/popover/src/vaadin-popover-focus-controller.js
+++ b/packages/popover/src/vaadin-popover-focus-controller.js
@@ -56,6 +56,18 @@ export class PopoverFocusController {
       return;
     }
 
+    // Focus is on the popover itself: move into the content explicitly, so that
+    // the tab order does not depend on the browser's sequential focus navigation
+    // starting point (Firefox continues from the last clicked node).
+    if (!host.noTabFocus && isElementFocused(host)) {
+      const firstContent = getTabbableElements(host._overlayElement.$.content)[0];
+      if (firstContent) {
+        event.preventDefault();
+        firstContent.focus();
+        return;
+      }
+    }
+
     // Native Tab would land on the popover when DOM order places it right
     // after the current element. Skip past it via the logical list.
     const activeElement = getDeepActiveElement();

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -449,6 +449,20 @@ describe('a11y', () => {
           expect(spy).to.be.calledOnce;
         });
 
+        it('should focus the overlay content on popover Tab', async () => {
+          target.focus();
+
+          // Move focus to the popover
+          await sendKeys({ press: 'Tab' });
+
+          const spy = sinon.spy(popover.querySelector('input'), 'focus');
+
+          // Move focus to the input inside the overlay
+          await sendKeys({ press: 'Tab' });
+
+          expect(spy).to.be.calledOnce;
+        });
+
         it('should focus the target on overlay content part Shift Tab', async () => {
           target.focus();
 

--- a/packages/popover/test/nested.test.js
+++ b/packages/popover/test/nested.test.js
@@ -1,5 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
+import { sendKeys } from '@vaadin/test-runner-commands';
 import { esc, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
+import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 import { Popover } from '../src/vaadin-popover.js';
 import { mouseenter, mouseleave } from './helpers.js';
 
@@ -105,6 +107,22 @@ describe('nested popover', () => {
       await nextRender();
 
       expect(popover.opened).to.be.true;
+    });
+
+    it('should focus the nested target on Tab from the popover', async () => {
+      target.focus();
+      await nextRender();
+
+      nestedTarget.focus();
+      nestedTarget.click();
+      await nextRender();
+
+      // Move focus back to the popover
+      popover.focus();
+
+      await sendKeys({ press: 'Tab' });
+
+      expect(getDeepActiveElement()).to.equal(nestedTarget);
     });
 
     it('should not close on focusout caused by nested popover outside click', async () => {


### PR DESCRIPTION
## Description

Related to #12646

Tab from the popover host into the popover content was left to native focus navigation. Firefox 155 changed the sequential focus navigation starting point: after a click on a non-focusable element it continues from the clicked node instead of the focused one, so pressing Tab after clicking the popover's text content moved focus back to the target rather than into the content. The other steps of the popover tab order are already handled explicitly by `PopoverFocusController`, so this one now is too.

- Made `PopoverFocusController` focus the first focusable content element on Tab when the popover host itself has focus, instead of relying on the browser's native tab order
  - Does not apply to `noTabFocus` popovers, where the host is not part of the tab order
- Added a test asserting that Tab from the popover moves focus into the overlay content

## Type of change

- Bugfix

## How to test

In Firefox 155 or newer:

1. Open `dev/popover.html` and check the `Focus` trigger.
2. Click the `Target` field — the popover opens.
3. Press <kbd>Tab</kbd> — focus moves to the popover.
4. Click the empty area of the popover next to its input — focus stays on the popover.
5. Press <kbd>Tab</kbd> — focus moves to the input inside the popover, not back to the `Target` field.

## Note
The Firefox change comes from the Gecko work that made the sequential focus navigation starting point independent of the text selection, shipped in Firefox 152 and refined since. Firefox 153 and Chromium continue Tab from the focused element; Firefox 155 continues from the clicked node. The HTML spec leaves the starting point up to the user agent, so this is a divergence from Chromium rather than a spec violation, and it is not specific to the popover: it reproduces with a plain `tabindex="0"` wrapper around an input and a text node.

- [Bug 2034851 — sequential focus navigation starting point should be separate from selection](https://bugzilla.mozilla.org/show_bug.cgi?id=2034851)
- [Bug 2049307 — incorrect tab focus after clicking internal link](https://bugzilla.mozilla.org/show_bug.cgi?id=2049307) (regression from the above)
- [HTML spec — sequential focus navigation starting point](https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation-starting-point)
- [Firefox 155 release notes for developers](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/155)
- [Sarah Higley — Focus management still matters](https://sarahmhigley.com/writing/focus-navigation-start-point/)
