### PR TITLE
refactor: update scroller and overlay opened state from base mixin

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-base-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-base-mixin.js
@@ -171,6 +171,24 @@ export const ComboBoxBaseMixin = (superClass) =>
     }
 
     /** @protected */
+    updated(props) {
+      super.updated(props);
+
+      // Note: `loading` is only declared by components that support a data provider.
+      if (props.has('opened') || props.has('_dropdownItems') || props.has('loading')) {
+        // Close the overlay if there are no items to display.
+        // See https://github.com/vaadin/vaadin-combo-box/pull/964
+        this._overlayOpened = this.opened && (!!this.loading || this._hasDropdownItems);
+      }
+
+      // Update the scroller only once the overlay is actually opened, so that the
+      // virtualizer does not measure and render items while the overlay is hidden.
+      if (['_overlayOpened', '_dropdownItems', '_focusedIndex', '_theme'].some((prop) => props.has(prop))) {
+        this._updateScroller();
+      }
+    }
+
+    /** @protected */
     disconnectedCallback() {
       super.disconnectedCallback();
 
@@ -246,6 +264,29 @@ export const ComboBoxBaseMixin = (superClass) =>
       // Prevent focusing scroller on input Tab
       scroller.setAttribute('tabindex', '-1');
       this.appendChild(scroller);
+    }
+
+    /**
+     * Update the scroller to reflect the dropdown items, the focused item
+     * and whether the overlay is opened.
+     * @protected
+     */
+    _updateScroller() {
+      const opened = this._overlayOpened;
+
+      if (opened) {
+        this._scroller.style.maxHeight =
+          getComputedStyle(this).getPropertyValue(`--${this._tagNamePrefix}-overlay-max-height`) || '65vh';
+      }
+
+      const isClosing = this.hasAttribute('closing');
+
+      this._scroller.setProperties({
+        items: opened || isClosing ? this._dropdownItems : [],
+        opened,
+        focusedIndex: this._focusedIndex,
+        theme: this._theme,
+      });
     }
 
     /**

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -94,11 +94,7 @@ export const ComboBoxMixin = (superClass) =>
     }
 
     static get observers() {
-      return [
-        '_openedOrItemsChanged(opened, _dropdownItems, loading)',
-        '_selectedItemChanged(selectedItem, itemValuePath, itemLabelPath)',
-        '_updateScroller(opened, _dropdownItems, _focusedIndex, _theme)',
-      ];
+      return ['_selectedItemChanged(selectedItem, itemValuePath, itemLabelPath)'];
     }
 
     /** @protected */
@@ -126,30 +122,6 @@ export const ComboBoxMixin = (superClass) =>
           this._scroller[prop] = this[prop];
         }
       });
