### PR TITLE
fix: follow date focus moved by assistive technology

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -318,6 +318,10 @@ export const DatePickerOverlayContentMixin = (superClass) =>
                 calendar.addEventListener('selected-date-changed', (e) => {
                   this.selectedDate = e.detail.value;
                 });
+
+                calendar.addEventListener('date-focus', (e) => {
+                  this.__onDateFocus(e.detail.date);
+                });
               });
 
               this.calendars = calendars;
@@ -909,6 +913,25 @@ export const DatePickerOverlayContentMixin = (superClass) =>
           this.focusableDateButton.focus();
         }
       }
+    }
+
+    /**
+     * Follows focus that something other than the keyboard handling moved to a date,
+     * such as a screen reader swiping to it, so that the arrow keys, the `focused` part
+     * and the day of month kept for PageUp / PageDown continue from that date.
+     * @private
+     */
+    __onDateFocus(date) {
+      // The calendar focuses the date this element already tracks, nothing to follow.
+      if (dateEquals(date, this.focusedDate)) {
+        return;
+      }
+      // Same rule as the arrow keys: a disabled date may take focus, a date outside min / max may not.
+      if (!this._dateAllowed(date, undefined, undefined, () => false)) {
+        return;
+      }
+      this.focusedDate = date;
+      this._focusedMonthDate = date.getDate();
     }
 
     async focusDate(date, keepMonth) {

--- a/packages/date-picker/src/vaadin-month-calendar-mixin.js
+++ b/packages/date-picker/src/vaadin-month-calendar-mixin.js
@@ -173,6 +173,22 @@ export const MonthCalendarMixin = (superClass) =>
       this.setAttribute('role', 'application');
 
       addListener(this.$.monthGrid, 'tap', this._handleTap.bind(this));
+      this.$.monthGrid.addEventListener('focusin', (e) => this._onDateFocusIn(e));
+    }
+
+    /**
+     * Reports the date whose button received focus, so the overlay can follow
+     * focus that was moved by something other than its own keyboard handling,
+     * such as a screen reader swiping to a date.
+     * @protected
+     */
+    _onDateFocusIn(e) {
+      const cell = e.target.closest('[part~=date]');
+      if (cell?.date) {
+        this.dispatchEvent(
+          new CustomEvent('date-focus', { detail: { date: cell.date }, bubbles: true, composed: true }),
+        );
+      }
     }
 
     /** @override */

--- a/packages/date-picker/test/keyboard-navigation.test.js
+++ b/packages/date-picker/test/keyboard-navigation.test.js
@@ -3,7 +3,16 @@ import { sendKeys } from '@vaadin/test-runner-commands';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
-import { getDefaultI18n, getFocusedCell, open, untilOverlayRendered, untilOverlayScrolled } from './helpers.js';
+import {
+  getDateButton,
+  getDateCell,
+  getDefaultI18n,
+  getFocusedCell,
+  getMonthCalendar,
+  open,
+  untilOverlayRendered,
+  untilOverlayScrolled,
+} from './helpers.js';
 
 describe('keyboard navigation', () => {
   describe('date-picker', () => {
@@ -78,6 +87,13 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'Space' });
 
         expect(content.focusedDate.getTime()).to.equal(focused.getTime());
+      });
+
+      it('should show a date focused from outside in the input', async () => {
+        await open(datePicker);
+        getDateButton(getDateCell(getMonthCalendar(datePicker, 2001, 0), 15)).focus();
+        await nextRender();
+        expect(input.value).to.equal('1/15/2001');
       });
     });
 
