### PR TITLE
fix: keep combo box overlay open when clearing cache while loading

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -120,10 +120,8 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       if (this.__previousDataProviderFilter !== filter) {
         this.__previousDataProviderFilter = filter;
 
-        this.__keepOverlayOpened = true;
-        this.size = undefined;
+        this.__dataProviderController.rootCache.size = undefined;
         this.clearCache();
-        this.__keepOverlayOpened = false;
       }
     }
 
@@ -152,7 +150,7 @@ export const ComboBoxDataProviderMixin = (superClass) =>
 
     /** @private */
     __onDataProviderPageRequested() {
-      this.loading = true;
+      this.__synchronizeControllerState();
     }
 
     /** @private */
@@ -179,14 +177,18 @@ export const ComboBoxDataProviderMixin = (superClass) =>
 
       this.__dataProviderController.clearCache();
 
-      this.__synchronizeControllerState();
-
+      // Request the first page before synchronizing the component state.
+      // Otherwise the component would observe an intermediate state where
+      // the items are empty but no request is pending, which would close
+      // the overlay and re-open it right away.
       if (this._shouldFetchData()) {
         this._forceNextRequest = false;
         this.__dataProviderController.loadFirstPage();
       } else {
         this._forceNextRequest = true;
       }
+
+      this.__synchronizeControllerState();
     }
 
     /**
@@ -240,9 +242,13 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       // will be requested in the `ready()` callback.
       if (this.__dataProviderInitialized && this.dataProvider) {
         const { rootCache } = this.__dataProviderController;
-        this.size = rootCache.size;
-        this.filteredItems = rootCache.items;
-        this.loading = this.__dataProviderController.isLoading();
+        // Apply all properties in one update so that observers depending on
+        // several of them never see a partially synchronized state.
+        this.setProperties({
+          size: rootCache.size,
+          filteredItems: rootCache.items,
+          loading: this.__dataProviderController.isLoading(),
+        });
       }
     }
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -91,18 +91,12 @@ export const ComboBoxMixin = (superClass) =>
           type: String,
           sync: true,
         },
-
-        /** @private */
-        __keepOverlayOpened: {
-          type: Boolean,
-          sync: true,
-        },
       };
     }
 
     static get observers() {
       return [
-        '_openedOrItemsChanged(opened, _dropdownItems, loading, __keepOverlayOpened)',
+        '_openedOrItemsChanged(opened, _dropdownItems, loading)',
         '_selectedItemChanged(selectedItem, itemValuePath, itemLabelPath)',
         '_updateScroller(opened, _dropdownItems, _focusedIndex, _theme)',
       ];
@@ -171,10 +165,10 @@ export const ComboBoxMixin = (superClass) =>
     }
 
     /** @private */
