### PR TITLE
test: remove MSCB and time-picker helperText unit tests

### DIFF
--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -299,23 +299,6 @@ describe('basic', () => {
     });
   });
 
-  describe('helper text', () => {
-    it('should set helper text content using helperText property', async () => {
-      comboBox.helperText = 'foo';
-      await nextRender();
-      expect(comboBox.querySelector('[slot="helper"]').textContent).to.eql('foo');
-    });
-
-    it('should display the helper text when slotted helper available', async () => {
-      const helper = document.createElement('div');
-      helper.setAttribute('slot', 'helper');
-      helper.textContent = 'foo';
-      comboBox.appendChild(helper);
-      await nextRender();
-      expect(comboBox.querySelector('[slot="helper"]').textContent).to.eql('foo');
-    });
-  });
-
   describe('theme attribute', () => {
     beforeEach(async () => {
       comboBox.setAttribute('theme', 'foo');

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -350,23 +350,6 @@ describe('time-picker', () => {
     });
   });
 
-  describe('helper text', () => {
-    it('should set helper text content using helperText property', async () => {
-      timePicker.helperText = 'foo';
-      await nextFrame();
-      expect(timePicker.querySelector('[slot="helper"]').textContent).to.eql('foo');
-    });
-
-    it('should display the helper text when slotted helper available', async () => {
-      const helper = document.createElement('div');
-      helper.setAttribute('slot', 'helper');
-      helper.textContent = 'foo';
-      timePicker.appendChild(helper);
-      await nextFrame();
-      expect(timePicker.querySelector('[slot="helper"]').textContent).to.eql('foo');
-    });
-  });
-
   describe('required', () => {
     beforeEach(() => {
       timePicker.required = true;


### PR DESCRIPTION
## Description

Removed tests that cover `FieldMixin` logic: components shouldn't need them, snapshot tests are enough.
None of other components have them, these 2 are likely leftovers from the original implementation.

## Type of change

- Test