### PR TITLE
fix: update badge has-content when slotted text node data changes

### DIFF
--- a/packages/badge/src/vaadin-badge.js
+++ b/packages/badge/src/vaadin-badge.js
@@ -127,11 +127,11 @@ class Badge extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(L
     // Both slots use `syncInitial` because `has-content` and `has-icon` control the size of the
     // badge. Without it, consumers that measure content synchronously, e.g. auto-width columns in
     // vaadin-grid, would measure a badge whose content is still hidden by `display: none`.
-    const slot = this.shadowRoot.querySelector('slot:not([name])');
+    this.__contentSlot = this.shadowRoot.querySelector('slot:not([name])');
     this.__slotObserver = new SlotObserver(
-      slot,
-      ({ currentNodes }) => {
-        this.toggleAttribute('has-content', currentNodes.filter((node) => !isEmptyTextNode(node)).length > 0);
+      this.__contentSlot,
+      () => {
+        this.__updateHasContent();
       },
       { syncInitial: true },
     );
@@ -143,6 +143,22 @@ class Badge extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(L
         this.toggleAttribute('has-icon', currentNodes.length > 0);
       },
       { syncInitial: true },
+    );
+
+    // Filling a slotted text node changes no assigned node, so it fires no `slotchange`.
+    // Flow relies on this: it appends an empty text node and sets its data later.
+    this.__textObserver = new MutationObserver(() => {
+      this.__updateHasContent();
+    });
+    this.__textObserver.observe(this, { characterData: true, subtree: true });
+  }
+
+  /** @private */
+  __updateHasContent() {
+    const nodes = this.__contentSlot.assignedNodes({ flatten: true });
+    this.toggleAttribute(
+      'has-content',
+      nodes.some((node) => !isEmptyTextNode(node)),
     );
   }
 }

--- a/packages/badge/test/badge.test.ts
+++ b/packages/badge/test/badge.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import '../src/vaadin-badge.js';
 import type { Badge } from '../src/vaadin-badge.js';
 
@@ -57,6 +57,29 @@ describe('vaadin-badge', () => {
     it('should not set has-content attribute when content is only whitespace', async () => {
       badge.textContent = '   ';
       await nextUpdate(badge);
+      expect(badge.hasAttribute('has-content')).to.be.false;
+    });
+
+    it('should toggle has-content attribute on slotted text node data change', async () => {
+      const text = document.createTextNode('');
+      badge.appendChild(text);
+      await nextFrame();
+
+      text.data = 'Text';
+      await nextFrame();
+      expect(badge.hasAttribute('has-content')).to.be.true;
+
+      text.data = '';
+      await nextFrame();
+      expect(badge.hasAttribute('has-content')).to.be.false;
+    });
+
+    it('should not set has-content attribute when a slotted text node data is only whitespace', async () => {
+      const text = document.createTextNode('');
+      badge.appendChild(text);
+      await nextFrame();
+      text.data = '   ';
+      await nextFrame();
       expect(badge.hasAttribute('has-content')).to.be.false;
     });
   });


### PR DESCRIPTION
## Description

Fixes #12663
Follow-up to #12399

`has-content` was derived from a `SlotObserver` alone, which only reacts to `slotchange` — an
assigned-node identity change. Writing text into a text node that is already slotted changes no
assigned node, so nothing fired and the attribute was never set, leaving `[part='content']` hidden.
This became visible on first render once #12399 made the initial slot pass synchronous: `firstUpdated`
now runs inside `connectedCallback`, so any caller that appends an empty text node and fills it
afterwards sees an empty badge. Flow does exactly that for every badge — `TextBindingStrategy` creates
the text node empty and writes the data later, when the reactive queue is flushed.

- Added a `characterData` `MutationObserver` on the badge light DOM, so `has-content` also tracks text
  written into an already-slotted text node
- Routed the slot observer and the new observer through a single `__updateHasContent()` recompute, so
  the whitespace filter cannot drift between the two paths
- Kept `syncInitial` on both slots, so content present at connect is still measured at full width by
  `auto-width` grid columns (#11891)
- Added tests for text data arriving after connect, toggling at runtime, and whitespace-only data

## Type of change

- Bugfix

## How to test

1. Open `dev/badge.html`
2. Paste this into the browser console:
   ```js
   const badge = document.createElement('vaadin-badge');
   const text = document.createTextNode('');
   badge.appendChild(text);
   document.body.appendChild(badge);
   text.data = 'Aktiv';
   ```
3. The badge should show "Aktiv" instead of rendering as an empty pill

> [!NOTE]
> The `auto-width` caveat from #12399 is unchanged: when the text arrives after connect, the recompute
> lands a microtask later, so a grid `auto-width` column still measures a collapsed badge and needs
> `recalculateColumnWidths()`. This PR makes the text visible, not the column width correct.
