### PR TITLE
fix: respect RTL when navigating menu-bar sub-menus with arrow keys

### DIFF
--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -131,6 +131,7 @@ export const ItemsMixin = (superClass) =>
 
       // Set theme attribute from parent element
       setOrRemoveAttribute(subMenu, 'theme', parent.getAttribute('theme'));
+      setOrRemoveAttribute(subMenu, 'dir', this.dir);
 
       const content = subMenuOverlay.$.content;
       content.style.minWidth = '';

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -361,6 +361,10 @@ export const MenuBarMixin = (superClass) =>
         this._themeChanged(this._theme);
       }
 
+      if (props.has('dir')) {
+        setOrRemoveAttribute(this._subMenu, 'dir', this.dir);
+      }
+
       if (props.has('disabled')) {
         this._overflow.toggleAttribute('disabled', this.disabled);
       }
@@ -888,12 +892,16 @@ export const MenuBarMixin = (superClass) =>
       const item = Array.from(e.composedPath()).find((el) => el._item);
       if (item) {
         const list = item.parentNode;
-        if (e.keyCode === 38 && item === list.items[0]) {
+        if (e.key === 'ArrowUp' && item === list.items[0]) {
           this._close(true);
         }
-        // ArrowLeft, or ArrowRight on non-parent submenu item,
-        if (e.keyCode === 37 || (e.keyCode === 39 && !item._item.children)) {
-          // Prevent ArrowLeft from being handled in context-menu
+
+        // Switch menu-bar button or open sub-menu on item arrow key.
+        const prevKey = this.__isRTL ? 'ArrowRight' : 'ArrowLeft';
+        const nextKey = this.__isRTL ? 'ArrowLeft' : 'ArrowRight';
+
+        if (e.key === prevKey || (e.key === nextKey && !item._item.children)) {
+          // Prevent the key from being handled in context-menu
           e.stopImmediatePropagation();
           this._handleKeyDown(e);
         }

--- a/packages/menu-bar/src/vaadin-menu-bar-submenu.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-submenu.d.ts
@@ -3,13 +3,14 @@
  * Copyright (c) 2019 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { ContextMenuMixin } from '@vaadin/context-menu/src/vaadin-context-menu-mixin.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 
 /**
  * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
  */
-declare class MenuBarSubmenu extends ContextMenuMixin(ThemePropertyMixin(HTMLElement)) {}
+declare class MenuBarSubmenu extends ContextMenuMixin(DirMixin(ThemePropertyMixin(HTMLElement))) {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/menu-bar/src/vaadin-menu-bar-submenu.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-submenu.js
@@ -9,6 +9,7 @@ import './vaadin-menu-bar-overlay.js';
 import { css, html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ContextMenuMixin } from '@vaadin/context-menu/src/vaadin-context-menu-mixin.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
@@ -21,7 +22,7 @@ import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-p
  * @extends HTMLElement
  * @protected
  */
-class MenuBarSubmenu extends ContextMenuMixin(ThemePropertyMixin(PolylitMixin(LitElement))) {
+class MenuBarSubmenu extends ContextMenuMixin(DirMixin(ThemePropertyMixin(PolylitMixin(LitElement)))) {
   static get is() {
     return 'vaadin-menu-bar-submenu';
   }

--- a/packages/menu-bar/test/keyboard-navigation.test.js
+++ b/packages/menu-bar/test/keyboard-navigation.test.js
@@ -391,6 +391,57 @@ describe('keyboard navigation', () => {
       });
     });
 
+    describe('RTL mode', () => {
+      let nestedMenu;
+
+      before(() => {
+        document.documentElement.setAttribute('dir', 'rtl');
+      });
+
+      after(() => {
+        document.documentElement.removeAttribute('dir');
+      });
+
+      beforeEach(async () => {
+        menu.items = [
+          {
+            text: 'Menu Item 1',
+            children: [{ text: 'Menu Item 1 1', children: [{ text: 'Menu Item 1 1 1' }] }, { text: 'Menu Item 1 2' }],
+          },
+          { text: 'Menu Item 2' },
+        ];
+        await nextUpdate(menu);
+        buttons = menu._buttons;
+
+        buttons[0].focus();
+        await sendKeys({ press: 'ArrowDown' });
+        await nextRender();
+        nestedMenu = subMenu._subMenu;
+      });
+
+      it('should open nested submenu on item Arrow Left', async () => {
+        await sendKeys({ press: 'ArrowLeft' });
+        await nextRender();
+
+        expect(nestedMenu.opened).to.be.true;
+      });
+
+      it('should not open nested submenu on item Arrow Right', async () => {
+        await sendKeys({ press: 'ArrowRight' });
+        await nextRender();
+
+        expect(nestedMenu.opened).to.be.false;
+      });
+
+      it('should switch menubar button without items and focus it on item Arrow Right', async () => {
+        await sendKeys({ press: 'ArrowRight' });
+        await nextRender();
+
+        expect(subMenu.opened).to.be.false;
+        expect(document.activeElement).to.equal(buttons[1]);
+      });
+    });
+
     describe('tab navigation mode', () => {
       beforeEach(() => {
         menu.tabNavigation = true;


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/issues/7681

`<vaadin-menu-bar-submenu>` applied no `DirMixin`, so `__isRTL` was `undefined` on every sub-menu and `ItemsMixin` always took its LTR branch. The menu-bar keydown handler matched `ArrowLeft` and `ArrowRight` by name and calls `stopImmediatePropagation()`, so the root sub-menu never reached `ItemsMixin` at all. Both halves have to read the same direction, and `DirMixin` gives them that only for a `dir` set on the `<html>` element, so the bar also forwards its own `dir` down, the way combo-box forwards it to its overlay.

- Added `DirMixin` to `<vaadin-menu-bar-submenu>`, so `__isRTL` reports the direction on sub-menus at every nesting level
- Forwarded the menu bar `dir` to the root sub-menu, and the menu `dir` to each nested sub-menu next to the existing `theme` forwarding in `ItemsMixin`
- Picked the arrow keys in `__onContextMenuKeydown` from `__isRTL`, so in RTL `ArrowLeft` opens a sub-menu and `ArrowRight` switches the menu bar button
- Matched the arrow keys in that handler by `key` instead of `keyCode`, which the `Tab` branch next to it already did
- Added three RTL sub-menu keyboard tests, each verified to fail without the fix

## Type of change

- Bugfix

## How to test

1. Open `dev/menu-bar.html`
2. Run `document.documentElement.setAttribute('dir', 'rtl')` in the browser console
3. Focus the `Share` button and press <kbd>ArrowDown</kbd> to open its sub-menu
4. Press <kbd>ArrowLeft</kbd> on `On social media` and see its sub-menu open
5. Press <kbd>ArrowRight</kbd> on `Get link` and see focus move to the next menu bar button

> [!NOTE]
> A `dir` set on an ancestor of the menu bar, rather than on the document or on the bar itself, is still not picked up: `DirMixin` does not see it and `KeyboardDirectionMixin` reads the host `dir` attribute directly. That case stays fully LTR, as it is today. Making it work means reading the direction from `:dir(rtl)` in `KeyboardDirectionMixin` as well, which belongs with the `DirMixin` removal in V26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
