### PR TITLE
refactor: compare combo-box items by itemIdPath in one place

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-base-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-base-mixin.js
@@ -487,6 +487,18 @@ export const ComboBoxBaseMixin = (superClass) =>
       return item ? item.toString() : '';
     }
 
+    /**
+     * Returns true when both items refer to the same item.
+     * Override to provide logic for item id path.
+     * @param {unknown} item
+     * @param {unknown} other
+     * @return {boolean}
+     * @protected
+     */
+    _isSameItem(item, other) {
+      return item === other;
+    }
+
     /** @private */
     _onArrowDown() {
       if (this.opened) {

--- a/packages/combo-box/src/vaadin-combo-box-items-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-items-mixin.d.ts
@@ -61,6 +61,15 @@ export declare class ComboBoxItemsMixinClass<TItem> {
   itemValuePath: string;
 
   /**
+   * Path for the id of the item. If `items` is an array of objects,
+   * the `itemIdPath` is used to compare and identify the same item
+   * in the selection and in `filteredItems` (items given by the
+   * `dataProvider` callback).
+   * @attr {string} item-id-path
+   */
+  itemIdPath: string | null | undefined;
+
+  /**
    * Controls which item is automatically set to be selected, for
    * example on Enter, when the typed filter only partially matches
    * its label. The item that will be selected is highlighted in the

--- a/packages/combo-box/src/vaadin-combo-box-items-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-items-mixin.js
@@ -113,6 +113,18 @@ export const ComboBoxItemsMixin = (superClass) =>
         },
 
         /**
+         * Path for the id of the item. If `items` is an array of objects,
+         * the `itemIdPath` is used to compare and identify the same item
+         * in the selection and in `filteredItems` (items given by the
+         * `dataProvider` callback).
+         * @attr {string} item-id-path
+         */
+        itemIdPath: {
+          type: String,
+          sync: true,
+        },
+
+        /**
          * Controls which item is automatically set to be selected, for
          * example on Enter, when the typed filter only partially matches
          * its label. The item that will be selected is highlighted in the
@@ -263,6 +275,26 @@ export const ComboBoxItemsMixin = (superClass) =>
         value = item ? item.toString() : '';
       }
       return value;
+    }
+
+    /**
+     * Override method from `ComboBoxBaseMixin` to compare object items
+     * by the value at `itemIdPath` instead of by identity.
+     * @param {unknown} item
+     * @param {unknown} other
+     * @return {boolean}
+     * @protected
+     * @override
+     */
+    _isSameItem(item, other) {
+      if (this.itemIdPath && item && other) {
+        const id = get(this.itemIdPath, item);
+        if (id !== undefined) {
+          return id === get(this.itemIdPath, other);
+        }
+      }
+
+      return super._isSameItem(item, other);
     }
 
     /** @private */

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -78,13 +78,4 @@ export declare class ComboBoxMixinClass<TItem> {
    * The selected item from the `items` array.
    */
   selectedItem: TItem | null | undefined;
-
-  /**
-   * Path for the id of the item. If `items` is an array of objects,
-   * the `itemIdPath` is used to compare and identify the same item
-   * in `selectedItem` and `filteredItems` (items given by the
-   * `dataProvider` callback).
-   * @attr {string} item-id-path
-   */
-  itemIdPath: string | null | undefined;
 }

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -78,18 +78,6 @@ export const ComboBoxMixin = (superClass) =>
         itemClassNameGenerator: {
           type: Object,
         },
-
-        /**
-         * Path for the id of the item. If `items` is an array of objects,
-         * the `itemIdPath` is used to compare and identify the same item
-         * in `selectedItem` and `filteredItems` (items given by the
-         * `dataProvider` callback).
-         * @attr {string} item-id-path
-         */
-        itemIdPath: {
-          type: String,
-          sync: true,
-        },
       };
     }
 
@@ -117,7 +105,7 @@ export const ComboBoxMixin = (superClass) =>
     updated(props) {
       super.updated(props);
 
-      ['loading', 'itemIdPath', 'itemClassNameGenerator', 'renderer', 'selectedItem'].forEach((prop) => {
+      ['loading', 'itemClassNameGenerator', 'renderer', 'selectedItem'].forEach((prop) => {
         if (props.has(prop)) {
           this._scroller[prop] = this[prop];
         }

--- a/packages/combo-box/src/vaadin-combo-box-scroller-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-scroller-mixin.d.ts
@@ -18,11 +18,6 @@ export declare class ComboBoxScrollerMixinClass<TItem, TOwner> {
   focusedIndex: number;
 
   /**
-   * Path for the id of the item, used to detect whether the item is selected.
-   */
-  itemIdPath: string | null | undefined;
-
-  /**
    * A full set of items to filter the visible options from.
    * Set to an empty array when combo-box is not opened.
    */
@@ -78,7 +73,7 @@ export declare class ComboBoxScrollerMixinClass<TItem, TOwner> {
    */
   scrollIntoView(index: number, alignToCenter?: boolean): void;
 
-  protected _isItemSelected(item: TItem, selectedItem: TItem, itemIdPath: string | null | undefined): void;
+  protected _isItemSelected(item: TItem, selectedItem: TItem): boolean;
 
   protected _updateElement(el: HTMLElement, index: number): void;
 }

--- a/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { setOrRemoveAttribute } from '@vaadin/component-base/src/dom-utils.js';
-import { get } from '@vaadin/component-base/src/path-utils.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 import { Virtualizer } from '@vaadin/component-base/src/virtualizer.js';
 import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
@@ -70,13 +69,6 @@ export const ComboBoxScrollerMixin = (superClass) =>
         itemClassNameGenerator: {
           type: Object,
           observer: '__itemClassNameGeneratorChanged',
-        },
-
-        /**
-         * Path for the id of the item, used to detect whether the item is selected.
-         */
-        itemIdPath: {
-          type: String,
         },
 
         /**
@@ -244,16 +236,15 @@ export const ComboBoxScrollerMixin = (superClass) =>
     /**
      * @param {string | object} item
      * @param {string | object} selectedItem
-     * @param {string} itemIdPath
+     * @return {boolean}
      * @protected
      */
-    _isItemSelected(item, selectedItem, itemIdPath) {
+    _isItemSelected(item, selectedItem) {
       if (item instanceof ComboBoxPlaceholder) {
         return false;
-      } else if (itemIdPath && item !== undefined && selectedItem !== undefined) {
-        return get(itemIdPath, item) === get(itemIdPath, selectedItem);
       }
-      return item === selectedItem;
+
+      return this.owner._isSameItem(item, selectedItem);
     }
 
     /** @private */
@@ -367,7 +358,7 @@ export const ComboBoxScrollerMixin = (superClass) =>
     _updateElement(el, index) {
       const item = this.items[index];
       const focusedIndex = this.focusedIndex;
-      const selected = this._isItemSelected(item, this.selectedItem, this.itemIdPath);
+      const selected = this._isItemSelected(item, this.selectedItem);
 
       el.setProperties({
         item,

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.d.ts
@@ -101,12 +101,6 @@ export declare class MultiSelectComboBoxMixinClass<TItem> {
   itemClassNameGenerator: (item: TItem) => string;
 
   /**
-   * Path for the id of the item, used to detect whether the item is selected.
-   * @attr {string} item-id-path
-   */
-  itemIdPath: string;
-
-  /**
    * The object used to localize this component. To change the default
    * localization, replace this with an object that provides all properties, or
    * just the individual properties you want to change.

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -80,15 +80,6 @@ export const MultiSelectComboBoxMixin = (superClass) =>
         },
 
         /**
-         * Path for the id of the item, used to detect whether the item is selected.
-         * @attr {string} item-id-path
-         */
-        itemIdPath: {
-          type: String,
-          sync: true,
-        },
-
-        /**
          * When true, filter string isn't cleared after selecting an item.
          */
         keepFilter: {
@@ -340,7 +331,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
     updated(props) {
       super.updated(props);
 
-      ['loading', 'itemIdPath', 'itemClassNameGenerator', 'renderer'].forEach((prop) => {
+      ['loading', 'itemClassNameGenerator', 'renderer'].forEach((prop) => {
         if (props.has(prop)) {
           this._scroller[prop] = this[prop];
         }
@@ -487,7 +478,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
         if (
           this._lastFilter &&
           this._lastFilter === this._inputElementValue &&
-          this._findIndex(focusedItem, this.selectedItems, this.itemIdPath) !== -1
+          this._findIndex(focusedItem, this.selectedItems) !== -1
         ) {
           this.__clearInternalValue();
           return;
@@ -673,7 +664,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
 
       if (items?.length && this._topGroup?.length) {
         // Filter out items included to the top group.
-        const filteredItems = items.filter((item) => this._findIndex(item, this._topGroup, this.itemIdPath) === -1);
+        const filteredItems = items.filter((item) => this._findIndex(item, this._topGroup) === -1);
         return this._topGroup.concat(filteredItems);
       }
 
@@ -686,17 +677,8 @@ export const MultiSelectComboBoxMixin = (superClass) =>
     }
 
     /** @private */
-    _findIndex(item, selectedItems, itemIdPath) {
-      if (itemIdPath && item) {
-        for (let index = 0; index < selectedItems.length; index++) {
-          if (selectedItems[index] && selectedItems[index][itemIdPath] === item[itemIdPath]) {
-            return index;
-          }
-        }
-        return -1;
-      }
-
-      return selectedItems.indexOf(item);
+    _findIndex(item, items) {
+      return items.findIndex((other) => this._isSameItem(item, other));
     }
 
     /**
@@ -729,7 +711,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
     /** @private */
     __removeItem(item) {
       const itemsCopy = [...this.selectedItems];
-      itemsCopy.splice(itemsCopy.indexOf(item), 1);
+      itemsCopy.splice(this._findIndex(item, itemsCopy), 1);
       this.__updateSelection(itemsCopy);
       const itemLabel = this._getItemLabel(item);
       this.__announceItem(itemLabel, false, itemsCopy.length);
@@ -739,7 +721,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
     __selectItem(item) {
       const itemsCopy = [...this.selectedItems];
 
-      const index = this._findIndex(item, itemsCopy, this.itemIdPath);
+      const index = this._findIndex(item, itemsCopy);
       const itemLabel = this._getItemLabel(item);
 
       let isSelected = false;
@@ -793,7 +775,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
       return (
         this._topGroup &&
         this._topGroup.some((item) => {
-          const selectedItem = this.selectedItems[this._findIndex(item, this.selectedItems, this.itemIdPath)];
+          const selectedItem = this.selectedItems[this._findIndex(item, this.selectedItems)];
           return selectedItem && item !== selectedItem;
         })
       );

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
@@ -43,10 +43,12 @@ class MultiSelectComboBoxScroller extends ComboBoxScrollerMixin(PolylitMixin(Lit
   }
 
   /**
+   * Override method from `ComboBoxScrollerMixin` to check
+   * the item against the selected items of the owner.
    * @protected
    * @override
    */
-  _isItemSelected(item, _selectedItem, itemIdPath) {
+  _isItemSelected(item) {
     if (item instanceof ComboBoxPlaceholder) {
       return false;
     }
@@ -55,7 +57,7 @@ class MultiSelectComboBoxScroller extends ComboBoxScrollerMixin(PolylitMixin(Lit
       return false;
     }
 
-    return this.owner._findIndex(item, this.owner.selectedItems, itemIdPath) > -1;
+    return this.owner.selectedItems.some((selectedItem) => this.owner._isSameItem(item, selectedItem));
   }
 
   /**

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -297,6 +297,49 @@ describe('selecting items', () => {
     });
   });
 
+  describe('item id path', () => {
+    beforeEach(() => {
+      comboBox.itemIdPath = 'db.key';
+      comboBox.itemLabelPath = 'label';
+      comboBox.items = [
+        { db: { key: '0' }, label: 'apple' },
+        { db: { key: '1' }, label: 'banana' },
+        { db: { key: '2' }, label: 'lemon' },
+      ];
+      comboBox.selectedItems = [{ db: { key: '1' }, label: 'banana' }];
+    });
+
+    it('should mark item as selected using a nested id path', () => {
+      comboBox.opened = true;
+      const items = getAllItems(comboBox);
+      expect(items[0].selected).to.be.false;
+      expect(items[1].selected).to.be.true;
+      expect(items[2].selected).to.be.false;
+    });
+
+    it('should deselect item matching by a nested id path on click', () => {
+      comboBox.opened = true;
+      getAllItems(comboBox)[1].click();
+      expect(comboBox.selectedItems).to.deep.equal([]);
+    });
+
+    it('should move item matching by a nested id path to the top', () => {
+      comboBox.selectedItemsOnTop = true;
+      comboBox.opened = true;
+      expectItems(['banana', 'apple', 'lemon']);
+    });
+
+    it('should compare primitive items by identity when id path is set', () => {
+      comboBox.items = ['apple', 'banana', 'lemon'];
+      comboBox.selectedItems = ['banana'];
+      comboBox.opened = true;
+      const items = getAllItems(comboBox);
+      expect(items[0].selected).to.be.false;
+      expect(items[1].selected).to.be.true;
+      expect(items[2].selected).to.be.false;
+    });
+  });
+
   describe('selected items on top', () => {
     beforeEach(() => {
       comboBox.selectedItemsOnTop = true;


### PR DESCRIPTION
## Description

Item identity was implemented three times with different semantics. The scroller mixin compared with `get()` from `path-utils`, multi-select-combo-box's `_findIndex` used plain property access, and `__removeItem` used `indexOf`. As a result nested paths such as `db.key` worked in combo-box but not in multi-select-combo-box.

The scroller also received `itemIdPath` as a property from the host only to pass it straight back to the host when asking whether an item is selected. That property had no observer, so forwarding it never triggered a render.

- Added `_isSameItem()` to `ComboBoxBaseMixin`, comparing items by identity, and overrode it in `ComboBoxItemsMixin` to compare by the value at `itemIdPath`
  - Follows the same split as `_getItemLabel()`. Time-picker applies the base mixin without the items mixin, so the default has to live in the base
- Moved the `itemIdPath` declaration to `ComboBoxItemsMixin`, where it was declared identically by combo-box and multi-select-combo-box
- Removed the `itemIdPath` property from `ComboBoxScrollerMixin`, so `_isItemSelected()` asks its owner instead of taking the path as an argument
- Changed multi-select-combo-box `_findIndex()` to take the item and the array, comparing through `_isSameItem()`, and used it in `__removeItem()` in place of `indexOf`
- Added tests for a nested `itemIdPath` covering the selected state, deselecting on click, the selected-items-on-top order, and primitive items

## Type of change

- Refactor

> [!NOTE]
> Two behavior fixes follow from sharing one comparison. Multi-select-combo-box now honors a nested `itemIdPath` the way combo-box already did. Items are no longer all reported as selected when `itemIdPath` is set on a component whose items are strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
