### PR TITLE
fix: retry pending scrollToIndex even when no rows are rendered

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -429,7 +429,7 @@ export const DataProviderMixin = (superClass) =>
 
     /** @private */
     __scrollToPendingIndexes() {
-      if (this.__pendingScrollToIndexes && this.$.items.children.length) {
+      if (this.__pendingScrollToIndexes) {
         const indexes = this.__pendingScrollToIndexes;
         delete this.__pendingScrollToIndexes;
         this.scrollToIndex(...indexes);

--- a/packages/grid/test/scroll-to-index.test.js
+++ b/packages/grid/test/scroll-to-index.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, listenOnce, nextFrame, nextResize } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, listenOnce, nextFrame, nextResize } from '@vaadin/testing-helpers';
 import './grid-test-styles.js';
 import '../all-imports.js';
 import {
@@ -188,6 +188,34 @@ describe('scroll to index', () => {
           cb(new Array(grid.pageSize).fill().map((_, index) => `foo${index}`));
         }
       };
+    });
+  });
+
+  describe('empty grid', () => {
+    let grid;
+
+    beforeEach(() => {
+      grid = createGrid(500, 0);
+      grid.dataProvider = (params, callback) => {
+        setTimeout(() => {
+          if (grid.size === 0) {
+            callback([], 0);
+          } else {
+            infiniteDataProvider(params, callback);
+          }
+        });
+      };
+      flushGrid(grid);
+    });
+
+    it('should not scroll to previously requested index after items are added', async () => {
+      grid.scrollToIndex(100);
+      await aTimeout(0);
+
+      grid.size = 1000;
+      await aTimeout(0);
+
+      expect(getFirstVisibleItem(grid).index).to.equal(0);
     });
   });
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/10014

When `scrollToIndex` is called before the grid is ready, or while data is still loading, the grid stores the indexes and retries the scroll after the next page load. That retry was skipped when the grid had no rendered rows. If the data provider returned no items, there were no rows, so the stored indexes were never used and never cleared. When items showed up later, the grid jumped to the old index. In Flow, the TreeGrid connector also stops requesting pages while a scroll is pending, which is how the linked issue ended up with a grid that no longer lazy loads.

- Removed the rendered rows check from `__scrollToPendingIndexes`, so the stored `scrollToIndex` call is always retried after a page load
  - `scrollToIndex` already stores the indexes again when the grid is not ready, and does nothing on an empty grid, so the check was not needed
- Added a test that calls `scrollToIndex` on an empty grid and checks that the grid stays at the top after items are added

## Type of change

- Bugfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