@@ -332,6 +348,49 @@ describe('keyboard navigation', () => {
       await sendKeys({ press: 'PageDown' });
       await untilOverlayScrolled(overlay);
       expect(overlay.focusedDate).to.eql(new Date(2000, 2, 31));
+    });
+
+    it('should follow focus moved to another date', async () => {
+      getDateButton(getDateCell(getMonthCalendar(overlay, 2000, 0), 15)).focus();
+      await nextRender();
+      expect(overlay.focusedDate).to.eql(new Date(2000, 0, 15));
+      const cell = getFocusedCell(overlay);
+      expect(cell.date).to.eql(new Date(2000, 0, 15));
+      expect(cell.getAttribute('part')).to.contain('focused');
+    });
+
+    it('should not notify when the focused date button regains focus', async () => {
+      const spy = sinon.spy();
+      overlay.addEventListener('focused-date-changed', spy);
+      const button = getDateButton(getDateCell(getMonthCalendar(overlay, 2000, 0), 1));
+      button.blur();
+      button.focus();
+      await nextRender();
+      expect(spy.called).to.be.false;
+    });
+
+    it('should not follow focus moved to a date outside max', async () => {
+      overlay.maxDate = new Date(2000, 0, 10);
+      await nextRender();
+      getDateButton(getDateCell(getMonthCalendar(overlay, 2000, 0), 15)).focus();
+      await nextRender();
+      expect(overlay.focusedDate).to.eql(new Date(2000, 0, 1));
+    });
+
+    it('should follow focus moved to a disabled date inside the range', async () => {
+      overlay.isDateDisabled = (date) => date.day === 15;
+      await nextRender();
+      getDateButton(getDateCell(getMonthCalendar(overlay, 2000, 0), 15)).focus();
+      await nextRender();
+      expect(overlay.focusedDate).to.eql(new Date(2000, 0, 15));
+    });
+
+    it('should keep the day of month of a date focused from outside on pagedown', async () => {
+      getDateButton(getDateCell(getMonthCalendar(overlay, 2000, 0), 15)).focus();
+      await nextRender();
+      await sendKeys({ press: 'PageDown' });
+      await untilOverlayScrolled(overlay);
+      expect(getFocusedCell(overlay).date).to.eql(new Date(2000, 1, 15));
     });
 
     it('should focus next year with shift and pagedown', async () => {


### PR DESCRIPTION
## Description

Part of #12398
Depends on #12596

Nothing synced `focusedDate` from DOM focus. The overlay only changes it from its own keyboard
handling and from `focusDate()`. When a screen reader moves focus to another date, for example
VoiceOver swiping on iOS, the arrow keys continue from the stale date, the `focused` part stays on
the wrong cell, and <kbd>PageUp</kbd> / <kbd>PageDown</kbd> keep the stale day of month. This is a
prerequisite for letting VoiceOver reach other months, which is not part of this PR.

- Added a `date-focus` event to `vaadin-month-calendar`, fired from a `focusin` listener on the grid
  with the `date` of the focused cell
- Made the overlay content follow `date-focus` by setting `focusedDate` and `_focusedMonthDate`
  - Ignored when the date already matches `focusedDate`, so focus set by `focusDate()` is a no-op
  - Ignored for dates outside `min` and `max`, the same rule the arrow keys use, while disabled
    dates inside the range are followed
- Added keyboard navigation tests for following focus, the no-op case, the range guard, the day of
  month kept for <kbd>PageDown</kbd>, and the input showing the focused date

## Type of change

- Bugfix

## How to test

1. Open `dev/date-picker.html` and click the field to open the calendar.
2. In the console, focus another date's button:
   ```js
   const dp = document.querySelector('vaadin-date-picker');
   const cal = dp._overlayContent.calendars.find((c) => !c.hasAttribute('aria-hidden'));
   [...cal.shadowRoot.querySelectorAll('[part~=date-button]')][20].focus();
   ```
3. The focus ring moves to that date and the input shows it.
4. Press <kbd>ArrowRight</kbd>. Focus moves one day on from that date, not from today.
5. Press <kbd>PageDown</kbd>. Focus lands on the same day of month in the next month.
6. Set `dp.max` to a date before the one you focused, repeat step 2 with a date past `max`. Nothing
   changes.
7. With iOS VoiceOver, open the calendar and swipe to another date. The focus ring follows the swipe.

> [!NOTE]
> On desktop the input already follows the focused date after arrow keys, and closing the overlay
> commits the input. Focus moved by assistive technology now takes the same path. On iOS the input
> is read only while the overlay is open, so a swipe never changes the committed value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