-    _openedOrItemsChanged(opened, items, loading, keepOverlayOpened) {
+    _openedOrItemsChanged(opened, items, loading) {
       // Close the overlay if there are no items to display.
       // See https://github.com/vaadin/vaadin-combo-box/pull/964
-      this._overlayOpened = opened && (keepOverlayOpened || loading || !!items?.length);
+      this._overlayOpened = opened && (loading || !!items?.length);
     }
 
     /**

--- a/packages/combo-box/test/data-provider-filtering.test.js
+++ b/packages/combo-box/test/data-provider-filtering.test.js
@@ -110,6 +110,17 @@ describe('data provider filtering', () => {
       expect(openedSpy).to.be.not.called;
     });
 
+    it('should not toggle between opened and closed when clearing cache while loading', () => {
+      // Data provider that does not respond, like a pending server request
+      comboBox.dataProvider = sinon.spy();
+      comboBox.filter = 'Item';
+      // Clear the cache while the filtered page is still loading
+      comboBox.clearCache();
+      // Dropdown should not have been closed and re-opened
+      expect(openedSpy).to.be.not.called;
+      expect(comboBox.$.overlay.opened).to.be.true;
+    });
+
     it('should not toggle between opened and closed when setting a value', () => {
       // Filter for something that should return results
       comboBox.filter = 'Item';

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -216,7 +216,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
     static get observers() {
       return [
         '_selectedItemsChanged(selectedItems)',
-        '__openedOrItemsChanged(opened, _dropdownItems, loading, __keepOverlayOpened)',
+        '__openedOrItemsChanged(opened, _dropdownItems, loading)',
         '__updateOverflowChip(_overflow, _overflowItems, disabled, readonly)',
         '__updateScroller(opened, _dropdownItems, _focusedIndex, _theme)',
         '__updateTopGroup(selectedItemsOnTop, selectedItems, opened)',
@@ -492,10 +492,10 @@ export const MultiSelectComboBoxMixin = (superClass) =>
     }
 
     /** @private */
-    __openedOrItemsChanged(opened, items, loading, keepOverlayOpened) {
+    __openedOrItemsChanged(opened, items, loading) {
       // Close the overlay if there are no items to display.
       // See https://github.com/vaadin/vaadin-combo-box/pull/964
-      this._overlayOpened = opened && (keepOverlayOpened || loading || !!items?.length);
+      this._overlayOpened = opened && (loading || !!items?.length);
     }
 
     /**

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -459,6 +459,16 @@ describe('selecting items', () => {
         expectItems(['apple', 'banana', 'lemon', 'orange']);
       });
 
+      it('should update dropdown items after filter is cleared while opened', async () => {
+        comboBox.opened = true;
+        getFirstItem(comboBox).click();
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
+        comboBox.inputElement.focus();
+        await sendKeys({ type: 'a' });
+        await sendKeys({ press: 'Backspace' });
+        expectItems(['orange', 'apple', 'banana', 'lemon']);
+      });
+
       it('should not include ghost items in the dropdown after clearing data provider cache', async () => {
         const allItems = ['apple', 'banana', 'lemon', 'orange'];
         comboBox.dataProvider = (_params, callback) => {


### PR DESCRIPTION
## Description

When a Flow combo box with server-side filtering receives new input, the Flow connector waits for a debounce and then calls `clearCache()` on the web component. This made the dropdown visibly flicker: the overlay closed, re-opened right away and replayed its opening animation, just as the filtered items arrived. The cause is inside `clearCache()`. It synchronized component state before requesting the first page, so for one synchronous step the items were empty and `loading` was false. The overlay observer treats that state as "no results" and closes the overlay, and the following page request opens it again. The internal filter change path avoided this with the `__keepOverlayOpened` flag, but external callers of `clearCache()`, like the connector, were not covered. The fix removes the intermediate state instead of guarding against it: the first page is requested before the component state is synchronized, and size, items and `loading` are applied in one update, so observers only ever see complete states. This makes the flag unnecessary.

- Moved the cache reset in `ComboBoxDataProviderMixin` into a protected `_resetCache({ resetSize })` used by `clearCache()` and the filter change handler
  - The first page is requested before component state is synchronized, so `loading` is already true when the empty item list is applied
  - The filter change handler resets the size on the controller cache instead of through the `size` property
- Moved the `vaadin-multi-select-combo-box` override from `clearCache()` to `_resetCache()` so that its read-only skip and top group re-sync keep applying to filter changes
  - The read-only skip now also covers the size reset, which previously ran before the skipped `clearCache()`
- Changed `__synchronizeControllerState()` to apply `size`, `filteredItems` and `loading` with a single `setProperties()` call
- Changed the `page-requested` handler to run a full state sync instead of only setting `loading`
- Removed the `__keepOverlayOpened` property and its use in the overlay observers of `vaadin-combo-box` and `vaadin-multi-select-combo-box`
- Added a combo box test that clears the cache while a filtered page is still loading and checks that the dropdown does not close and re-open
- Added multi-select tests for the top group order after clearing a filter while open, and for keeping cached items on a filter change when read-only

Related to https://github.com/vaadin/flow-components/pull/9300, which refactored the combo box connector to use `clearCache`.

## Type of change

- Bugfix