### PR TITLE
fix: make tooltip stickOnContact work in styled mode

### DIFF
--- a/packages/charts/src/styles/vaadin-chart-base-styles.js
+++ b/packages/charts/src/styles/vaadin-chart-base-styles.js
@@ -55,6 +55,12 @@ const tooltipStyles = (scope) => css`
     filter: drop-shadow(var(--vaadin-charts-tooltip-shadow, 0 4px 8px rgba(0, 0, 0, 0.2))) !important;
   }
 
+  /* Marked by the mixin for stickOnContact, which Highcharts itself only honours
+     outside styled mode. See highcharts/highcharts#25310. */
+  ${unsafeCSS(scope)} .highcharts-tooltip.vaadin-chart-sticky-tooltip {
+    pointer-events: auto;
+  }
+
   ${unsafeCSS(scope)} .highcharts-tooltip text,
   ${unsafeCSS(scope)} .highcharts-tooltip foreignObject span {
     fill: var(--highcharts-neutral-color-80, var(--vaadin-charts-data-label, var(--vaadin-text-color)));

--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -696,6 +696,7 @@ export const ChartMixin = (superClass) =>
       }
 
       this.__syncOutsideTooltipColors();
+      this.__markStickyTooltip();
       this.__redrawOrganizationDataLabels();
     }
 
@@ -722,6 +723,22 @@ export const ChartMixin = (superClass) =>
         for (let i = 0; i < 10; i++) {
           container.style.setProperty(`--_color-${i}`, style.getPropertyValue(`--_color-${i}`));
         }
+      });
+    }
+
+    /**
+     * Marks the tooltip so the stylesheet can make it reachable by the pointer. CSS
+     * cannot see the `stickOnContact` option, and Highcharts only applies it itself
+     * when styled mode is off. See highcharts/highcharts#25310.
+     *
+     * @private
+     */
+    __markStickyTooltip() {
+      const { tooltip } = this.configuration;
+
+      Highcharts.addEvent(tooltip, 'refresh', () => {
+        // `refresh` also fires when a formatter returns false, before any label exists.
+        tooltip.label?.element.classList.toggle('vaadin-chart-sticky-tooltip', tooltip.shouldStickOnContact());
       });
     }
 

--- a/packages/charts/test/tooltip-stick-on-contact.test.js
+++ b/packages/charts/test/tooltip-stick-on-contact.test.js
@@ -1,0 +1,54 @@
+import { expect } from '@vaadin/chai-plugins';
+import { resetMouse, sendMouse } from '@vaadin/test-runner-commands';
+import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import './chart-not-animated-styles.js';
+import '../src/vaadin-chart.js';
+
+describe('vaadin-chart tooltip stickOnContact', () => {
+  let chart;
+
+  async function moveMouseTo(position) {
+    await sendMouse({ type: 'move', position });
+    await nextFrame();
+    await nextFrame();
+  }
+
+  function elementAtTooltipCentre() {
+    // The label <g> is wider than the painted tooltip, so aim at the box.
+    const rect = document.querySelector('.highcharts-tooltip-box').getBoundingClientRect();
+    const [x, y] = [Math.round(rect.x + rect.width / 2), Math.round(rect.y + rect.height / 2)];
+    return [document.elementFromPoint(x, y), [x, y]];
+  }
+
+  beforeEach(async () => {
+    chart = fixtureSync(`
+      <vaadin-chart type="column" tooltip style="width: 500px; height: 300px"
+        additional-options='{ "tooltip": { "stickOnContact": true, "outside": true } }'>
+        <vaadin-chart-series title="Installation" values="[43934, 52503, 57177, 69658]"></vaadin-chart-series>
+      </vaadin-chart>
+    `);
+    await oneEvent(chart, 'chart-load');
+
+    const rect = chart.configuration.series[0].points[3].graphic.element.getBoundingClientRect();
+    await moveMouseTo([Math.round(rect.x + rect.width / 2), Math.round(rect.y + 10)]);
+  });
+
+  afterEach(async () => {
+    await resetMouse();
+  });
+
+  it('should keep the tooltip under the pointer moved onto it', async () => {
+    const [element, centre] = elementAtTooltipCentre();
+    expect(element.closest('.highcharts-tooltip')).to.exist;
+
+    await moveMouseTo(centre);
+    expect(elementAtTooltipCentre()[0].closest('.highcharts-tooltip')).to.exist;
+  });
+
+  it('should not fail when the formatter returns false', async () => {
+    chart.configuration.update({ tooltip: { formatter: () => false } });
+    await nextFrame();
+
+    expect(() => chart.configuration.series[0].points[1].onMouseOver()).to.not.throw();
+  });
+});


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/12213
Depends on #12660

`tooltip.stickOnContact` had no effect. The option's whole job is to make the tooltip reachable by the pointer, but Highcharts only applies the `pointer-events` for it when styled mode is off (`Core/Tooltip.js`, inside `if (!styledMode)`), and charts always run styled. The tooltip kept `pointer-events: none`, so the pointer passed straight through to the chart canvas and the tooltip closed.

This is an upstream gap rather than something specific to Vaadin: it reproduces with plain Highcharts and their own `highcharts.css`, and is reported as [highcharts/highcharts#25310](https://github.com/highcharts/highcharts/issues/25310).

- Added a `pointer-events: auto` rule to the shared tooltip styles, which apply both in the shadow root and to an `outside` tooltip in `document.body`
- Marked the tooltip label from the mixin on every `refresh`, since CSS cannot see the `stickOnContact` option
  - Guarded against the label not existing yet, which happens when a `formatter` returns `false`: Highcharts calls `hide()` and still fires `refresh`
- Added tests covering both the pointer reaching the tooltip and the `formatter` case

## Type of change

- Bugfix

## How to test

1. Run `yarn start` and open `dev/charts/column.html`.
2. Add `"stickOnContact": true` inside the existing `"tooltip"` object of `additional-options`.
3. Hover a column, then move the pointer onto the tooltip.
4. The tooltip stays open on the same column. Before this change the pointer went through it to the chart background and the tooltip disappeared.

> [!NOTE]
> The rect that bridges the point and the tooltip (`highcharts-tracker`) is still unpainted in styled mode, so it is not hit-testable. Moving between the two over a gap could in principle drop the contact, but a stepwise pointer walk did not reproduce it. Left alone rather than fixed speculatively.
