### PR TITLE
refactor: retarget document handlers instead of copying Highcharts bodies

### DIFF
--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -28,7 +28,6 @@ import 'highcharts/es-modules/masters/modules/bullet.src.js';
 import 'highcharts/es-modules/masters/modules/gantt.src.js';
 import 'highcharts/es-modules/masters/modules/draggable-points.src.js';
 import KeyboardNavigation from 'highcharts/es-modules/Accessibility/KeyboardNavigation.js';
-import HTMLUtilities from 'highcharts/es-modules/Accessibility/Utils/HTMLUtilities.js';
 import Pointer from 'highcharts/es-modules/Core/Pointer.js';
 import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
 import { deepMerge } from '@vaadin/component-base/src/object-utils.js';
@@ -51,56 +50,28 @@ Highcharts.wrap(Highcharts.Chart.prototype, 'getSVG', function (proceed, ...args
 });
 /* eslint-enable @typescript-eslint/no-invalid-this, prefer-arrow-callback */
 
-// Monkeypatch the onDocumentMouseMove method to fix the check for the source of the event
-// Due to the fact that the event is attached to the document, the target of the event is
-// the <vaadin-chart> element, so we need to use the composedPath to get the actual target (#7107)
-Pointer.prototype.onDocumentMouseMove = function (e) {
-  const chart = this.chart;
-  const chartPosition = this.chartPosition;
-  const pEvt = this.normalize(e, chartPosition);
-  const tooltip = chart.tooltip;
-  // If we're outside, hide the tooltip
-  if (
-    chartPosition &&
-    (!tooltip || !tooltip.isSticky) &&
-    !chart.isInsidePlot(pEvt.chartX - chart.plotLeft, pEvt.chartY - chart.plotTop, {
-      visiblePlotOnly: true,
-    }) &&
-    // Use the first element from the composed path instead of the actual target
-    !this.inClass(pEvt.composedPath()[0], 'highcharts-tracker')
-  ) {
-    this.reset();
+// Document-level handlers see <vaadin-chart> as the target inside a shadow root, so retarget
+// to the composed path. Remove when fixed: vaadin/web-components#7107 (onDocumentMouseMove)
+// and highcharts/highcharts#23490 (onMouseUp).
+/* eslint-disable @typescript-eslint/no-invalid-this */
+function withComposedTarget(proceed, e, ...args) {
+  // Only a shadow host can be a retargeted event target.
+  if (!e.target?.shadowRoot) {
+    return proceed.call(this, e, ...args);
   }
-};
 
-// As the `mouseup` event is attached to the document element, the target will reference
-// the instance of the `vaadin-chart` element instead of the element the event originated from.
-// That causes some mishbehaviors, e.g. in a drilldown series, clicking in the point does not
-// drills down the series in some cases.
-// Change to check for the first element in the composed path as the target of the event.
-// Workaround for https://github.com/highcharts/highcharts/issues/23490
-//
-// TODO: Remove this monkeypatch once the referenced issue is fixed
-const { simulatedEventTarget } = HTMLUtilities;
-KeyboardNavigation.prototype.onMouseUp = function (e) {
-  delete this.isClickingChart;
-  if (!this.keyboardReset && e.relatedTarget !== simulatedEventTarget) {
-    const chart = this.chart;
-    const target = e.composedPath()[0];
-    if (!target || !chart.container.contains(target)) {
-      const curMod = this.modules?.[this.currentModuleIx || 0];
-      if (curMod?.terminate) {
-        curMod.terminate();
-      }
-      this.currentModuleIx = 0;
-    }
-    if (chart.focusElement) {
-      chart.focusElement.removeFocusBorder();
-      delete chart.focusElement;
-    }
-    this.keyboardReset = true;
+  // `delete` restores the inherited Event.prototype.target accessor.
+  Object.defineProperty(e, 'target', { value: e.composedPath()[0], configurable: true });
+  try {
+    return proceed.call(this, e, ...args);
+  } finally {
+    delete e.target;
   }
-};
+}
+/* eslint-enable @typescript-eslint/no-invalid-this */
+
+Highcharts.wrap(Pointer.prototype, 'onDocumentMouseMove', withComposedTarget);
+Highcharts.wrap(KeyboardNavigation.prototype, 'onMouseUp', withComposedTarget);
 
 // Init Highcharts global language defaults
 // No data message should be empty by default


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/12213

`Pointer.onDocumentMouseMove` and `KeyboardNavigation.onMouseUp` were full copies of Highcharts 9.2.2 method bodies, carried only so they could read the composed path: both handlers are attached to the document, so inside a shadow root the event target is the `<vaadin-chart>` element rather than the element the event came from.

- Replaced both copies with a `withComposedTarget` wrapper that retargets the event and delegates to the current upstream implementation, removing ~48 lines of vendored Highcharts code
- Skipped the retarget unless the event target is a shadow host, so the common case does not pay for `composedPath()` on every document mousemove

Delegating to 12.2.0 instead of the frozen 9.2.2 body changes the mousemove reset condition in two ways:

- `tooltip.isSticky`, which Highcharts assigns `false` once and never again, is replaced by `shouldStickOnContact()`, so a sticky tooltip now suppresses the reset. #12661 builds on this and covers it with a test.
- A new `target === ownerDocument` clause broadens when the reset fires.

## Type of change

- Refactor

> [!NOTE]
> `onMouseUp` is covered by the pointer release tests in `accessibility.test.js`, which fail without the wrapper. The mousemove retarget has no test: it only differs when the pointer is inside a tracker but outside the plot area, and trackers are clipped to the plot — across line, area, pie and column the only overhang measured was 1px at the column baseline.