-    }
-
-    /** @private */
-    _updateScroller(opened, items, focusedIndex, theme) {
-      if (opened) {
-        this._scroller.style.maxHeight =
-          getComputedStyle(this).getPropertyValue(`--${this._tagNamePrefix}-overlay-max-height`) || '65vh';
-      }
-
-      const isClosing = this.hasAttribute('closing');
-
-      this._scroller.setProperties({
-        items: opened || isClosing ? items : [],
-        opened,
-        focusedIndex,
-        theme,
-      });
-    }
-
-    /** @private */
-    _openedOrItemsChanged(opened, items, loading) {
-      // Close the overlay if there are no items to display.
-      // See https://github.com/vaadin/vaadin-combo-box/pull/964
-      this._overlayOpened = opened && (loading || !!items?.length);
     }
 
     /**

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -216,9 +216,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
     static get observers() {
       return [
         '_selectedItemsChanged(selectedItems)',
-        '__openedOrItemsChanged(opened, _dropdownItems, loading)',
         '__updateOverflowChip(_overflow, _overflowItems, disabled, readonly)',
-        '__updateScroller(opened, _dropdownItems, _focusedIndex, _theme)',
         '__updateTopGroup(selectedItemsOnTop, selectedItems, opened)',
       ];
     }
@@ -454,30 +452,6 @@ export const MultiSelectComboBoxMixin = (superClass) =>
       if (!this.loading || this.allowCustomValue) {
         this._commitValue();
       }
-    }
-
-    /** @private */
-    __updateScroller(opened, items, focusedIndex, theme) {
-      if (opened) {
-        this._scroller.style.maxHeight =
-          getComputedStyle(this).getPropertyValue(`--${this._tagNamePrefix}-overlay-max-height`) || '65vh';
-      }
-
-      const isClosing = this.hasAttribute('closing');
-
-      this._scroller.setProperties({
-        items: opened || isClosing ? items : [],
-        opened,
-        focusedIndex,
-        theme,
-      });
-    }
-
-    /** @private */
-    __openedOrItemsChanged(opened, items, loading) {
-      // Close the overlay if there are no items to display.
-      // See https://github.com/vaadin/vaadin-combo-box/pull/964
-      this._overlayOpened = opened && (loading || !!items?.length);
     }
 
     /**

--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -105,11 +105,7 @@ export const TimePickerMixin = (superClass) =>
     }
 
     static get observers() {
-      return [
-        '_openedOrItemsChanged(opened, _dropdownItems)',
-        '_updateScroller(opened, _dropdownItems, _focusedIndex, _theme, value)',
-        '__updateAriaAttributes(_dropdownItems, opened, inputElement)',
-      ];
+      return ['__updateAriaAttributes(_dropdownItems, opened, inputElement)'];
     }
 
     static get defaultI18n() {
@@ -248,6 +244,10 @@ export const TimePickerMixin = (superClass) =>
       if (props.has('__effectiveI18n') && this.value) {
         this.__updateInputValue(this.__getTimeObject(this.value));
       }
+
+      if (props.has('value') || props.has('_dropdownItems')) {
+        this._scroller.selectedItem = this._dropdownItems?.find((item) => item.value === this.value);
+      }
     }
 
     /**
@@ -271,30 +271,6 @@ export const TimePickerMixin = (superClass) =>
      */
     _getItemLabel(item) {
       return item ? item.label : '';
-    }
-
-    /** @private */
-    _updateScroller(opened, items, focusedIndex, theme, value) {
-      if (opened) {
-        this._scroller.style.maxHeight =
-          getComputedStyle(this).getPropertyValue(`--${this._tagNamePrefix}-overlay-max-height`) || '65vh';
-      }
-
-      const isClosing = this.hasAttribute('closing');
-
-      this._scroller.setProperties({
-        items: opened || isClosing ? items : [],
-        opened,
-        focusedIndex,
-        theme,
-        selectedItem: items?.find((item) => item.value === value),
-      });
-    }
-
-    /** @private */
-    _openedOrItemsChanged(opened, items) {
-      // Close the overlay if there are no items to display.
-      this._overlayOpened = opened && !!items?.length;
     }
 
     /**


### PR DESCRIPTION
## Description

Depends on #12726

Combo-box, multi-select-combo-box and time-picker each kept their own observers to derive `_overlayOpened` and to push `opened`, items, focused index and theme to the scroller. Fixes to that code had to land three times (#12653, #12115, #12330). This PR moves it into `ComboBoxBaseMixin`.

The scroller now follows `_overlayOpened` instead of `opened`. The scroller renders its items through the virtualizer as soon as its `opened` flips. If that happens while the overlay popover is still hidden, the virtualizer measures zero height, renders nothing and does not recover. The old code only avoided this because of the order in which each component listed its observers. During the move, multi-select-combo-box's top-group observer started running first and hit this case in the `partial-match-mode` tests, which is how the dependency was found.

- Added `updated()` to `ComboBoxBaseMixin` that derives `_overlayOpened` from `opened`, `loading` and the dropdown items, and calls the new protected `_updateScroller()`
  - `_updateScroller()` runs when `_overlayOpened`, `_dropdownItems`, `_focusedIndex` or `_theme` change, and passes `_overlayOpened` as the scroller's `opened`
- Removed the `_updateScroller` and `_openedOrItemsChanged` observers and methods from combo-box, multi-select-combo-box and time-picker
- Replaced time-picker's scroller observer with a `selectedItem` forward in its own `updated()`

## Type of change

- Refactor

> [!NOTE]
> Verified with the Flow `vaadin-combo-box-flow-integration-tests` module against this change (271 tests, 0 failures), including `LazyLoadingIT` and `ComboBoxClientSideDataRangeIT`. For combo-box, `_ensureFirstPage(opened)` now runs before the overlay opens, which multi-select-combo-box already did. The Flow connector, TestBench and the time-picker connector do not touch any of the moved members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
