### PR TITLE
refactor: cleanup and improve menu-bar mixin internal logic

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -463,7 +463,6 @@ export const MenuBarMixin = (superClass) =>
           this.__restoreItem(button, item);
         }
       });
-      this.__updateOverflow([]);
     }
 
     /** @private */
@@ -541,6 +540,7 @@ export const MenuBarMixin = (superClass) =>
 
       // Reset all buttons in the menu bar and the overflow button
       this.__restoreButtons(buttons);
+      this.__updateOverflow([]);
 
       // Hide any overflowing buttons and put them in the 'overflow' button
       this.__setOverflowItems(buttons, overflow);
@@ -553,7 +553,11 @@ export const MenuBarMixin = (superClass) =>
       const isSingleButton = newOverflowCount === buttons.length || (newOverflowCount === 0 && buttons.length === 1);
       this.toggleAttribute('has-single-button', isSingleButton);
 
-      // Collect visible buttons to detect if tabindex should be updated
+      this.__updateVisibleButtons(buttons);
+    }
+
+    /** @private */
+    __updateVisibleButtons(buttons) {
       const visibleButtons = buttons.filter((btn) => btn.style.visibility !== 'hidden');
 
       if (!visibleButtons.length) {
@@ -565,8 +569,7 @@ export const MenuBarMixin = (superClass) =>
         this._setTabindex(visibleButtons[visibleButtons.length - 1], true);
       }
 
-      // Apply first/last visible attributes to the visible buttons
-      visibleButtons.forEach((btn, index, visibleButtons) => {
+      visibleButtons.forEach((btn, index) => {
         btn.toggleAttribute('first-visible', index === 0);
         btn.toggleAttribute('last-visible', !this._hasOverflow && index === visibleButtons.length - 1);
       });

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -615,9 +615,7 @@ export const MenuBarMixin = (superClass) =>
             const hasChildren = Boolean(item?.children);
 
             if (itemCopy.component) {
-              const component = this.__getComponent(itemCopy);
-              itemCopy.component = component;
-              component.item = itemCopy;
+              itemCopy.component = this.__getComponent(itemCopy);
             }
 
             return html`
@@ -983,13 +981,12 @@ export const MenuBarMixin = (superClass) =>
 
     /** @private */
     _focusFirstItem() {
-      const list = this._subMenu._overlayElement._contentRoot.firstElementChild;
-      list.focus();
+      this._subMenu._menuListBox.focus();
     }
 
     /** @private */
     _focusLastItem() {
-      const list = this._subMenu._overlayElement._contentRoot.firstElementChild;
+      const list = this._subMenu._menuListBox;
       const item = list.items[list.items.length - 1];
       if (item) {
         item.focus();

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -447,8 +447,7 @@ export const MenuBarMixin = (superClass) =>
 
     /** @private */
     __getOverflowCount(overflow) {
-      // We can't use optional chaining due to webpack 4
-      return (overflow.item && overflow.item.children && overflow.item.children.length) || 0;
+      return overflow.item?.children?.length ?? 0;
     }
 
     /** @private */
@@ -459,7 +458,7 @@ export const MenuBarMixin = (superClass) =>
         button.style.width = '';
 
         // Teleport item component back from "overflow" sub-menu
-        const item = button.item && button.item.component;
+        const item = button.item?.component;
         if (item instanceof HTMLElement && item.getAttribute('role') === 'menuitem') {
           this.__restoreItem(button, item);
         }
@@ -643,7 +642,7 @@ export const MenuBarMixin = (superClass) =>
       const button = event.target;
       // Propagate click event from button to the item component if it was outside
       // it e.g. by calling `click()` on the button (used by the Flow counterpart).
-      if (button.item && button.item.component && !event.composedPath().includes(button.item.component)) {
+      if (button.item?.component && !event.composedPath().includes(button.item.component)) {
         event.stopPropagation();
         button.item.component.click();
       }
@@ -690,7 +689,7 @@ export const MenuBarMixin = (superClass) =>
 
       this._tooltipController.setTarget(button);
 
-      if (wasExpanded && button.item && button.item.children) {
+      if (wasExpanded && button.item?.children) {
         this.__openSubMenu(button, true, { keepFocus: true });
       } else if (!this._subMenu.opened) {
         this._tooltipController.open({ trigger: 'focus' });

--- a/packages/menu-bar/src/vaadin-menu-bar-submenu.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-submenu.js
@@ -122,7 +122,7 @@ class MenuBarSubmenu extends ContextMenuMixin(ThemePropertyMixin(PolylitMixin(Li
     super.close();
 
     // Only handle 1st level submenu
-    if (this.hasAttribute('is-root')) {
+    if (this.isRoot) {
       this.parentElement._close();
     }
   }


### PR DESCRIPTION
## Description

Three pure moves in the menu-bar mixin. No observer, property declaration, or type definition changes, and the public API is untouched.

- Resolved the sub-menu list-box through `_menuListBox` from `ItemsMixin` instead of walking `_overlayElement._contentRoot.firstElementChild`
- Read `isRoot` from the reflected property instead of the `is-root` attribute, so `close()` and `render()` read the same source
- Removed the `item` reference written to the item component, which nothing reads
  - The overflow sub-menu sets `_item` on the same element, and the tooltip controller reads `item` from the button
- Replaced the manual null checks left over from webpack 4 with optional chaining
- Split the tabindex and `first-visible` / `last-visible` updates out of `__detectOverflow` into `__updateVisibleButtons`
- Moved the overflow reset out of `__restoreButtons`, whose name did not cover it, into `__detectOverflow` in the same position

Each moved piece was checked by mutating it and confirming that a test fails. Removing the `item` reference is the one change no test catches, which matches it having no reader.

## Type of change

- Refactor

## Note

The `_menuListBox` was added in 25.3 as part of slotted list-box support, so this shouldn't be backported to 25.2
