### PR TITLE
fix: restore filter to input on Escape in multi-select-combo-box

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -446,6 +446,17 @@ export const MultiSelectComboBoxMixin = (superClass) =>
     }
 
     /**
+     * Override method from `ComboBoxBaseMixin` to revert the input to the
+     * filter, as this component does not use `value` for the input text.
+     * @protected
+     * @override
+     */
+    _revertInputValue() {
+      this._inputElementValue = this.filter;
+      this._clearSelectionRange();
+    }
+
+    /**
      * @protected
      * @override
      */

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -587,6 +587,35 @@ describe('selecting items', () => {
     });
   });
 
+  describe('escape with focused item', () => {
+    beforeEach(() => {
+      comboBox.items = ['apple', 'banana', 'lemon', 'orange'];
+    });
+
+    it('should restore the filter to the input on Escape', async () => {
+      await sendKeys({ type: 'an' });
+      await sendKeys({ press: 'ArrowDown' });
+      expect(inputElement.value).to.equal('banana');
+
+      await sendKeys({ press: 'Escape' });
+      expect(comboBox.opened).to.be.true;
+      expect(comboBox.filter).to.equal('an');
+      expect(inputElement.value).to.equal('an');
+    });
+
+    it('should restore the filter to the input on Escape when keepFilter is set', async () => {
+      comboBox.keepFilter = true;
+      await sendKeys({ type: 'an' });
+      await sendKeys({ press: 'ArrowDown' });
+      expect(inputElement.value).to.equal('banana');
+
+      await sendKeys({ press: 'Escape' });
+      expect(comboBox.opened).to.be.true;
+      expect(comboBox.filter).to.equal('an');
+      expect(inputElement.value).to.equal('an');
+    });
+  });
+
   describe('keep filter', () => {
     beforeEach(() => {
       comboBox.items = ['apple', 'banana', 'lemon', 'orange'];


### PR DESCRIPTION
## Description

Pressing <kbd>Escape</kbd> while an item is highlighted reverts the input through `_revertInputValue()`. The base implementation assigns `value`, which suits a single value field. Multi-select-combo-box keeps its selection in `selectedItems`, declares `value` as private and never assigns it, so the assignment always wrote an empty string. The input was cleared while `filter` stayed set and the overlay stayed open, leaving the list filtered against text the user could no longer see. Combo-box already restores the filter in its own override, which is also what the comment in the base handler describes.

- Added a `_revertInputValue()` override that restores the input to the current filter
- Added tests for <kbd>Escape</kbd> on a highlighted item, at the default setting and with `keepFilter`

The nearest existing test presses <kbd>Escape</kbd> twice and only asserts afterwards, so the first press clearing the input was hidden by the second press closing the overlay and clearing the filter for real.

## Type of change

- Bugfix

## How to test

1. Open `dev/multi-select-combo-box.html`
2. Type `li` in the field
3. Press <kbd>ArrowDown</kbd> to highlight an item, the input shows that item's full name
4. Press <kbd>Escape</kbd>
5. The input shows `li` again and the dropdown stays open with the filtered items

🤖 Generated with [Claude Code](https://claude.com/claude-code)
