### PR TITLE
feat: add select all button to multi-select-combo-box

### DIFF
--- a/dev/playground/multi-select-combo-box.html
+++ b/dev/playground/multi-select-combo-box.html
@@ -50,6 +50,11 @@
           <vaadin-checkbox id="autoOpenDisabled" value="autoOpenDisabled" label="Auto open disabled"></vaadin-checkbox>
           <vaadin-checkbox id="keepFilter" value="keepFilter" label="Keep filter"></vaadin-checkbox>
           <vaadin-checkbox
+            id="selectAllButtonVisible"
+            value="selectAllButtonVisible"
+            label="Select all button visible"
+          ></vaadin-checkbox>
+          <vaadin-checkbox
             id="selectedItemsOnTop"
             value="selectedItemsOnTop"
             label="Selected items on top"
@@ -129,6 +134,7 @@
         'autoExpandVertically',
         'autoOpenDisabled',
         'keepFilter',
+        'selectAllButtonVisible',
         'selectedItemsOnTop',
       ].forEach((prop) => {
         document.getElementById(prop).addEventListener('checked-changed', (e) => {

--- a/packages/aura/src/components/multi-select-combo-box.css
+++ b/packages/aura/src/components/multi-select-combo-box.css
@@ -12,8 +12,9 @@ vaadin-multi-select-combo-box-chip {
 }
 
 vaadin-multi-select-combo-box::part(select-all) {
-  padding-inline: var(--vaadin-padding-s);
-  border-radius: var(--vaadin-item-border-radius);
+  padding-inline: max(0px, var(--vaadin-padding-inline-container) - var(--aura-item-overlay-padding-inline));
+  gap: var(--vaadin-gap-xs);
+  font-size: var(--aura-font-size-s);
   color: var(--aura-accent-text-color);
   font-weight: var(--aura-font-weight-medium);
 }

--- a/packages/aura/src/components/multi-select-combo-box.css
+++ b/packages/aura/src/components/multi-select-combo-box.css
@@ -10,3 +10,16 @@
 vaadin-multi-select-combo-box-chip {
   --vaadin-icon-size: 1.25em;
 }
+
+vaadin-multi-select-combo-box::part(select-all) {
+  padding-inline: var(--vaadin-padding-s);
+  border-radius: var(--vaadin-item-border-radius);
+  color: var(--aura-accent-text-color);
+  font-weight: var(--aura-font-weight-medium);
+}
+
+@media (any-hover: hover) {
+  vaadin-multi-select-combo-box::part(select-all):hover {
+    background: var(--_aura-highlight-color);
+  }
+}

--- a/packages/multi-select-combo-box/src/select-all-controller.js
+++ b/packages/multi-select-combo-box/src/select-all-controller.js
@@ -49,7 +49,7 @@ export class SelectAllController {
     const visible = host.selectAllButtonVisible && !host.readonly && !host.dataProvider;
 
     // Do not drop focus to the body when the button is about to be hidden.
-    if (!visible && this.isButtonFocused()) {
+    if (!visible && this.#isButtonFocused()) {
       host.inputElement.focus();
     }
 
@@ -64,39 +64,6 @@ export class SelectAllController {
   }
 
   /**
-   * Returns true when the event originates from the button.
-   * @param {Event} event
-   * @return {boolean}
-   */
-  isButtonEvent(event) {
-    return event.composedPath().includes(this.#button);
-  }
-
-  /**
-   * Returns true when the button has focus.
-   * @return {boolean}
-   */
-  isButtonFocused() {
-    return this.#button === getDeepActiveElement();
-  }
-
-  /**
-   * Returns true when the focus event moves focus between the input and the
-   * button, in which case the host should keep its focused state.
-   * @param {FocusEvent} event
-   * @return {boolean}
-   */
-  isFocusMovingToInputOrButton(event) {
-    const host = this.#host;
-    if (this.#button.hidden) {
-      return false;
-    }
-    // The button is in the shadow root, so when focus moves from the input to
-    // the button, `relatedTarget` is retargeted to the host element itself.
-    return event.relatedTarget === host || event.relatedTarget === host.inputElement;
-  }
-
-  /**
    * Handles a keydown event of the host. Returns true when the event was
    * consumed and the host should not handle it any further.
    * @param {KeyboardEvent} event
@@ -105,7 +72,7 @@ export class SelectAllController {
   handleKeyDown(event) {
     const host = this.#host;
 
-    if (this.isButtonEvent(event)) {
+    if (this.#isButtonEvent(event)) {
       switch (event.key) {
         case 'Tab':
           // Move focus back to the input instead of leaving the component
@@ -140,7 +107,7 @@ export class SelectAllController {
    * overlay containing the button is about to close.
    */
   restoreFocus() {
-    if (this.isButtonFocused()) {
+    if (this.#isButtonFocused()) {
       this.#host.inputElement.focus();
     }
   }
@@ -181,6 +148,20 @@ export class SelectAllController {
 
     this.#button.focus({ focusVisible: true });
     host.removeAttribute('focus-ring');
+  }
+
+  /**
+   * Returns true when the event originates from the button.
+   */
+  #isButtonEvent(event) {
+    return event.composedPath().includes(this.#button);
+  }
+
+  /**
+   * Returns true when the button has focus.
+   */
+  #isButtonFocused() {
+    return this.#button === getDeepActiveElement();
   }
 
   /**

--- a/packages/multi-select-combo-box/src/select-all-controller.js
+++ b/packages/multi-select-combo-box/src/select-all-controller.js
@@ -1,0 +1,212 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { announce } from '@vaadin/a11y-base/src/announce.js';
+import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
+
+/**
+ * A controller that manages the select all button of `<vaadin-multi-select-combo-box>`.
+ * It shows or hides the button, updates its label, selects or deselects the items
+ * matching the current filter when the button is clicked, and keeps focus inside
+ * the component while moving between the input and the button.
+ *
+ * The button is only supported with the `items` API. With a data provider, the
+ * component may not have all items loaded, so the button is not shown.
+ *
+ * The host renders the button and calls `update` after every change to a property
+ * the button depends on.
+ */
+export class SelectAllController {
+  #allSelected = false;
+
+  #host;
+
+  #button;
+
+  /**
+   * @param {HTMLElement} host the multi-select combo box
+   * @param {HTMLButtonElement} button the select all button rendered by the host
+   */
+  constructor(host, button) {
+    this.#host = host;
+    this.#button = button;
+    button.addEventListener('click', () => this.#onClick());
+    this.update();
+  }
+
+  /**
+   * Updates the button to reflect the current state of the host. To be called
+   * by the host whenever a property the button depends on has changed.
+   */
+  update() {
+    const host = this.#host;
+    const button = this.#button;
+
+    this.#allSelected = this.#isEveryFilteredItemSelected();
+
+    const visible = host.selectAllButtonVisible && !host.readonly && !host.dataProvider;
+
+    // Do not drop focus to the body when the button is about to be hidden.
+    if (!visible && this.isButtonFocused()) {
+      host.inputElement.focus();
+    }
+
+    const { selectAll, deselectAll, selectFiltered, deselectFiltered } = host.__effectiveI18n;
+    if (host.filter) {
+      button.textContent = this.#allSelected ? deselectFiltered : selectFiltered;
+    } else {
+      button.textContent = this.#allSelected ? deselectAll : selectAll;
+    }
+
+    button.hidden = !visible;
+  }
+
+  /**
+   * Returns true when the event originates from the button.
+   * @param {Event} event
+   * @return {boolean}
+   */
+  isButtonEvent(event) {
+    return event.composedPath().includes(this.#button);
+  }
+
+  /**
+   * Returns true when the button has focus.
+   * @return {boolean}
+   */
+  isButtonFocused() {
+    return this.#button === getDeepActiveElement();
+  }
+
+  /**
+   * Returns true when the focus event moves focus between the input and the
+   * button, in which case the host should keep its focused state.
+   * @param {FocusEvent} event
+   * @return {boolean}
+   */
+  isFocusMovingToInputOrButton(event) {
+    const host = this.#host;
+    if (this.#button.hidden) {
+      return false;
+    }
+    // The button is in the shadow root, so when focus moves from the input to
+    // the button, `relatedTarget` is retargeted to the host element itself.
+    return event.relatedTarget === host || event.relatedTarget === host.inputElement;
+  }
+
+  /**
+   * Handles a keydown event of the host. Returns true when the event was
+   * consumed and the host should not handle it any further.
+   * @param {KeyboardEvent} event
+   * @return {boolean}
+   */
+  handleKeyDown(event) {
+    const host = this.#host;
+
+    if (this.isButtonEvent(event)) {
+      switch (event.key) {
+        case 'Tab':
+          // Move focus back to the input instead of leaving the component
+          event.preventDefault();
+          host.inputElement.focus();
+          return true;
+        case 'Escape':
+        case 'ArrowDown':
+        case 'ArrowUp':
+          // Move focus back to the input and let the host handle the key as if pressed there.
+          host.inputElement.focus();
+          event.preventDefault();
+          return false;
+        default:
+          // Leave other keys to the button, e.g. Enter and Space activating it.
+          return true;
+      }
+    }
+
+    // Move focus to the button instead of leaving the component
+    if (event.key === 'Tab' && host._overlayOpened && !this.#button.hidden) {
+      event.preventDefault();
+      this.#focusButton();
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Moves focus back to the input if the button has focus, e.g. when the
+   * overlay containing the button is about to close.
+   */
+  restoreFocus() {
+    if (this.isButtonFocused()) {
+      this.#host.inputElement.focus();
+    }
+  }
+
+  /**
+   * Selects the items matching the current filter, or deselects them when
+   * they are all selected already.
+   */
+  #onClick() {
+    const host = this.#host;
+    const filteredItems = this.#getFilteredItems();
+    let selectedItems;
+
+    if (this.#allSelected) {
+      selectedItems = host.selectedItems.filter((item) => host._findIndex(item, filteredItems, host.itemIdPath) === -1);
+    } else {
+      const missingItems = filteredItems.filter(
+        (item) => host._findIndex(item, host.selectedItems, host.itemIdPath) === -1,
+      );
+      selectedItems = [...host.selectedItems, ...missingItems];
+    }
+
+    host.__updateSelection(selectedItems);
+    this.#announceResult();
+  }
+
+  #focusButton() {
+    const host = this.#host;
+
+    // Only the button should look focused, so reset the highlighted
+    // item and chip, and restore the input to show the filter instead
+    // of the label of the previously highlighted item.
+    if (host._focusedIndex > -1) {
+      host._focusedIndex = -1;
+      host._inputElementValue = host.filter;
+    }
+    host._focusedChipIndex = -1;
+
+    this.#button.focus({ focusVisible: true });
+    host.removeAttribute('focus-ring');
+  }
+
+  /**
+   * Returns the items matching the current filter.
+   */
+  #getFilteredItems() {
+    return this.#host.filteredItems || [];
+  }
+
+  /**
+   * Returns true when there are items matching the current filter and
+   * all of them are selected.
+   */
+  #isEveryFilteredItemSelected() {
+    const host = this.#host;
+    const items = this.#getFilteredItems();
+    return items.length > 0 && items.every((item) => host._findIndex(item, host.selectedItems, host.itemIdPath) > -1);
+  }
+
+  #announceResult() {
+    const host = this.#host;
+    const count = host.selectedItems.length;
+    if (count === 0) {
+      announce(host.__effectiveI18n.cleared);
+    } else {
+      announce(host.__effectiveI18n.total.replace('{count}', count));
+    }
+  }
+}

--- a/packages/multi-select-combo-box/src/select-all-controller.js
+++ b/packages/multi-select-combo-box/src/select-all-controller.js
@@ -122,11 +122,9 @@ export class SelectAllController {
     let selectedItems;
 
     if (this.#allSelected) {
-      selectedItems = host.selectedItems.filter((item) => host._findIndex(item, filteredItems, host.itemIdPath) === -1);
+      selectedItems = host.selectedItems.filter((item) => host._findIndex(item, filteredItems) === -1);
     } else {
-      const missingItems = filteredItems.filter(
-        (item) => host._findIndex(item, host.selectedItems, host.itemIdPath) === -1,
-      );
+      const missingItems = filteredItems.filter((item) => host._findIndex(item, host.selectedItems) === -1);
       selectedItems = [...host.selectedItems, ...missingItems];
     }
 
@@ -178,7 +176,7 @@ export class SelectAllController {
   #isEveryFilteredItemSelected() {
     const host = this.#host;
     const items = this.#getFilteredItems();
-    return items.length > 0 && items.every((item) => host._findIndex(item, host.selectedItems, host.itemIdPath) > -1);
+    return items.length > 0 && items.every((item) => host._findIndex(item, host.selectedItems) > -1);
   }
 
   #announceResult() {

--- a/packages/multi-select-combo-box/src/select-all-controller.js
+++ b/packages/multi-select-combo-box/src/select-all-controller.js
@@ -44,14 +44,22 @@ export class SelectAllController {
     const host = this.#host;
     const button = this.#button;
 
-    this.#allSelected = this.#isEveryFilteredItemSelected();
-
     const visible = host.selectAllButtonVisible && !host.readonly && !host.dataProvider;
-
-    // Do not drop focus to the body when the button is about to be hidden.
-    if (!visible && this.#isButtonFocused()) {
-      host.inputElement.focus();
+    if (!visible) {
+      // Do not drop focus to the body when the button is about to be hidden.
+      if (this.#isButtonFocused()) {
+        host.inputElement.focus();
+      }
     }
+
+    button.hidden = !visible;
+
+    if (!visible) {
+      // Skip further updates if the button is hidden anyway
+      return;
+    }
+
+    this.#allSelected = this.#isEveryFilteredItemSelected();
 
     const { selectAll, deselectAll, selectFiltered, deselectFiltered } = host.__effectiveI18n;
     if (host.filter) {
@@ -59,8 +67,6 @@ export class SelectAllController {
     } else {
       button.textContent = this.#allSelected ? deselectAll : selectAll;
     }
-
-    button.hidden = !visible;
   }
 
   /**

--- a/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-base-styles.js
+++ b/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-base-styles.js
@@ -17,6 +17,10 @@ export const multiSelectComboBoxStyles = [
       --_wrapper-gap: var(--vaadin-multi-select-combo-box-chips-gap, 2px);
     }
 
+    [hidden] {
+      display: none !important;
+    }
+
     #chips {
       display: flex;
       align-items: center;
@@ -62,20 +66,21 @@ export const multiSelectComboBoxStyles = [
 
     [part='select-all'] {
       appearance: none;
+      display: flex;
+      align-items: center;
       flex: none;
       box-sizing: border-box;
       /* Do not let the label affect the width of the overlay */
       contain: inline-size;
       margin: var(--vaadin-item-overlay-padding, 4px);
-      margin-block-end: 0;
-      padding: var(--vaadin-padding-block-container) var(--vaadin-padding-inline-container);
+      padding: var(--vaadin-item-padding, var(--vaadin-padding-xs) var(--vaadin-padding-inline-container));
+      column-gap: var(--vaadin-item-gap, var(--vaadin-gap-s));
       border: 0;
-      border-radius: var(--vaadin-radius-m);
+      border-radius: var(--vaadin-item-border-radius, var(--vaadin-radius-m));
       background: transparent;
       color: var(--vaadin-text-color);
       font: inherit;
       font-weight: 500;
-      text-align: center;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -84,8 +89,20 @@ export const multiSelectComboBoxStyles = [
       -webkit-tap-highlight-color: transparent;
     }
 
+    /* Reserve the same space as the item checkmark icon */
+    [part='select-all']::before {
+      content: '';
+      width: var(--vaadin-icon-size, 1lh);
+      flex: none;
+    }
+
     [part='select-all']:focus-visible {
       outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
+      outline-offset: calc(var(--vaadin-focus-ring-width) * -1);
+    }
+
+    [part='select-all']:not([hidden]) + slot::slotted(*) {
+      border-top: 1px solid var(--vaadin-border-color-secondary);
     }
   `,
 ];

--- a/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-base-styles.js
+++ b/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-base-styles.js
@@ -87,9 +87,5 @@ export const multiSelectComboBoxStyles = [
     [part='select-all']:focus-visible {
       outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
     }
-
-    [part='select-all'][hidden] {
-      display: none;
-    }
   `,
 ];

--- a/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-base-styles.js
+++ b/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-base-styles.js
@@ -59,5 +59,37 @@ export const multiSelectComboBoxStyles = [
     :host([auto-expand-horizontally]) {
       --vaadin-field-default-width: auto;
     }
+
+    [part='select-all'] {
+      appearance: none;
+      flex: none;
+      box-sizing: border-box;
+      /* Do not let the label affect the width of the overlay */
+      contain: inline-size;
+      margin: var(--vaadin-item-overlay-padding, 4px);
+      margin-block-end: 0;
+      padding: var(--vaadin-padding-block-container) var(--vaadin-padding-inline-container);
+      border: 0;
+      border-radius: var(--vaadin-radius-m);
+      background: transparent;
+      color: var(--vaadin-text-color);
+      font: inherit;
+      font-weight: 500;
+      text-align: center;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      cursor: var(--vaadin-clickable-cursor);
+      touch-action: manipulation;
+      -webkit-tap-highlight-color: transparent;
+    }
+
+    [part='select-all']:focus-visible {
+      outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
+    }
+
+    [part='select-all'][hidden] {
+      display: none;
+    }
   `,
 ];

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.d.ts
@@ -37,6 +37,10 @@ export interface MultiSelectComboBoxI18n {
   selected?: string;
   deselected?: string;
   total?: string;
+  selectAll?: string;
+  deselectAll?: string;
+  selectFiltered?: string;
+  deselectFiltered?: string;
 }
 
 export declare function MultiSelectComboBoxMixin<TItem, T extends Constructor<HTMLElement>>(
@@ -119,6 +123,16 @@ export declare class MultiSelectComboBoxMixinClass<TItem> {
    *   // Screen reader announcement of the selected items count.
    *   // {count} is replaced with the actual count of items.
    *   total: '{count} items selected',
+   *   // Label of the select all button when no filter is set.
+   *   selectAll: 'Select all',
+   *   // Label of the select all button when no filter is set
+   *   // and all items are selected.
+   *   deselectAll: 'Deselect all',
+   *   // Label of the select all button when a filter is set.
+   *   selectFiltered: 'Select filtered',
+   *   // Label of the select all button when a filter is set
+   *   // and all items matching the filter are selected.
+   *   deselectFiltered: 'Deselect filtered',
    * }
    * ```
    */
@@ -166,6 +180,17 @@ export declare class MultiSelectComboBoxMixinClass<TItem> {
    * @attr {boolean} selected-items-on-top
    */
   selectedItemsOnTop: boolean;
+
+  /**
+   * Set to true to show a button above the dropdown items for selecting
+   * or deselecting all items matching the current filter at once. Items
+   * that do not match the filter keep their selection state.
+   *
+   * The button is only supported with the `items` API. It is not shown
+   * when using `dataProvider`.
+   * @attr {boolean} select-all-button-visible
+   */
+  selectAllButtonVisible: boolean;
 
   /**
    * Clears the selected items.

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.d.ts
@@ -123,16 +123,16 @@ export declare class MultiSelectComboBoxMixinClass<TItem> {
    *   // Screen reader announcement of the selected items count.
    *   // {count} is replaced with the actual count of items.
    *   total: '{count} items selected',
-   *   // Label of the select all button when no filter is set.
-   *   selectAll: 'Select all',
-   *   // Label of the select all button when no filter is set
+   *   // Text of the select all button when no filter is set.
+   *   selectAll: 'Select All',
+   *   // Text of the select all button when no filter is set
    *   // and all items are selected.
-   *   deselectAll: 'Deselect all',
-   *   // Label of the select all button when a filter is set.
-   *   selectFiltered: 'Select filtered',
-   *   // Label of the select all button when a filter is set
+   *   deselectAll: 'Deselect All',
+   *   // Text of the select all button when a filter is set.
+   *   selectFiltered: 'Select Filtered',
+   *   // Text of the select all button when a filter is set
    *   // and all items matching the filter are selected.
-   *   deselectFiltered: 'Deselect filtered',
+   *   deselectFiltered: 'Deselect Filtered',
    * }
    * ```
    */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -355,11 +355,6 @@ export const MultiSelectComboBoxMixin = (superClass) =>
         },
       });
       this.addController(this._overflowController);
-    }
-
-    /** @protected */
-    firstUpdated(props) {
-      super.firstUpdated(props);
 
       this._selectAllController = new SelectAllController(this, this.shadowRoot.querySelector('[part="select-all"]'));
     }
@@ -410,7 +405,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
         '__effectiveI18n',
       ];
       if (selectAllProps.some((prop) => props.has(prop))) {
-        this._selectAllController.update();
+        this._selectAllController?.update();
       }
     }
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -592,22 +592,10 @@ export const MultiSelectComboBoxMixin = (superClass) =>
     }
 
     /**
-     * Override method inherited from `FocusMixin` to not update the focused
-     * state when focus moves to the select all button, so that only the
-     * button shows a focus ring while it is focused.
-     *
-     * @param {FocusEvent} event
-     * @return {boolean}
-     * @protected
-     * @override
-     */
-    _shouldSetFocus(event) {
-      return !this._selectAllController.isButtonEvent(event) && super._shouldSetFocus(event);
-    }
-
-    /**
      * Override method from `ComboBoxBaseMixin` to not remove the focused
-     * state when focus moves between the input and the select all button.
+     * state when focus moves to another focusable element of this component,
+     * such as the select all button. That button is in the shadow root, so
+     * `relatedTarget` is retargeted to the host element itself.
      *
      * @param {FocusEvent} event
      * @return {boolean}
@@ -615,7 +603,12 @@ export const MultiSelectComboBoxMixin = (superClass) =>
      * @override
      */
     _shouldRemoveFocus(event) {
-      return !this._selectAllController.isFocusMovingToInputOrButton(event) && super._shouldRemoveFocus(event);
+      const { relatedTarget } = event;
+      if (relatedTarget === this || relatedTarget === this.inputElement) {
+        return false;
+      }
+
+      return super._shouldRemoveFocus(event);
     }
 
     /**

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -15,6 +15,7 @@ import { TooltipController } from '@vaadin/component-base/src/tooltip-controller
 import { InputControlMixin } from '@vaadin/field-base/src/input-control-mixin.js';
 import { InputController } from '@vaadin/field-base/src/input-controller.js';
 import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
+import { SelectAllController } from './select-all-controller.js';
 
 const DEFAULT_I18N = {
   cleared: 'Selection cleared',
@@ -22,6 +23,10 @@ const DEFAULT_I18N = {
   selected: 'added to selection',
   deselected: 'removed from selection',
   total: '{count} items selected',
+  selectAll: 'Select all',
+  deselectAll: 'Deselect all',
+  selectFiltered: 'Select filtered',
+  deselectFiltered: 'Deselect filtered',
 };
 
 export const MultiSelectComboBoxMixin = (superClass) =>
@@ -165,6 +170,21 @@ export const MultiSelectComboBoxMixin = (superClass) =>
           sync: true,
         },
 
+        /**
+         * Set to true to show a button above the dropdown items for selecting
+         * or deselecting all items matching the current filter at once. Items
+         * that do not match the filter keep their selection state.
+         *
+         * The button is only supported with the `items` API. It is not shown
+         * when using `dataProvider`.
+         * @attr {boolean} select-all-button-visible
+         */
+        selectAllButtonVisible: {
+          type: Boolean,
+          value: false,
+          sync: true,
+        },
+
         /** @private */
         value: {
           type: String,
@@ -235,6 +255,16 @@ export const MultiSelectComboBoxMixin = (superClass) =>
      *   // Screen reader announcement of the selected items count.
      *   // {count} is replaced with the actual count of items.
      *   total: '{count} items selected',
+     *   // Label of the select all button when no filter is set.
+     *   selectAll: 'Select all',
+     *   // Label of the select all button when no filter is set
+     *   // and all items are selected.
+     *   deselectAll: 'Deselect all',
+     *   // Label of the select all button when a filter is set.
+     *   selectFiltered: 'Select filtered',
+     *   // Label of the select all button when a filter is set
+     *   // and all items matching the filter are selected.
+     *   deselectFiltered: 'Deselect filtered',
      * }
      * ```
      * @type {!MultiSelectComboBoxI18n}
@@ -328,6 +358,13 @@ export const MultiSelectComboBoxMixin = (superClass) =>
     }
 
     /** @protected */
+    firstUpdated(props) {
+      super.firstUpdated(props);
+
+      this._selectAllController = new SelectAllController(this, this.shadowRoot.querySelector('[part="select-all"]'));
+    }
+
+    /** @protected */
     updated(props) {
       super.updated(props);
 
@@ -360,6 +397,20 @@ export const MultiSelectComboBoxMixin = (superClass) =>
         if (this.dataProvider) {
           this.clearCache();
         }
+      }
+
+      const selectAllProps = [
+        'selectAllButtonVisible',
+        'readonly',
+        'dataProvider',
+        'filteredItems',
+        'selectedItems',
+        'filter',
+        'itemIdPath',
+        '__effectiveI18n',
+      ];
+      if (selectAllProps.some((prop) => props.has(prop))) {
+        this._selectAllController.update();
       }
     }
 
@@ -437,6 +488,9 @@ export const MultiSelectComboBoxMixin = (superClass) =>
      * @override
      */
     _onClosed() {
+      // Do not leave focus on the select all button, which is hidden together with the overlay.
+      this._selectAllController.restoreFocus();
+
       // Do not commit selected item again on outside click
       this._ignoreCommitValue = true;
 
@@ -540,6 +594,33 @@ export const MultiSelectComboBoxMixin = (superClass) =>
       if (blurred && this.readonly) {
         this.close();
       }
+    }
+
+    /**
+     * Override method inherited from `FocusMixin` to not update the focused
+     * state when focus moves to the select all button, so that only the
+     * button shows a focus ring while it is focused.
+     *
+     * @param {FocusEvent} event
+     * @return {boolean}
+     * @protected
+     * @override
+     */
+    _shouldSetFocus(event) {
+      return !this._selectAllController.isButtonEvent(event) && super._shouldSetFocus(event);
+    }
+
+    /**
+     * Override method from `ComboBoxBaseMixin` to not remove the focused
+     * state when focus moves between the input and the select all button.
+     *
+     * @param {FocusEvent} event
+     * @return {boolean}
+     * @protected
+     * @override
+     */
+    _shouldRemoveFocus(event) {
+      return !this._selectAllController.isFocusMovingToInputOrButton(event) && super._shouldRemoveFocus(event);
     }
 
     /**
@@ -1093,6 +1174,10 @@ export const MultiSelectComboBoxMixin = (superClass) =>
      * @override
      */
     _onKeyDown(event) {
+      if (this._selectAllController.handleKeyDown(event)) {
+        return;
+      }
+
       super._onKeyDown(event);
 
       const chips = this._chips;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -23,10 +23,10 @@ const DEFAULT_I18N = {
   selected: 'added to selection',
   deselected: 'removed from selection',
   total: '{count} items selected',
-  selectAll: 'Select all',
-  deselectAll: 'Deselect all',
-  selectFiltered: 'Select filtered',
-  deselectFiltered: 'Deselect filtered',
+  selectAll: 'Select All',
+  deselectAll: 'Deselect All',
+  selectFiltered: 'Select Filtered',
+  deselectFiltered: 'Deselect Filtered',
 };
 
 export const MultiSelectComboBoxMixin = (superClass) =>
@@ -255,16 +255,16 @@ export const MultiSelectComboBoxMixin = (superClass) =>
      *   // Screen reader announcement of the selected items count.
      *   // {count} is replaced with the actual count of items.
      *   total: '{count} items selected',
-     *   // Label of the select all button when no filter is set.
-     *   selectAll: 'Select all',
-     *   // Label of the select all button when no filter is set
+     *   // Text of the select all button when no filter is set.
+     *   selectAll: 'Select All',
+     *   // Text of the select all button when no filter is set
      *   // and all items are selected.
-     *   deselectAll: 'Deselect all',
-     *   // Label of the select all button when a filter is set.
-     *   selectFiltered: 'Select filtered',
-     *   // Label of the select all button when a filter is set
+     *   deselectAll: 'Deselect All',
+     *   // Text of the select all button when a filter is set.
+     *   selectFiltered: 'Select Filtered',
+     *   // Text of the select all button when a filter is set
      *   // and all items matching the filter are selected.
-     *   deselectFiltered: 'Deselect filtered',
+     *   deselectFiltered: 'Deselect Filtered',
      * }
      * ```
      * @type {!MultiSelectComboBoxI18n}

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -110,6 +110,7 @@ export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap 
  * `helper-text`          | The helper text element wrapper
  * `required-indicator`   | The `required` state indicator element
  * `toggle-button`        | The toggle button
+ * `select-all`           | The button for selecting or deselecting all items, shown in the overlay
  * `overlay`              | The overlay container
  * `content`              | The overlay content
  * `loader`               | The loading indicator shown while loading items

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -200,6 +200,7 @@ class MultiSelectComboBox extends MultiSelectComboBoxMixin(
 
       <vaadin-multi-select-combo-box-overlay
         id="overlay"
+        role="application"
         exportparts="overlay, content, loader"
         .owner="${this}"
         .dir="${this.dir}"

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -48,6 +48,7 @@ import { MultiSelectComboBoxMixin } from './vaadin-multi-select-combo-box-mixin.
  * `helper-text`          | The helper text element wrapper
  * `required-indicator`   | The `required` state indicator element
  * `toggle-button`        | The toggle button
+ * `select-all`           | The button for selecting or deselecting all items, shown in the overlay
  * `overlay`              | The overlay container
  * `content`              | The overlay content
  * `loader`               | The loading indicator shown while loading items
@@ -208,6 +209,7 @@ class MultiSelectComboBox extends MultiSelectComboBoxMixin(
         .positionTarget="${this._inputField}"
         no-vertical-overlap
       >
+        <button part="select-all" type="button" hidden></button>
         <slot name="overlay"></slot>
       </vaadin-multi-select-combo-box-overlay>
     `;

--- a/packages/multi-select-combo-box/test/accessibility.test.js
+++ b/packages/multi-select-combo-box/test/accessibility.test.js
@@ -127,6 +127,16 @@ describe('accessibility', () => {
         expect(items[0].getAttribute('aria-selected')).to.equal('false');
       });
     });
+
+    describe('overlay', () => {
+      it('should apply role="application" on the overlay', () => {
+        // The overlay sets role="application" to prevent screen readers from
+        // exiting focus mode when the select all button is focused. Without
+        // this pressing Arrow Down / Up from the button does not restore focus
+        // to the input and arrow key navigation breaks in NVDA and JAWS.
+        expect(comboBox.$.overlay.role).to.equal('application');
+      });
+    });
   });
 
   describe('announcements', () => {

--- a/packages/multi-select-combo-box/test/accessibility.test.js
+++ b/packages/multi-select-combo-box/test/accessibility.test.js
@@ -129,6 +129,11 @@ describe('accessibility', () => {
     });
 
     describe('overlay', () => {
+      beforeEach(async () => {
+        comboBox = fixtureSync(`<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>`);
+        await nextRender();
+      });
+
       it('should apply role="application" on the overlay', () => {
         // The overlay sets role="application" to prevent screen readers from
         // exiting focus mode when the select all button is focused. Without

--- a/packages/multi-select-combo-box/test/accessibility.test.js
+++ b/packages/multi-select-combo-box/test/accessibility.test.js
@@ -3,7 +3,7 @@ import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-multi-select-combo-box.js';
-import { getAllItems, getFirstItem } from './helpers.js';
+import { getAllItems, getFirstItem, getSelectAllButton, setInputValue } from './helpers.js';
 
 describe('accessibility', () => {
   let comboBox, inputElement;
@@ -236,6 +236,63 @@ describe('accessibility', () => {
       clock.tick(150);
 
       expect(region.textContent).to.equal('Apple removed from selection 0 items selected');
+    });
+
+    describe('select all', () => {
+      beforeEach(() => {
+        comboBox.selectAllButtonVisible = true;
+        comboBox.opened = true;
+      });
+
+      it('should announce the total when selecting all items', () => {
+        getSelectAllButton(comboBox).click();
+
+        clock.tick(150);
+
+        expect(region.textContent).to.equal('4 items selected');
+      });
+
+      it('should announce the total when selecting filtered items', () => {
+        comboBox.selectedItems = [lemon];
+        setInputValue(comboBox, 'an');
+
+        getSelectAllButton(comboBox).click();
+
+        clock.tick(150);
+
+        expect(region.textContent).to.equal('3 items selected');
+      });
+
+      it('should announce the total when deselecting filtered items', () => {
+        comboBox.selectedItems = [lemon, banana, orange];
+        setInputValue(comboBox, 'an');
+
+        getSelectAllButton(comboBox).click();
+
+        clock.tick(150);
+
+        expect(region.textContent).to.equal('1 items selected');
+      });
+
+      it('should announce cleared selection when deselecting all items', () => {
+        comboBox.selectedItems = fruits;
+
+        getSelectAllButton(comboBox).click();
+
+        clock.tick(150);
+
+        expect(region.textContent).to.equal('Selection cleared');
+      });
+
+      it('should use custom i18n messages', () => {
+        comboBox.i18n = { total: '{count} selected' };
+
+        getSelectAllButton(comboBox).click();
+
+        clock.tick(150);
+
+        expect(region.textContent).to.equal('4 selected');
+      });
     });
   });
 });

--- a/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
+++ b/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
@@ -484,7 +484,6 @@ snapshots["vaadin-multi-select-combo-box host opened overlay"] =
     part="select-all"
     type="button"
   >
-    Select All
   </button>
   <slot name="overlay">
   </slot>
@@ -577,7 +576,6 @@ snapshots["vaadin-multi-select-combo-box shadow default"] =
     part="select-all"
     type="button"
   >
-    Select All
   </button>
   <slot name="overlay">
   </slot>
@@ -653,7 +651,6 @@ snapshots["vaadin-multi-select-combo-box shadow disabled"] =
     part="select-all"
     type="button"
   >
-    Select All
   </button>
   <slot name="overlay">
   </slot>
@@ -729,7 +726,6 @@ snapshots["vaadin-multi-select-combo-box shadow readonly"] =
     part="select-all"
     type="button"
   >
-    Select All
   </button>
   <slot name="overlay">
   </slot>
@@ -805,7 +801,6 @@ snapshots["vaadin-multi-select-combo-box shadow invalid"] =
     part="select-all"
     type="button"
   >
-    Select All
   </button>
   <slot name="overlay">
   </slot>

--- a/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
+++ b/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
@@ -484,7 +484,7 @@ snapshots["vaadin-multi-select-combo-box host opened overlay"] =
     part="select-all"
     type="button"
   >
-    Select all
+    Select All
   </button>
   <slot name="overlay">
   </slot>
@@ -557,7 +557,7 @@ snapshots["vaadin-multi-select-combo-box shadow default"] =
     part="select-all"
     type="button"
   >
-    Select all
+    Select All
   </button>
   <slot name="overlay">
   </slot>
@@ -633,7 +633,7 @@ snapshots["vaadin-multi-select-combo-box shadow disabled"] =
     part="select-all"
     type="button"
   >
-    Select all
+    Select All
   </button>
   <slot name="overlay">
   </slot>
@@ -709,7 +709,7 @@ snapshots["vaadin-multi-select-combo-box shadow readonly"] =
     part="select-all"
     type="button"
   >
-    Select all
+    Select All
   </button>
   <slot name="overlay">
   </slot>
@@ -785,7 +785,7 @@ snapshots["vaadin-multi-select-combo-box shadow invalid"] =
     part="select-all"
     type="button"
   >
-    Select all
+    Select All
   </button>
   <slot name="overlay">
   </slot>
@@ -805,7 +805,7 @@ snapshots["vaadin-multi-select-combo-box host opened overlay select all button"]
     part="select-all"
     type="button"
   >
-    Select all
+    Select All
   </button>
   <slot name="overlay">
   </slot>

--- a/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
+++ b/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
@@ -492,6 +492,26 @@ snapshots["vaadin-multi-select-combo-box host opened overlay"] =
 `;
 /* end snapshot vaadin-multi-select-combo-box host opened overlay */
 
+snapshots["vaadin-multi-select-combo-box host opened overlay select all button"] = 
+`<vaadin-multi-select-combo-box-overlay
+  exportparts="overlay, content, loader"
+  id="overlay"
+  no-vertical-overlap=""
+  popover="manual"
+  role="application"
+>
+  <button
+    part="select-all"
+    type="button"
+  >
+    Select All
+  </button>
+  <slot name="overlay">
+  </slot>
+</vaadin-multi-select-combo-box-overlay>
+`;
+/* end snapshot vaadin-multi-select-combo-box host opened overlay select all button */
+
 snapshots["vaadin-multi-select-combo-box shadow default"] = 
 `<div class="vaadin-multi-select-combo-box-container">
   <div part="label">
@@ -792,24 +812,4 @@ snapshots["vaadin-multi-select-combo-box shadow invalid"] =
 </vaadin-multi-select-combo-box-overlay>
 `;
 /* end snapshot vaadin-multi-select-combo-box shadow invalid */
-
-snapshots["vaadin-multi-select-combo-box host opened overlay select all button"] = 
-`<vaadin-multi-select-combo-box-overlay
-  exportparts="overlay, content, loader"
-  id="overlay"
-  no-vertical-overlap=""
-  popover="manual"
-  role="application"
->
-  <button
-    part="select-all"
-    type="button"
-  >
-    Select All
-  </button>
-  <slot name="overlay">
-  </slot>
-</vaadin-multi-select-combo-box-overlay>
-`;
-/* end snapshot vaadin-multi-select-combo-box host opened overlay select all button */
 

--- a/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
+++ b/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
@@ -477,6 +477,7 @@ snapshots["vaadin-multi-select-combo-box host opened overlay"] =
   id="overlay"
   no-vertical-overlap=""
   popover="manual"
+  role="application"
 >
   <button
     hidden=""
@@ -549,6 +550,7 @@ snapshots["vaadin-multi-select-combo-box shadow default"] =
   id="overlay"
   no-vertical-overlap=""
   popover="manual"
+  role="application"
 >
   <button
     hidden=""
@@ -624,6 +626,7 @@ snapshots["vaadin-multi-select-combo-box shadow disabled"] =
   id="overlay"
   no-vertical-overlap=""
   popover="manual"
+  role="application"
 >
   <button
     hidden=""
@@ -699,6 +702,7 @@ snapshots["vaadin-multi-select-combo-box shadow readonly"] =
   id="overlay"
   no-vertical-overlap=""
   popover="manual"
+  role="application"
 >
   <button
     hidden=""
@@ -774,6 +778,7 @@ snapshots["vaadin-multi-select-combo-box shadow invalid"] =
   id="overlay"
   no-vertical-overlap=""
   popover="manual"
+  role="application"
 >
   <button
     hidden=""
@@ -794,6 +799,7 @@ snapshots["vaadin-multi-select-combo-box host opened overlay select all button"]
   id="overlay"
   no-vertical-overlap=""
   popover="manual"
+  role="application"
 >
   <button
     part="select-all"

--- a/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
+++ b/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
@@ -478,6 +478,13 @@ snapshots["vaadin-multi-select-combo-box host opened overlay"] =
   no-vertical-overlap=""
   popover="manual"
 >
+  <button
+    hidden=""
+    part="select-all"
+    type="button"
+  >
+    Select all
+  </button>
   <slot name="overlay">
   </slot>
 </vaadin-multi-select-combo-box-overlay>
@@ -543,6 +550,13 @@ snapshots["vaadin-multi-select-combo-box shadow default"] =
   no-vertical-overlap=""
   popover="manual"
 >
+  <button
+    hidden=""
+    part="select-all"
+    type="button"
+  >
+    Select all
+  </button>
   <slot name="overlay">
   </slot>
 </vaadin-multi-select-combo-box-overlay>
@@ -611,6 +625,13 @@ snapshots["vaadin-multi-select-combo-box shadow disabled"] =
   no-vertical-overlap=""
   popover="manual"
 >
+  <button
+    hidden=""
+    part="select-all"
+    type="button"
+  >
+    Select all
+  </button>
   <slot name="overlay">
   </slot>
 </vaadin-multi-select-combo-box-overlay>
@@ -679,6 +700,13 @@ snapshots["vaadin-multi-select-combo-box shadow readonly"] =
   no-vertical-overlap=""
   popover="manual"
 >
+  <button
+    hidden=""
+    part="select-all"
+    type="button"
+  >
+    Select all
+  </button>
   <slot name="overlay">
   </slot>
 </vaadin-multi-select-combo-box-overlay>
@@ -747,9 +775,35 @@ snapshots["vaadin-multi-select-combo-box shadow invalid"] =
   no-vertical-overlap=""
   popover="manual"
 >
+  <button
+    hidden=""
+    part="select-all"
+    type="button"
+  >
+    Select all
+  </button>
   <slot name="overlay">
   </slot>
 </vaadin-multi-select-combo-box-overlay>
 `;
 /* end snapshot vaadin-multi-select-combo-box shadow invalid */
+
+snapshots["vaadin-multi-select-combo-box host opened overlay select all button"] = 
+`<vaadin-multi-select-combo-box-overlay
+  exportparts="overlay, content, loader"
+  id="overlay"
+  no-vertical-overlap=""
+  popover="manual"
+>
+  <button
+    part="select-all"
+    type="button"
+  >
+    Select all
+  </button>
+  <slot name="overlay">
+  </slot>
+</vaadin-multi-select-combo-box-overlay>
+`;
+/* end snapshot vaadin-multi-select-combo-box host opened overlay select all button */
 

--- a/packages/multi-select-combo-box/test/dom/multi-select-combo-box.test.js
+++ b/packages/multi-select-combo-box/test/dom/multi-select-combo-box.test.js
@@ -81,6 +81,12 @@ describe('vaadin-multi-select-combo-box', () => {
       it('overlay', async () => {
         await expect(multiSelectComboBox.$.overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
       });
+
+      it('overlay select all button', async () => {
+        multiSelectComboBox.selectAllButtonVisible = true;
+        await nextRender();
+        await expect(multiSelectComboBox.$.overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+      });
     });
   });
 

--- a/packages/multi-select-combo-box/test/helpers.js
+++ b/packages/multi-select-combo-box/test/helpers.js
@@ -75,3 +75,8 @@ export function setInputValue(comboBox, value) {
  * Returns all the chips of the combo-box.
  */
 export const getChips = (comboBox) => comboBox.querySelectorAll('vaadin-multi-select-combo-box-chip');
+
+/**
+ * Returns the select all button of the combo-box.
+ */
+export const getSelectAllButton = (comboBox) => comboBox.shadowRoot.querySelector('[part="select-all"]');

--- a/packages/multi-select-combo-box/test/helpers.js
+++ b/packages/multi-select-combo-box/test/helpers.js
@@ -61,6 +61,16 @@ export const getFirstItem = (comboBox) => {
 };
 
 /**
+ * Returns the index of the currently focused item for a combo-box.
+ *
+ * @param {Element} comboBox
+ * @return {number}
+ */
+export const getFocusedItemIndex = (comboBox) => {
+  return getAllItems(comboBox).findIndex((item) => item.hasAttribute('focused'));
+};
+
+/**
  * Emulates the user filling in something in the combo-box input.
  *
  * @param {Element} comboBox

--- a/packages/multi-select-combo-box/test/partial-match-mode.test.js
+++ b/packages/multi-select-combo-box/test/partial-match-mode.test.js
@@ -2,14 +2,10 @@ import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import '../src/vaadin-multi-select-combo-box.js';
-import { getAllItems } from './helpers.js';
+import { getFocusedItemIndex } from './helpers.js';
 
 describe('partial-match-mode', () => {
   let comboBox, inputElement;
-
-  function getFocusedItemIndex() {
-    return getAllItems(comboBox).findIndex((item) => item.hasAttribute('focused'));
-  }
 
   beforeEach(async () => {
     comboBox = fixtureSync('<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>');
@@ -29,12 +25,12 @@ describe('partial-match-mode', () => {
 
     it('should highlight the exact match', async () => {
       await sendKeys({ type: 'grape' });
-      expect(getFocusedItemIndex()).to.equal(1);
+      expect(getFocusedItemIndex(comboBox)).to.equal(1);
     });
 
     it('should not highlight partial matches', async () => {
       await sendKeys({ type: 'gra' });
-      expect(getFocusedItemIndex()).to.equal(-1);
+      expect(getFocusedItemIndex(comboBox)).to.equal(-1);
     });
 
     describe('value commit', () => {
@@ -66,23 +62,23 @@ describe('partial-match-mode', () => {
 
     it('should highlight the first partial match', async () => {
       await sendKeys({ type: 'gra' });
-      expect(getFocusedItemIndex()).to.equal(0);
+      expect(getFocusedItemIndex(comboBox)).to.equal(0);
     });
 
     it('should highlight the exact match when there is one', async () => {
       await sendKeys({ type: 'grape' });
-      expect(getFocusedItemIndex()).to.equal(1);
+      expect(getFocusedItemIndex(comboBox)).to.equal(1);
     });
 
     it('should not highlight the first partial match when custom values are allowed', async () => {
       comboBox.allowCustomValue = true;
       await sendKeys({ type: 'gra' });
-      expect(getFocusedItemIndex()).to.equal(-1);
+      expect(getFocusedItemIndex(comboBox)).to.equal(-1);
     });
 
     it('should not highlight anything when the filter is empty', () => {
       comboBox.open();
-      expect(getFocusedItemIndex()).to.equal(-1);
+      expect(getFocusedItemIndex(comboBox)).to.equal(-1);
     });
 
     describe('value commit', () => {
@@ -146,17 +142,17 @@ describe('partial-match-mode', () => {
 
     it('should highlight the only partial match', async () => {
       await sendKeys({ type: 'ban' });
-      expect(getFocusedItemIndex()).to.equal(0);
+      expect(getFocusedItemIndex(comboBox)).to.equal(0);
     });
 
     it('should not highlight anything when multiple items match', async () => {
       await sendKeys({ type: 'gra' });
-      expect(getFocusedItemIndex()).to.equal(-1);
+      expect(getFocusedItemIndex(comboBox)).to.equal(-1);
     });
 
     it('should highlight the exact match when there is one', async () => {
       await sendKeys({ type: 'grape' });
-      expect(getFocusedItemIndex()).to.equal(1);
+      expect(getFocusedItemIndex(comboBox)).to.equal(1);
     });
 
     describe('value commit', () => {
@@ -197,7 +193,7 @@ describe('partial-match-mode', () => {
     it('should highlight the first partial match when opening the dropdown after typing', async () => {
       await sendKeys({ type: 'grap' });
       await sendKeys({ press: 'ArrowDown' });
-      expect(getFocusedItemIndex()).to.equal(0);
+      expect(getFocusedItemIndex(comboBox)).to.equal(0);
     });
 
     it('should select the first partial match on Enter after opening the dropdown', async () => {

--- a/packages/multi-select-combo-box/test/select-all.test.js
+++ b/packages/multi-select-combo-box/test/select-all.test.js
@@ -422,7 +422,7 @@ describe('select all', () => {
 
       await sendKeys({ press: 'Tab' });
       expect(comboBox.hasAttribute('focused')).to.be.true;
-      expect(comboBox.hasAttribute('focused')).to.be.true;
+      expect(comboBox.hasAttribute('focus-ring')).to.be.true;
       expect(button.matches(':focus-visible')).to.be.false;
     });
 

--- a/packages/multi-select-combo-box/test/select-all.test.js
+++ b/packages/multi-select-combo-box/test/select-all.test.js
@@ -1,0 +1,610 @@
+import { expect } from '@vaadin/chai-plugins';
+import { resetMouse, sendKeys, sendMouse } from '@vaadin/test-runner-commands';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../src/vaadin-multi-select-combo-box.js';
+import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getAllItems, getDataProvider, getSelectAllButton, setInputValue } from './helpers.js';
+
+describe('select all', () => {
+  let comboBox, inputElement, button;
+
+  const getFocusedItem = () => getAllItems(comboBox).find((item) => item.hasAttribute('focused'));
+
+  const getLabel = () => getSelectAllButton(comboBox).textContent.trim();
+
+  const clickButton = () => getSelectAllButton(comboBox).click();
+
+  beforeEach(async () => {
+    comboBox = fixtureSync(`<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>`);
+    comboBox.items = ['Apple', 'Banana', 'Lemon', 'Orange'];
+    await nextRender();
+    inputElement = comboBox.inputElement;
+  });
+
+  describe('visibility', () => {
+    const isButtonVisible = () => getSelectAllButton(comboBox).checkVisibility();
+
+    beforeEach(() => {
+      comboBox.opened = true;
+    });
+
+    it('should hide button by default', () => {
+      expect(isButtonVisible()).to.be.false;
+    });
+
+    it('should toggle button visibility when the property changes', () => {
+      comboBox.selectAllButtonVisible = true;
+      expect(isButtonVisible()).to.be.true;
+
+      comboBox.selectAllButtonVisible = false;
+      expect(isButtonVisible()).to.be.false;
+    });
+
+    it('should hide button when readonly', () => {
+      // Keep the overlay open in readonly mode, which only lists selected items
+      comboBox.selectedItems = ['Apple'];
+      comboBox.selectAllButtonVisible = true;
+      comboBox.readonly = true;
+      expect(comboBox.$.overlay.opened).to.be.true;
+      expect(isButtonVisible()).to.be.false;
+
+      comboBox.readonly = false;
+      expect(isButtonVisible()).to.be.true;
+    });
+
+    it('should hide button when using a data provider', async () => {
+      const items = Array.from({ length: 100 }, (_, i) => `Item ${i}`);
+      comboBox = fixtureSync(
+        `<vaadin-multi-select-combo-box select-all-button-visible></vaadin-multi-select-combo-box>`,
+      );
+      comboBox.selectAllButtonVisible = true;
+      comboBox.pageSize = 10;
+      comboBox.dataProvider = getDataProvider(items);
+      await nextRender();
+      comboBox.opened = true;
+
+      expect(isButtonVisible()).to.be.false;
+    });
+  });
+
+  describe('label', () => {
+    beforeEach(() => {
+      comboBox.selectAllButtonVisible = true;
+      button = getSelectAllButton(comboBox);
+    });
+
+    it('should use selectAll label when nothing is selected', () => {
+      expect(getLabel()).to.equal('Select all');
+    });
+
+    it('should use selectAll label when some items are selected', () => {
+      comboBox.selectedItems = ['Apple'];
+      expect(getLabel()).to.equal('Select all');
+    });
+
+    it('should use deselectAll label when all items are selected', () => {
+      comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange'];
+      expect(getLabel()).to.equal('Deselect all');
+    });
+
+    it('should use selectFiltered label when a filter is set', () => {
+      setInputValue(comboBox, 'an');
+      expect(getLabel()).to.equal('Select filtered');
+    });
+
+    it('should use selectFiltered label when some filtered items are selected', () => {
+      comboBox.selectedItems = ['Banana'];
+      setInputValue(comboBox, 'an');
+      expect(getLabel()).to.equal('Select filtered');
+    });
+
+    it('should use deselectFiltered label when all filtered items are selected', () => {
+      comboBox.selectedItems = ['Banana', 'Orange'];
+      setInputValue(comboBox, 'an');
+      expect(getLabel()).to.equal('Deselect filtered');
+    });
+
+    it('should update the label when the filter is cleared', () => {
+      comboBox.selectedItems = ['Banana', 'Orange'];
+      setInputValue(comboBox, 'an');
+      setInputValue(comboBox, '');
+      expect(getLabel()).to.equal('Select all');
+    });
+
+    it('should ignore unknown values when computing the label', () => {
+      comboBox.allowCustomValue = true;
+      comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange', 'Custom'];
+      expect(getLabel()).to.equal('Deselect all');
+    });
+
+    it('should compute the label from filtered items when selected items are on top', () => {
+      comboBox.selectedItemsOnTop = true;
+      comboBox.selectedItems = ['Pear'];
+      comboBox.opened = true;
+      expect(getLabel()).to.equal('Select all');
+    });
+
+    it('should use custom i18n labels', () => {
+      comboBox.i18n = {
+        selectAll: 'Alle auswählen',
+        deselectAll: 'Auswahl aufheben',
+        selectFiltered: 'Gefilterte auswählen',
+        deselectFiltered: 'Gefilterte abwählen',
+      };
+      expect(getLabel()).to.equal('Alle auswählen');
+
+      comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange'];
+      expect(getLabel()).to.equal('Auswahl aufheben');
+
+      setInputValue(comboBox, 'an');
+      expect(getLabel()).to.equal('Gefilterte abwählen');
+
+      comboBox.selectedItems = [];
+      expect(getLabel()).to.equal('Gefilterte auswählen');
+    });
+
+    describe('object items', () => {
+      const apple = { id: 1, name: 'Apple' };
+      const banana = { id: 2, name: 'Banana' };
+      const lemon = { id: 3, name: 'Lemon' };
+
+      beforeEach(() => {
+        comboBox.itemIdPath = 'id';
+        comboBox.itemLabelPath = 'name';
+        comboBox.items = [apple, banana, lemon];
+      });
+
+      it('should use deselectAll label when all items are selected by id', () => {
+        comboBox.selectedItems = [{ ...apple }, { ...banana }, { ...lemon }];
+        expect(getLabel()).to.equal('Deselect all');
+      });
+
+      it('should use selectAll label when some items are selected by id', () => {
+        comboBox.selectedItems = [{ ...apple }];
+        expect(getLabel()).to.equal('Select all');
+      });
+    });
+  });
+
+  describe('clicking', () => {
+    let changeSpy, selectedItemsChangedSpy;
+
+    beforeEach(() => {
+      comboBox.selectAllButtonVisible = true;
+      button = getSelectAllButton(comboBox);
+      changeSpy = sinon.spy();
+      comboBox.addEventListener('change', changeSpy);
+      selectedItemsChangedSpy = sinon.spy();
+      comboBox.addEventListener('selected-items-changed', selectedItemsChangedSpy);
+      comboBox.opened = true;
+    });
+
+    it('should select all items', () => {
+      comboBox.selectedItems = [];
+      clickButton();
+      expect(comboBox.selectedItems).to.deep.equal(['Apple', 'Banana', 'Lemon', 'Orange']);
+    });
+
+    it('should deselect all items', () => {
+      comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange'];
+      clickButton();
+      expect(comboBox.selectedItems).to.deep.equal([]);
+    });
+
+    it('should select all items when some items are selected', () => {
+      comboBox.selectedItems = ['Apple'];
+      clickButton();
+      expect(comboBox.selectedItems).to.deep.equal(['Apple', 'Banana', 'Lemon', 'Orange']);
+    });
+
+    it('should select all items keeping the order of already selected items', () => {
+      comboBox.selectedItems = ['Lemon'];
+      clickButton();
+      expect(comboBox.selectedItems).to.deep.equal(['Lemon', 'Apple', 'Banana', 'Orange']);
+    });
+
+    it('should select only filtered items', () => {
+      comboBox.selectedItems = ['Lemon'];
+      setInputValue(comboBox, 'an');
+      clickButton();
+      expect(comboBox.selectedItems).to.deep.equal(['Lemon', 'Banana', 'Orange']);
+    });
+
+    it('should deselect only filtered items', () => {
+      comboBox.selectedItems = ['Lemon', 'Banana', 'Orange'];
+      setInputValue(comboBox, 'an');
+      clickButton();
+      expect(comboBox.selectedItems).to.deep.equal(['Lemon']);
+    });
+
+    it('should keep the filter after clicking', () => {
+      setInputValue(comboBox, 'an');
+      clickButton();
+      expect(comboBox.filter).to.equal('an');
+      expect(inputElement.value).to.equal('an');
+    });
+
+    it('should preserve unknown values when selecting all items', () => {
+      comboBox.allowCustomValue = true;
+      comboBox.selectedItems = ['Custom'];
+      clickButton();
+      expect(comboBox.selectedItems).to.deep.equal(['Custom', 'Apple', 'Banana', 'Lemon', 'Orange']);
+    });
+
+    it('should preserve unknown values when deselecting all items', () => {
+      comboBox.allowCustomValue = true;
+      comboBox.selectedItems = ['Custom', 'Apple', 'Banana', 'Lemon', 'Orange'];
+      clickButton();
+      expect(comboBox.selectedItems).to.deep.equal(['Custom']);
+    });
+
+    it('should select all items when selected items are on top', () => {
+      comboBox.selectedItemsOnTop = true;
+      comboBox.selectedItems = ['Pear'];
+      clickButton();
+      expect(comboBox.selectedItems).to.deep.equal(['Pear', 'Apple', 'Banana', 'Lemon', 'Orange']);
+    });
+
+    it('should update the label after selecting all items', () => {
+      clickButton();
+      expect(getLabel()).to.equal('Deselect all');
+    });
+
+    it('should update the label after deselecting all items', () => {
+      comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange'];
+      clickButton();
+      expect(getLabel()).to.equal('Select all');
+    });
+
+    it('should fire change event once when selecting all items', () => {
+      clickButton();
+      expect(changeSpy).to.be.calledOnce;
+    });
+
+    it('should fire change event once when deselecting all items', () => {
+      comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange'];
+      clickButton();
+      expect(changeSpy).to.be.calledOnce;
+    });
+
+    it('should fire selected-items-changed event when selecting all items', () => {
+      clickButton();
+      expect(selectedItemsChangedSpy).to.be.calledOnce;
+      expect(selectedItemsChangedSpy.firstCall.args[0].detail.value).to.deep.equal([
+        'Apple',
+        'Banana',
+        'Lemon',
+        'Orange',
+      ]);
+    });
+
+    it('should update selected state of the dropdown items', () => {
+      clickButton();
+      getAllItems(comboBox).forEach((item) => {
+        expect(item.hasAttribute('selected')).to.be.true;
+      });
+
+      clickButton();
+      getAllItems(comboBox).forEach((item) => {
+        expect(item.hasAttribute('selected')).to.be.false;
+      });
+    });
+
+    it('should keep the overlay opened', () => {
+      clickButton();
+      expect(comboBox.opened).to.be.true;
+
+      clickButton();
+      expect(comboBox.opened).to.be.true;
+    });
+
+    it('should validate when selecting all items', () => {
+      const validatedSpy = sinon.spy();
+      comboBox.addEventListener('validated', validatedSpy);
+      clickButton();
+      expect(validatedSpy).to.be.calledOnce;
+    });
+
+    it('should mark required field as invalid when deselecting all items', () => {
+      comboBox.required = true;
+      comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange'];
+      clickButton();
+      expect(comboBox.invalid).to.be.true;
+    });
+
+    describe('object items', () => {
+      const apple = { id: 1, name: 'Apple' };
+      const banana = { id: 2, name: 'Banana' };
+      const lemon = { id: 3, name: 'Lemon' };
+
+      beforeEach(() => {
+        comboBox.itemIdPath = 'id';
+        comboBox.itemLabelPath = 'name';
+        comboBox.items = [apple, banana, lemon];
+      });
+
+      it('should select all items by id', () => {
+        comboBox.selectedItems = [{ ...banana }];
+        clickButton();
+        expect(comboBox.selectedItems).to.deep.equal([banana, apple, lemon]);
+      });
+
+      it('should deselect all items by id', () => {
+        comboBox.selectedItems = [{ ...apple }, { ...banana }, { ...lemon }];
+        clickButton();
+        expect(comboBox.selectedItems).to.deep.equal([]);
+      });
+    });
+  });
+
+  describe('keyboard', () => {
+    beforeEach(() => {
+      comboBox.selectAllButtonVisible = true;
+      comboBox.opened = true;
+      button = getSelectAllButton(comboBox);
+      button.focus();
+    });
+
+    it('should select all items on Space', async () => {
+      await sendKeys({ press: 'Space' });
+      expect(comboBox.selectedItems).to.deep.equal(['Apple', 'Banana', 'Lemon', 'Orange']);
+      expect(getLabel()).to.equal('Deselect all');
+    });
+
+    it('should select all items on Enter', async () => {
+      await sendKeys({ press: 'Enter' });
+      expect(comboBox.selectedItems).to.deep.equal(['Apple', 'Banana', 'Lemon', 'Orange']);
+      expect(getLabel()).to.equal('Deselect all');
+    });
+
+    it('should not submit the surrounding form on Enter', async () => {
+      const form = fixtureSync('<form></form>');
+      const submitSpy = sinon.spy((event) => event.preventDefault());
+      form.addEventListener('submit', submitSpy);
+      form.appendChild(comboBox);
+      await nextRender();
+      comboBox.opened = true;
+      getSelectAllButton(comboBox).focus();
+
+      await sendKeys({ press: 'Enter' });
+      expect(submitSpy).to.not.be.called;
+    });
+  });
+
+  describe('focus handling', () => {
+    let lastGlobalFocusable;
+
+    beforeEach(() => {
+      comboBox.selectAllButtonVisible = true;
+      button = getSelectAllButton(comboBox);
+      lastGlobalFocusable = fixtureSync('<input id="last-global-focusable" />');
+      inputElement.focus();
+      comboBox.opened = true;
+    });
+
+    afterEach(async () => {
+      await resetMouse();
+    });
+
+    it('should trap focus between input and button', async () => {
+      await sendKeys({ press: 'Tab' });
+      expect(getDeepActiveElement()).to.equal(button);
+
+      await sendKeys({ press: 'Tab' });
+      expect(getDeepActiveElement()).to.equal(inputElement);
+
+      await sendKeys({ press: 'Shift+Tab' });
+      expect(getDeepActiveElement()).to.equal(button);
+
+      await sendKeys({ press: 'Shift+Tab' });
+      expect(getDeepActiveElement()).to.equal(inputElement);
+    });
+
+    it('should keep the overlay opened when switching between input and button', async () => {
+      await sendKeys({ press: 'Tab' });
+      expect(comboBox.opened).to.be.true;
+      expect(comboBox.$.overlay.opened).to.be.true;
+
+      await sendKeys({ press: 'Tab' });
+      expect(comboBox.opened).to.be.true;
+      expect(comboBox.$.overlay.opened).to.be.true;
+    });
+
+    it('should update focus attribute when switching between input and button', async () => {
+      expect(comboBox.hasAttribute('focused')).to.be.true;
+      expect(comboBox.hasAttribute('focus-ring')).to.be.true;
+
+      await sendKeys({ press: 'Tab' });
+      expect(comboBox.hasAttribute('focused')).to.be.true; // is not removed
+      expect(comboBox.hasAttribute('focus-ring')).to.be.false;
+      expect(button.matches(':focus-visible')).to.be.true;
+
+      await sendKeys({ press: 'Tab' });
+      expect(comboBox.hasAttribute('focused')).to.be.true;
+      expect(comboBox.hasAttribute('focused')).to.be.true;
+      expect(button.matches(':focus-visible')).to.be.false;
+    });
+
+    it('should reset the focused item when focusing button', async () => {
+      await sendKeys({ press: 'ArrowDown' });
+      expect(getFocusedItem()).to.be.ok;
+      expect(inputElement.hasAttribute('aria-activedescendant')).to.be.true;
+
+      await sendKeys({ press: 'Tab' });
+      expect(getFocusedItem()).to.be.undefined;
+      expect(inputElement.hasAttribute('aria-activedescendant')).to.be.false;
+    });
+
+    it('should restore the filter to the input when focusing button', async () => {
+      await sendKeys({ type: 'an' });
+      await sendKeys({ press: 'ArrowDown' });
+      expect(inputElement.value).to.equal('Banana');
+
+      await sendKeys({ press: 'Tab' });
+      expect(inputElement.value).to.equal('an');
+      expect(comboBox.filter).to.equal('an');
+    });
+
+    it('should not trap focus in the component when the button is not visible', async () => {
+      comboBox.selectAllButtonVisible = false;
+
+      await sendKeys({ press: 'Tab' });
+      expect(comboBox.opened).to.be.false;
+      expect(getDeepActiveElement()).to.equal(lastGlobalFocusable);
+    });
+
+    it('should not focus the button on Tab when the overlay is closed', async () => {
+      await sendKeys({ press: 'Escape' });
+      await sendKeys({ press: 'Tab' });
+      expect(getDeepActiveElement()).to.equal(lastGlobalFocusable);
+    });
+
+    it('should not focus the button on Tab when readonly', async () => {
+      comboBox.readonly = true;
+      comboBox.selectedItems = ['Apple'];
+      await sendKeys({ press: 'Tab' });
+      expect(getDeepActiveElement()).to.equal(lastGlobalFocusable);
+    });
+
+    it('should keep the button focused after selecting all items', async () => {
+      button.focus();
+      await sendKeys({ press: 'Space' });
+      expect(getDeepActiveElement()).to.equal(button);
+      expect(comboBox.opened).to.be.true;
+    });
+
+    it('should close the overlay and focus the input on Escape', async () => {
+      button.focus();
+      await sendKeys({ press: 'Escape' });
+      expect(comboBox.opened).to.be.false;
+      expect(getDeepActiveElement()).to.equal(inputElement);
+    });
+
+    it('should focus the input and the first item on ArrowDown', async () => {
+      button.focus();
+      await sendKeys({ press: 'ArrowDown' });
+      expect(getDeepActiveElement()).to.equal(inputElement);
+      expect(getFocusedItem()).to.equal(getAllItems(comboBox)[0]);
+    });
+
+    it('should focus the input and the last item on ArrowUp', async () => {
+      button.focus();
+      await sendKeys({ press: 'ArrowUp' });
+      expect(getDeepActiveElement()).to.equal(inputElement);
+      expect(getFocusedItem()).to.equal(getAllItems(comboBox)[3]);
+    });
+
+    it('should focus the input when the overlay is closed', () => {
+      button.focus();
+      comboBox.close();
+      expect(getDeepActiveElement()).to.equal(inputElement);
+    });
+
+    it('should focus the input when the overlay is closed on outside click', async () => {
+      button.focus();
+      await sendMouse({ type: 'click', position: [400, 400] });
+      expect(comboBox.opened).to.be.false;
+      expect(getDeepActiveElement()).to.equal(inputElement);
+    });
+
+    it('should focus the input when the button is removed', () => {
+      button.focus();
+      comboBox.selectAllButtonVisible = false;
+      expect(getDeepActiveElement()).to.equal(inputElement);
+      expect(comboBox.opened).to.be.true;
+    });
+  });
+
+  describe('pointer', () => {
+    beforeEach(async () => {
+      comboBox.selectAllButtonVisible = true;
+      button = getSelectAllButton(comboBox);
+      inputElement.focus();
+      await sendKeys({ press: 'ArrowDown' });
+    });
+
+    afterEach(async () => {
+      await resetMouse();
+    });
+
+    it('should select all items on click without moving focus', async () => {
+      const rect = button.getBoundingClientRect();
+      await sendMouse({
+        type: 'click',
+        position: [Math.round(rect.left + rect.width / 2), Math.round(rect.top + rect.height / 2)],
+      });
+      expect(comboBox.selectedItems).to.deep.equal(['Apple', 'Banana', 'Lemon', 'Orange']);
+      expect(getDeepActiveElement()).to.equal(inputElement);
+      expect(comboBox.opened).to.be.true;
+    });
+  });
+
+  describe('a11y', () => {
+    let clock, region;
+
+    before(() => {
+      region = document.querySelector('[aria-live]');
+    });
+
+    beforeEach(() => {
+      comboBox.selectAllButtonVisible = true;
+      comboBox.opened = true;
+      clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should announce the total when selecting all items', () => {
+      clickButton();
+
+      clock.tick(150);
+
+      expect(region.textContent).to.equal('4 items selected');
+    });
+
+    it('should announce the total when selecting filtered items', () => {
+      comboBox.selectedItems = ['Lemon'];
+      setInputValue(comboBox, 'an');
+
+      clickButton();
+
+      clock.tick(150);
+
+      expect(region.textContent).to.equal('3 items selected');
+    });
+
+    it('should announce the total when deselecting filtered items', () => {
+      comboBox.selectedItems = ['Lemon', 'Banana', 'Orange'];
+      setInputValue(comboBox, 'an');
+
+      clickButton();
+
+      clock.tick(150);
+
+      expect(region.textContent).to.equal('1 items selected');
+    });
+
+    it('should announce cleared selection when deselecting all items', () => {
+      comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange'];
+
+      clickButton();
+
+      clock.tick(150);
+
+      expect(region.textContent).to.equal('Selection cleared');
+    });
+
+    it('should use custom i18n messages', () => {
+      comboBox.i18n = { total: '{count} selected' };
+
+      clickButton();
+
+      clock.tick(150);
+
+      expect(region.textContent).to.equal('4 selected');
+    });
+  });
+});

--- a/packages/multi-select-combo-box/test/select-all.test.js
+++ b/packages/multi-select-combo-box/test/select-all.test.js
@@ -72,54 +72,54 @@ describe('select all', () => {
     });
 
     it('should use selectAll label when nothing is selected', () => {
-      expect(getSelectAllText()).to.equal('Select all');
+      expect(getSelectAllText()).to.equal('Select All');
     });
 
     it('should use selectAll label when some items are selected', () => {
       comboBox.selectedItems = ['Apple'];
-      expect(getSelectAllText()).to.equal('Select all');
+      expect(getSelectAllText()).to.equal('Select All');
     });
 
     it('should use deselectAll label when all items are selected', () => {
       comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange'];
-      expect(getSelectAllText()).to.equal('Deselect all');
+      expect(getSelectAllText()).to.equal('Deselect All');
     });
 
     it('should use selectFiltered label when a filter is set', () => {
       setInputValue(comboBox, 'an');
-      expect(getSelectAllText()).to.equal('Select filtered');
+      expect(getSelectAllText()).to.equal('Select Filtered');
     });
 
     it('should use selectFiltered label when some filtered items are selected', () => {
       comboBox.selectedItems = ['Banana'];
       setInputValue(comboBox, 'an');
-      expect(getSelectAllText()).to.equal('Select filtered');
+      expect(getSelectAllText()).to.equal('Select Filtered');
     });
 
     it('should use deselectFiltered label when all filtered items are selected', () => {
       comboBox.selectedItems = ['Banana', 'Orange'];
       setInputValue(comboBox, 'an');
-      expect(getSelectAllText()).to.equal('Deselect filtered');
+      expect(getSelectAllText()).to.equal('Deselect Filtered');
     });
 
     it('should update the label when the filter is cleared', () => {
       comboBox.selectedItems = ['Banana', 'Orange'];
       setInputValue(comboBox, 'an');
       setInputValue(comboBox, '');
-      expect(getSelectAllText()).to.equal('Select all');
+      expect(getSelectAllText()).to.equal('Select All');
     });
 
     it('should ignore unknown values when computing the label', () => {
       comboBox.allowCustomValue = true;
       comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange', 'Custom'];
-      expect(getSelectAllText()).to.equal('Deselect all');
+      expect(getSelectAllText()).to.equal('Deselect All');
     });
 
     it('should compute the label from filtered items when selected items are on top', () => {
       comboBox.selectedItemsOnTop = true;
       comboBox.selectedItems = ['Pear'];
       comboBox.opened = true;
-      expect(getSelectAllText()).to.equal('Select all');
+      expect(getSelectAllText()).to.equal('Select All');
     });
 
     it('should use custom i18n labels', () => {
@@ -154,12 +154,12 @@ describe('select all', () => {
 
       it('should use deselectAll label when all items are selected by id', () => {
         comboBox.selectedItems = [{ ...apple }, { ...banana }, { ...lemon }];
-        expect(getSelectAllText()).to.equal('Deselect all');
+        expect(getSelectAllText()).to.equal('Deselect All');
       });
 
       it('should use selectAll label when some items are selected by id', () => {
         comboBox.selectedItems = [{ ...apple }];
-        expect(getSelectAllText()).to.equal('Select all');
+        expect(getSelectAllText()).to.equal('Select All');
       });
     });
   });
@@ -245,13 +245,13 @@ describe('select all', () => {
 
     it('should update the label after selecting all items', () => {
       clickButton();
-      expect(getSelectAllText()).to.equal('Deselect all');
+      expect(getSelectAllText()).to.equal('Deselect All');
     });
 
     it('should update the label after deselecting all items', () => {
       comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange'];
       clickButton();
-      expect(getSelectAllText()).to.equal('Select all');
+      expect(getSelectAllText()).to.equal('Select All');
     });
 
     it('should fire change event once when selecting all items', () => {
@@ -346,13 +346,13 @@ describe('select all', () => {
     it('should select all items on Space', async () => {
       await sendKeys({ press: 'Space' });
       expect(comboBox.selectedItems).to.deep.equal(['Apple', 'Banana', 'Lemon', 'Orange']);
-      expect(getSelectAllText()).to.equal('Deselect all');
+      expect(getSelectAllText()).to.equal('Deselect All');
     });
 
     it('should select all items on Enter', async () => {
       await sendKeys({ press: 'Enter' });
       expect(comboBox.selectedItems).to.deep.equal(['Apple', 'Banana', 'Lemon', 'Orange']);
-      expect(getSelectAllText()).to.equal('Deselect all');
+      expect(getSelectAllText()).to.equal('Deselect All');
     });
 
     it('should not submit the surrounding form', () => {

--- a/packages/multi-select-combo-box/test/select-all.test.js
+++ b/packages/multi-select-combo-box/test/select-all.test.js
@@ -1,17 +1,15 @@
 import { expect } from '@vaadin/chai-plugins';
-import { resetMouse, sendKeys, sendMouse } from '@vaadin/test-runner-commands';
+import { resetMouse, sendKeys, sendMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-multi-select-combo-box.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
-import { getAllItems, getDataProvider, getSelectAllButton, setInputValue } from './helpers.js';
+import { getAllItems, getDataProvider, getFocusedItemIndex, getSelectAllButton, setInputValue } from './helpers.js';
 
 describe('select all', () => {
   let comboBox, inputElement, button;
 
-  const getFocusedItem = () => getAllItems(comboBox).find((item) => item.hasAttribute('focused'));
-
-  const getLabel = () => getSelectAllButton(comboBox).textContent.trim();
+  const getSelectAllText = () => getSelectAllButton(comboBox).textContent.trim();
 
   const clickButton = () => getSelectAllButton(comboBox).click();
 
@@ -22,23 +20,22 @@ describe('select all', () => {
     inputElement = comboBox.inputElement;
   });
 
-  describe('visibility', () => {
-    const isButtonVisible = () => getSelectAllButton(comboBox).checkVisibility();
-
+  describe('enabling', () => {
     beforeEach(() => {
+      button = getSelectAllButton(comboBox);
       comboBox.opened = true;
     });
 
     it('should hide button by default', () => {
-      expect(isButtonVisible()).to.be.false;
+      expect(button.hasAttribute('hidden')).to.be.true;
     });
 
-    it('should toggle button visibility when the property changes', () => {
+    it('should toggle button hidden attribute when the property changes', () => {
       comboBox.selectAllButtonVisible = true;
-      expect(isButtonVisible()).to.be.true;
+      expect(button.hasAttribute('hidden')).to.be.false;
 
       comboBox.selectAllButtonVisible = false;
-      expect(isButtonVisible()).to.be.false;
+      expect(button.hasAttribute('hidden')).to.be.true;
     });
 
     it('should hide button when readonly', () => {
@@ -47,10 +44,10 @@ describe('select all', () => {
       comboBox.selectAllButtonVisible = true;
       comboBox.readonly = true;
       expect(comboBox.$.overlay.opened).to.be.true;
-      expect(isButtonVisible()).to.be.false;
+      expect(button.hasAttribute('hidden')).to.be.true;
 
       comboBox.readonly = false;
-      expect(isButtonVisible()).to.be.true;
+      expect(button.hasAttribute('hidden')).to.be.false;
     });
 
     it('should hide button when using a data provider', async () => {
@@ -64,7 +61,7 @@ describe('select all', () => {
       await nextRender();
       comboBox.opened = true;
 
-      expect(isButtonVisible()).to.be.false;
+      expect(button.hasAttribute('hidden')).to.be.true;
     });
   });
 
@@ -75,54 +72,54 @@ describe('select all', () => {
     });
 
     it('should use selectAll label when nothing is selected', () => {
-      expect(getLabel()).to.equal('Select all');
+      expect(getSelectAllText()).to.equal('Select all');
     });
 
     it('should use selectAll label when some items are selected', () => {
       comboBox.selectedItems = ['Apple'];
-      expect(getLabel()).to.equal('Select all');
+      expect(getSelectAllText()).to.equal('Select all');
     });
 
     it('should use deselectAll label when all items are selected', () => {
       comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange'];
-      expect(getLabel()).to.equal('Deselect all');
+      expect(getSelectAllText()).to.equal('Deselect all');
     });
 
     it('should use selectFiltered label when a filter is set', () => {
       setInputValue(comboBox, 'an');
-      expect(getLabel()).to.equal('Select filtered');
+      expect(getSelectAllText()).to.equal('Select filtered');
     });
 
     it('should use selectFiltered label when some filtered items are selected', () => {
       comboBox.selectedItems = ['Banana'];
       setInputValue(comboBox, 'an');
-      expect(getLabel()).to.equal('Select filtered');
+      expect(getSelectAllText()).to.equal('Select filtered');
     });
 
     it('should use deselectFiltered label when all filtered items are selected', () => {
       comboBox.selectedItems = ['Banana', 'Orange'];
       setInputValue(comboBox, 'an');
-      expect(getLabel()).to.equal('Deselect filtered');
+      expect(getSelectAllText()).to.equal('Deselect filtered');
     });
 
     it('should update the label when the filter is cleared', () => {
       comboBox.selectedItems = ['Banana', 'Orange'];
       setInputValue(comboBox, 'an');
       setInputValue(comboBox, '');
-      expect(getLabel()).to.equal('Select all');
+      expect(getSelectAllText()).to.equal('Select all');
     });
 
     it('should ignore unknown values when computing the label', () => {
       comboBox.allowCustomValue = true;
       comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange', 'Custom'];
-      expect(getLabel()).to.equal('Deselect all');
+      expect(getSelectAllText()).to.equal('Deselect all');
     });
 
     it('should compute the label from filtered items when selected items are on top', () => {
       comboBox.selectedItemsOnTop = true;
       comboBox.selectedItems = ['Pear'];
       comboBox.opened = true;
-      expect(getLabel()).to.equal('Select all');
+      expect(getSelectAllText()).to.equal('Select all');
     });
 
     it('should use custom i18n labels', () => {
@@ -132,16 +129,16 @@ describe('select all', () => {
         selectFiltered: 'Gefilterte auswählen',
         deselectFiltered: 'Gefilterte abwählen',
       };
-      expect(getLabel()).to.equal('Alle auswählen');
+      expect(getSelectAllText()).to.equal('Alle auswählen');
 
       comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange'];
-      expect(getLabel()).to.equal('Auswahl aufheben');
+      expect(getSelectAllText()).to.equal('Auswahl aufheben');
 
       setInputValue(comboBox, 'an');
-      expect(getLabel()).to.equal('Gefilterte abwählen');
+      expect(getSelectAllText()).to.equal('Gefilterte abwählen');
 
       comboBox.selectedItems = [];
-      expect(getLabel()).to.equal('Gefilterte auswählen');
+      expect(getSelectAllText()).to.equal('Gefilterte auswählen');
     });
 
     describe('object items', () => {
@@ -157,12 +154,12 @@ describe('select all', () => {
 
       it('should use deselectAll label when all items are selected by id', () => {
         comboBox.selectedItems = [{ ...apple }, { ...banana }, { ...lemon }];
-        expect(getLabel()).to.equal('Deselect all');
+        expect(getSelectAllText()).to.equal('Deselect all');
       });
 
       it('should use selectAll label when some items are selected by id', () => {
         comboBox.selectedItems = [{ ...apple }];
-        expect(getLabel()).to.equal('Select all');
+        expect(getSelectAllText()).to.equal('Select all');
       });
     });
   });
@@ -248,13 +245,13 @@ describe('select all', () => {
 
     it('should update the label after selecting all items', () => {
       clickButton();
-      expect(getLabel()).to.equal('Deselect all');
+      expect(getSelectAllText()).to.equal('Deselect all');
     });
 
     it('should update the label after deselecting all items', () => {
       comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange'];
       clickButton();
-      expect(getLabel()).to.equal('Select all');
+      expect(getSelectAllText()).to.equal('Select all');
     });
 
     it('should fire change event once when selecting all items', () => {
@@ -349,26 +346,17 @@ describe('select all', () => {
     it('should select all items on Space', async () => {
       await sendKeys({ press: 'Space' });
       expect(comboBox.selectedItems).to.deep.equal(['Apple', 'Banana', 'Lemon', 'Orange']);
-      expect(getLabel()).to.equal('Deselect all');
+      expect(getSelectAllText()).to.equal('Deselect all');
     });
 
     it('should select all items on Enter', async () => {
       await sendKeys({ press: 'Enter' });
       expect(comboBox.selectedItems).to.deep.equal(['Apple', 'Banana', 'Lemon', 'Orange']);
-      expect(getLabel()).to.equal('Deselect all');
+      expect(getSelectAllText()).to.equal('Deselect all');
     });
 
-    it('should not submit the surrounding form on Enter', async () => {
-      const form = fixtureSync('<form></form>');
-      const submitSpy = sinon.spy((event) => event.preventDefault());
-      form.addEventListener('submit', submitSpy);
-      form.appendChild(comboBox);
-      await nextRender();
-      comboBox.opened = true;
-      getSelectAllButton(comboBox).focus();
-
-      await sendKeys({ press: 'Enter' });
-      expect(submitSpy).to.not.be.called;
+    it('should not submit the surrounding form', () => {
+      expect(getSelectAllButton(comboBox).getAttribute('type')).to.equal('button');
     });
   });
 
@@ -416,23 +404,21 @@ describe('select all', () => {
       expect(comboBox.hasAttribute('focus-ring')).to.be.true;
 
       await sendKeys({ press: 'Tab' });
-      expect(comboBox.hasAttribute('focused')).to.be.true; // is not removed
+      expect(comboBox.hasAttribute('focused')).to.be.true;
       expect(comboBox.hasAttribute('focus-ring')).to.be.false;
-      expect(button.matches(':focus-visible')).to.be.true;
 
       await sendKeys({ press: 'Tab' });
       expect(comboBox.hasAttribute('focused')).to.be.true;
       expect(comboBox.hasAttribute('focus-ring')).to.be.true;
-      expect(button.matches(':focus-visible')).to.be.false;
     });
 
     it('should reset the focused item when focusing button', async () => {
       await sendKeys({ press: 'ArrowDown' });
-      expect(getFocusedItem()).to.be.ok;
+      expect(getFocusedItemIndex(comboBox)).to.equal(0);
       expect(inputElement.hasAttribute('aria-activedescendant')).to.be.true;
 
       await sendKeys({ press: 'Tab' });
-      expect(getFocusedItem()).to.be.undefined;
+      expect(getFocusedItemIndex(comboBox)).to.equal(-1);
       expect(inputElement.hasAttribute('aria-activedescendant')).to.be.false;
     });
 
@@ -485,14 +471,14 @@ describe('select all', () => {
       button.focus();
       await sendKeys({ press: 'ArrowDown' });
       expect(getDeepActiveElement()).to.equal(inputElement);
-      expect(getFocusedItem()).to.equal(getAllItems(comboBox)[0]);
+      expect(getFocusedItemIndex(comboBox)).to.equal(0);
     });
 
     it('should focus the input and the last item on ArrowUp', async () => {
       button.focus();
       await sendKeys({ press: 'ArrowUp' });
       expect(getDeepActiveElement()).to.equal(inputElement);
-      expect(getFocusedItem()).to.equal(getAllItems(comboBox)[3]);
+      expect(getFocusedItemIndex(comboBox)).to.equal(3);
     });
 
     it('should focus the input when the overlay is closed', () => {
@@ -529,82 +515,10 @@ describe('select all', () => {
     });
 
     it('should select all items on click without moving focus', async () => {
-      const rect = button.getBoundingClientRect();
-      await sendMouse({
-        type: 'click',
-        position: [Math.round(rect.left + rect.width / 2), Math.round(rect.top + rect.height / 2)],
-      });
+      await sendMouseToElement({ type: 'click', element: button });
       expect(comboBox.selectedItems).to.deep.equal(['Apple', 'Banana', 'Lemon', 'Orange']);
       expect(getDeepActiveElement()).to.equal(inputElement);
       expect(comboBox.opened).to.be.true;
-    });
-  });
-
-  describe('a11y', () => {
-    let clock, region;
-
-    before(() => {
-      region = document.querySelector('[aria-live]');
-    });
-
-    beforeEach(() => {
-      comboBox.selectAllButtonVisible = true;
-      comboBox.opened = true;
-      clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
-    });
-
-    afterEach(() => {
-      clock.restore();
-    });
-
-    it('should announce the total when selecting all items', () => {
-      clickButton();
-
-      clock.tick(150);
-
-      expect(region.textContent).to.equal('4 items selected');
-    });
-
-    it('should announce the total when selecting filtered items', () => {
-      comboBox.selectedItems = ['Lemon'];
-      setInputValue(comboBox, 'an');
-
-      clickButton();
-
-      clock.tick(150);
-
-      expect(region.textContent).to.equal('3 items selected');
-    });
-
-    it('should announce the total when deselecting filtered items', () => {
-      comboBox.selectedItems = ['Lemon', 'Banana', 'Orange'];
-      setInputValue(comboBox, 'an');
-
-      clickButton();
-
-      clock.tick(150);
-
-      expect(region.textContent).to.equal('1 items selected');
-    });
-
-    it('should announce cleared selection when deselecting all items', () => {
-      comboBox.selectedItems = ['Apple', 'Banana', 'Lemon', 'Orange'];
-
-      clickButton();
-
-      clock.tick(150);
-
-      expect(region.textContent).to.equal('Selection cleared');
-    });
-
-    it('should use custom i18n messages', () => {
-      comboBox.i18n = { total: '{count} selected' };
-
-      clickButton();
-
-      clock.tick(150);
-
-      expect(region.textContent).to.equal('4 selected');
     });
   });
 });

--- a/packages/multi-select-combo-box/test/select-all.test.js
+++ b/packages/multi-select-combo-box/test/select-all.test.js
@@ -55,6 +55,7 @@ describe('select all', () => {
       comboBox = fixtureSync(
         `<vaadin-multi-select-combo-box select-all-button-visible></vaadin-multi-select-combo-box>`,
       );
+      button = getSelectAllButton(comboBox);
       comboBox.selectAllButtonVisible = true;
       comboBox.pageSize = 10;
       comboBox.dataProvider = getDataProvider(items);

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -113,6 +113,7 @@ assertType<boolean>(narrowedComboBox.required);
 assertType<boolean>(narrowedComboBox.selectedItemsOnTop);
 assertType<boolean>(narrowedComboBox.autoExpandVertically);
 assertType<boolean>(narrowedComboBox.collapseChips);
+assertType<boolean>(narrowedComboBox.selectAllButtonVisible);
 
 // Mixins
 assertType<ComboBoxBaseMixinClass>(narrowedComboBox);
@@ -159,3 +160,9 @@ assertType<ThemableMixinClass>(narrowedItem);
 // I18n
 assertType<MultiSelectComboBoxI18n>({});
 assertType<MultiSelectComboBoxI18n>({ cleared: 'Cleared' });
+assertType<MultiSelectComboBoxI18n>({
+  selectAll: 'Select all',
+  deselectAll: 'Deselect all',
+  selectFiltered: 'Select filtered',
+  deselectFiltered: 'Deselect filtered',
+});

--- a/packages/vaadin-lumo-styles/src/components/multi-select-combo-box.css
+++ b/packages/vaadin-lumo-styles/src/components/multi-select-combo-box.css
@@ -95,4 +95,37 @@
     color: var(--lumo-contrast-60pct);
     cursor: var(--lumo-clickable-cursor);
   }
+
+  [part='select-all'] {
+    appearance: none;
+    flex: none;
+    box-sizing: border-box;
+    /* Do not let the label affect the width of the overlay */
+    contain: inline-size;
+    height: var(--lumo-size-m);
+    margin: var(--lumo-space-xs) var(--lumo-space-xs) 0;
+    padding: 0 calc(var(--lumo-size-m) / 6);
+    border: none;
+    border-radius: var(--lumo-border-radius-m);
+    background: transparent;
+    color: var(--lumo-primary-text-color);
+    font-family: var(--lumo-font-family);
+    font-size: var(--lumo-font-size-m);
+    font-weight: 500;
+    line-height: var(--lumo-line-height-xs);
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: var(--lumo-clickable-cursor);
+    -webkit-tap-highlight-color: transparent;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  [part='select-all']:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 var(--vaadin-focus-ring-width, 2px)
+      var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
+  }
 }

--- a/packages/vaadin-lumo-styles/src/components/multi-select-combo-box.css
+++ b/packages/vaadin-lumo-styles/src/components/multi-select-combo-box.css
@@ -15,6 +15,10 @@
     pointer-events: auto;
   }
 
+  [hidden] {
+    display: none !important;
+  }
+
   #chips {
     display: flex;
     align-items: center;
@@ -98,22 +102,24 @@
 
   [part='select-all'] {
     appearance: none;
+    display: flex;
+    align-items: center;
     flex: none;
     box-sizing: border-box;
     /* Do not let the label affect the width of the overlay */
     contain: inline-size;
-    height: var(--lumo-size-m);
-    margin: var(--lumo-space-xs) var(--lumo-space-xs) 0;
-    padding: 0 calc(var(--lumo-size-m) / 6);
+    height: var(--lumo-size-s);
+    margin: var(--vaadin-item-overlay-padding, 4px);
+    padding: 0.5em calc(var(--lumo-space-l) + var(--lumo-border-radius-m) / 4) 0.5em
+      var(--_lumo-list-box-item-padding-left, calc(var(--lumo-border-radius-m) / 4));
     border: none;
     border-radius: var(--lumo-border-radius-m);
     background: transparent;
     color: var(--lumo-primary-text-color);
     font-family: var(--lumo-font-family);
-    font-size: var(--lumo-font-size-m);
+    font-size: var(--lumo-font-size-s);
     font-weight: 500;
     line-height: var(--lumo-line-height-xs);
-    text-align: center;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -123,9 +129,28 @@
     -moz-osx-font-smoothing: grayscale;
   }
 
+  /* Reserve the same space as the item checkmark icon */
+  [part='select-all']::before {
+    content: '';
+    font-size: var(--lumo-icon-size-m);
+    width: calc(var(--lumo-font-size-m) / var(--lumo-font-size-s) * 1em);
+    flex: none;
+    margin: calc((1 - var(--lumo-line-height-xs)) * var(--lumo-font-size-m) / 2) 0;
+  }
+
+  @media (any-hover: hover) {
+    [part='select-all']:hover {
+      background: var(--lumo-primary-color-10pct);
+    }
+  }
+
   [part='select-all']:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 var(--vaadin-focus-ring-width, 2px)
+    box-shadow: inset 0 0 0 var(--vaadin-focus-ring-width, 2px)
       var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
+  }
+
+  [part='select-all']:not([hidden]) + slot::slotted(*) {
+    border-top: 1px solid var(--vaadin-border-color-secondary);
   }
 }


### PR DESCRIPTION
## Description

Part of #4590
Related to https://github.com/vaadin/flow-components/issues/4876

Adds an opt-in "Select all" button to `vaadin-multi-select-combo-box`:
- When `selectAllButtonVisible` is set, a button is rendered at the top of the dropdown overlay, above the item list.
- Clicking it selects every item that matches the current filter, or deselects them when they are all selected already.
- Items that do not match the filter keep their selection state, the action does not replace the selection.
- The label switches between "Select all" / "Deselect all" without a filter and "Select filtered" / "Deselect filtered" with one.
- All four labels can be customized through `i18n`.
- Keyboard users reach the button with <kbd>Tab</kbd> while the dropdown is open.
- Focus cycles between the input and the button instead of leaving the component.
- <kbd>Escape</kbd>, <kbd>ArrowDown</kbd> and <kbd>ArrowUp</kbd> return focus to the input and act as if pressed there.
- Updating the selection announces the new selection count to screen readers.

### Implementation notes

- Added the `selectAllButtonVisible` property and the `selectAll`, `deselectAll`, `selectFiltered` and `deselectFiltered` i18n keys
- Added the `select-all` shadow part with base, Lumo and Aura styles. It does not use `select-all-button` as that conflicts with existing styling rules for clear and toggle buttons.
- The button logic lives in an internal `SelectAllController` in `select-all-controller.js`. It is not exported from the package and has no `.d.ts`, following the dashboard controllers. The mixin calls `update()` from `updated()` whenever a property the button depends on has changed.
- The button is rendered in the shadow root as a sibling of the overlay slot, so it stays out of the `role="listbox"` scroller and does not affect `aria-activedescendant` handling.
- Selection changes go through the existing `__updateSelection()`, so `change`, `selected-items-changed` and validation behave exactly as they do for clicking a single item.
- Focus between the input and the button is kept inside the component by overriding `_shouldSetFocus` and `_shouldRemoveFocus`. Only the button shows a focus ring while it is focused, the host drops its `focus-ring` attribute but keeps `focused`.

### Limitations

- This PR covers the `items` API only. Support for `dataProvider` comes as a follow-up.
- Styling is preliminary and will be improved later. As such no visual tests are added yet.

## Type of change

- Feature